### PR TITLE
Add hover micro-animations to landing page tool cards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -996,3 +996,90 @@ select.input-table {
 .overflow-y-auto, .overflow-x-auto {
   -webkit-overflow-scrolling: touch;
 }
+
+/* ─────────────────────────────────────────────────────
+   LANDING HOVER MICRO-ANIMATIONS
+   Scoped to .la-hover-anim ancestor; state-change
+   motion only, one animation per card, reduced-motion
+   disables everything.
+───────────────────────────────────────────────────── */
+@keyframes la-lufs-fill {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(1); }
+}
+@keyframes la-fmt-pulse {
+  0%, 100% { background-color: rgba(255,255,255,0.06); color: rgba(255,255,255,0.6); }
+  40%      { background-color: rgba(20,184,166,0.15); color: #5eead4; }
+}
+@keyframes la-wave-fill {
+  from { background-color: rgba(255,255,255,0.12); }
+  to   { background-color: rgba(20,184,166,0.5); }
+}
+@keyframes la-big-wave-fill {
+  from { background-color: rgba(255,255,255,0.15); }
+  to   { background-color: rgba(20,184,166,0.6); }
+}
+@keyframes la-dot-pulse {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.35); }
+}
+@keyframes la-shimmer {
+  0%   { transform: translateX(-100%); opacity: 0; }
+  20%  { opacity: 1; }
+  80%  { opacity: 1; }
+  100% { transform: translateX(100%); opacity: 0; }
+}
+@keyframes la-pill-v1-cycle {
+  0%, 100% { background-color: rgba(255,255,255,0.08); color: rgba(255,255,255,0.6); }
+  15%, 40% { background-color: #14B8A6; color: #1a1a1a; }
+}
+@keyframes la-pill-v2-cycle {
+  0%, 40%, 100% { background-color: rgba(255,255,255,0.08); color: rgba(255,255,255,0.6); }
+  50%, 75%      { background-color: #14B8A6; color: #1a1a1a; }
+}
+@keyframes la-pill-v3-cycle {
+  0%, 100%  { background-color: #14B8A6; color: #1a1a1a; }
+  15%, 85%  { background-color: rgba(255,255,255,0.08); color: rgba(255,255,255,0.6); }
+}
+@keyframes la-marker-pulse {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.25); }
+}
+
+.la-hover-anim:hover .la-anim-lufs {
+  animation: la-lufs-fill 700ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.la-hover-anim:hover .la-anim-fmt {
+  animation: la-fmt-pulse 280ms ease-out;
+}
+.la-hover-anim:hover .la-anim-wave-future {
+  animation: la-wave-fill 400ms ease-out forwards;
+}
+.la-hover-anim:hover .la-anim-big-wave-future {
+  animation: la-big-wave-fill 400ms ease-out forwards;
+}
+.la-hover-anim:hover .la-anim-dot {
+  animation: la-dot-pulse 400ms ease-out;
+}
+.la-hover-anim:hover .la-anim-shimmer {
+  animation: la-shimmer 900ms ease-out;
+}
+.la-hover-anim:hover .la-anim-pill-v1 {
+  animation: la-pill-v1-cycle 900ms ease-out;
+}
+.la-hover-anim:hover .la-anim-pill-v2 {
+  animation: la-pill-v2-cycle 900ms ease-out;
+}
+.la-hover-anim:hover .la-anim-pill-v3 {
+  animation: la-pill-v3-cycle 900ms ease-out;
+}
+.la-hover-anim:hover .la-anim-marker {
+  animation: la-marker-pulse 400ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .la-hover-anim,
+  .la-hover-anim * {
+    animation: none !important;
+  }
+}

--- a/src/components/landing/audio-tools-grid.tsx
+++ b/src/components/landing/audio-tools-grid.tsx
@@ -22,7 +22,7 @@ function LufsMeter() {
       </div>
       <div className="relative h-3 rounded-full bg-white/8 overflow-hidden">
         <div
-          className="absolute inset-y-0 left-0 rounded-full"
+          className="la-anim-lufs absolute inset-y-0 left-0 rounded-full origin-left"
           style={{
             width: "62%",
             background: "linear-gradient(90deg, #14B8A6 0%, #22C55E 80%, #FE5E0E 100%)",
@@ -52,7 +52,8 @@ function FormatConversion() {
               i === 0
                 ? "bg-[#14B8A6]/15 text-[#5eead4]"
                 : "bg-white/6 text-white/60"
-            }`}
+            } ${i > 0 ? "la-anim-fmt" : ""}`}
+            style={i > 0 ? { animationDelay: `${(i - 1) * 200}ms` } : undefined}
           >
             {fmt}
           </span>
@@ -74,12 +75,13 @@ function MiniWaveform() {
         return (
           <div
             key={i}
-            className="flex-1 rounded-full"
+            className={`flex-1 rounded-full ${isPast ? "" : "la-anim-wave-future"}`}
             style={{
               height: `${h * 100}%`,
               background: isPast
                 ? "rgba(20,184,166,0.5)"
                 : "rgba(255,255,255,0.12)",
+              animationDelay: isPast ? undefined : `${(i - 18) * 40}ms`,
             }}
           />
         );
@@ -96,11 +98,15 @@ function CommentTimeline() {
         { pos: "22%", color: "#FE5E0E" },
         { pos: "45%", color: "#3B82F6" },
         { pos: "72%", color: "#14B8A6" },
-      ].map((m) => (
+      ].map((m, idx) => (
         <div
           key={m.pos}
-          className="absolute top-1 w-4 h-4 rounded-full flex items-center justify-center text-[7px] font-bold text-white"
-          style={{ left: m.pos, background: m.color }}
+          className="la-anim-dot absolute top-1 w-4 h-4 rounded-full flex items-center justify-center text-[7px] font-bold text-white"
+          style={{
+            left: m.pos,
+            background: m.color,
+            animationDelay: `${idx * 80}ms`,
+          }}
         >
           &bull;
         </div>
@@ -111,7 +117,7 @@ function CommentTimeline() {
 
 function BriefPreview() {
   return (
-    <div className="mt-4 rounded-lg bg-white/4 p-3 space-y-2">
+    <div className="mt-4 rounded-lg bg-white/4 p-3 space-y-2 relative overflow-hidden">
       <div className="h-2 w-20 rounded-full bg-white/12" />
       <div className="h-1.5 w-full rounded-full bg-white/6" />
       <div className="h-1.5 w-3/4 rounded-full bg-white/6" />
@@ -122,17 +128,26 @@ function BriefPreview() {
           </span>
         ))}
       </div>
+      <div
+        aria-hidden="true"
+        className="la-anim-shimmer pointer-events-none absolute inset-0 opacity-0"
+        style={{
+          background:
+            "linear-gradient(90deg, transparent, rgba(255,255,255,0.08) 50%, transparent)",
+        }}
+      />
     </div>
   );
 }
 
 function VersionTabs() {
+  const pillAnim = ["la-anim-pill-v1", "la-anim-pill-v2", "la-anim-pill-v3"];
   return (
     <div className="mt-4 flex items-center gap-1.5">
       {["v1", "v2", "v3"].map((v, i) => (
         <span
           key={v}
-          className={`text-[10px] px-2.5 py-1 rounded-full font-medium ${
+          className={`${pillAnim[i]} text-[10px] px-2.5 py-1 rounded-full font-medium ${
             i === 2
               ? "bg-[#14B8A6] text-[#1a1a1a] font-semibold"
               : "bg-white/8 text-white/60"
@@ -216,7 +231,7 @@ export async function AudioToolsGrid() {
           {tools.map((tool) => (
             <div
               key={tool.title}
-              className="rounded-xl bg-[#1a1a1a] border border-white/8 p-5 shadow-lg"
+              className="la-hover-anim group rounded-xl bg-[#1a1a1a] border border-white/8 p-5 shadow-lg"
             >
               <div className="w-11 h-11 rounded-lg bg-[#14B8A6]/12 flex items-center justify-center text-[#14B8A6] mb-4" aria-hidden="true">
                 {tool.icon}

--- a/src/components/landing/feature-showcase.tsx
+++ b/src/components/landing/feature-showcase.tsx
@@ -201,7 +201,7 @@ function WebPortalMock() {
 
 function AudioReviewMock() {
   return (
-    <div className="rounded-xl bg-[#1a1a1a] border border-white/8 p-5 shadow-lg">
+    <div className="la-hover-anim group rounded-xl bg-[#1a1a1a] border border-white/8 p-5 shadow-lg">
       <div className="flex items-center justify-between mb-4">
         <div className="text-sm font-semibold text-white">
           Waveform &middot; v3
@@ -229,26 +229,27 @@ function AudioReviewMock() {
           return (
             <div
               key={i}
-              className="flex-1 rounded-full"
+              className={`flex-1 rounded-full ${isPast ? "" : "la-anim-big-wave-future"}`}
               style={{
                 height: `${h * 100}%`,
                 background: isPast
                   ? "rgba(20,184,166,0.6)"
                   : "rgba(255,255,255,0.15)",
+                animationDelay: isPast ? undefined : `${(i - 35) * 32}ms`,
               }}
             />
           );
         })}
         {/* Comment markers */}
         <div
-          className="absolute top-1 rounded-full w-4 h-4 flex items-center justify-center text-[8px] font-bold"
-          style={{ left: "25%", background: "#FE5E0E", color: "#fff" }}
+          className="la-anim-marker absolute top-1 rounded-full w-4 h-4 flex items-center justify-center text-[8px] font-bold"
+          style={{ left: "25%", background: "#FE5E0E", color: "#fff", animationDelay: "0ms" }}
         >
           1
         </div>
         <div
-          className="absolute top-1 rounded-full w-4 h-4 flex items-center justify-center text-[8px] font-bold"
-          style={{ left: "58%", background: "#3B82F6", color: "#fff" }}
+          className="la-anim-marker absolute top-1 rounded-full w-4 h-4 flex items-center justify-center text-[8px] font-bold"
+          style={{ left: "58%", background: "#3B82F6", color: "#fff", animationDelay: "400ms" }}
         >
           2
         </div>


### PR DESCRIPTION
## Summary
- Seven landing-page graphics (6 audio tool cards + Audio Review waveform) now play a single purposeful animation on hover.
- Pure CSS keyframes scoped to `.la-hover-anim`, no animation library added.
- `prefers-reduced-motion` guard disables all of it for users who opt out.

## Test plan
- [x] Hover each of the 6 tool cards: only that card's graphic animates, matches spec (LUFS fill, format pulse, waveform sweep, dot pulse, shimmer, version pill cycle)
- [x] Hover the Audio Review card: bar sweep + marker pulses
- [x] Leave → graphics snap back to rest state
- [x] Reduced-motion: zero animations fire with guard active (verified via forced-hover test)
- [x] Rest state unchanged (LUFS full, shimmer hidden, dots visible, v3 teal)
- [ ] Spot-check on a real device with touch (no hover = rest state, intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)