### PR TITLE
Security: fix 3 IDOR/auth vulns (signAudioUrls, portal delete, attribute-signup)

### DIFF
--- a/src/app/api/attributions/attribute-signup/route.ts
+++ b/src/app/api/attributions/attribute-signup/route.ts
@@ -1,12 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
 /**
  * POST /api/attributions/attribute-signup
  * Called during the signup flow when an attribution cookie is present.
- * Links the new user to the attribution record and sets attributed_to_engineer
- * on the profile.
+ * Links the AUTHENTICATED user to the attribution record and sets
+ * attributed_to_engineer on the profile.
+ *
+ * Authorization: the target user id is taken from the session, NOT
+ * the request body. The previous version trusted body.new_user_id +
+ * a body-supplied attribution_id (which is publicly returned by
+ * /track-click), letting any caller stamp attribution onto any
+ * user's profile.
  */
 export async function POST(req: NextRequest) {
   const ip = getClientIp(req);
@@ -16,13 +23,18 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const body = await req.json();
-    const { attribution_id, new_user_id } = body as {
-      attribution_id: string;
-      new_user_id: string;
-    };
+    // Auth: the caller MUST be the just-signed-up user.
+    const userClient = await createSupabaseServerClient();
+    const { data: { user } } = await userClient.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const new_user_id = user.id;
 
-    if (!attribution_id || !new_user_id) {
+    const body = await req.json();
+    const { attribution_id } = body as { attribution_id: string };
+
+    if (!attribution_id) {
       return NextResponse.json(
         { error: "Missing required fields" },
         { status: 400 },

--- a/src/app/api/portal/comment/route.ts
+++ b/src/app/api/portal/comment/route.ts
@@ -65,6 +65,13 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Track not found" }, { status: 404 });
     }
 
+    // Generate an opaque delete token. The portal client stores it in
+    // localStorage keyed by the new comment's id; only the holder of
+    // this token can delete the comment via the portal endpoint
+    // (preventing the previous bug where any visitor with the share
+    // token could delete any comment by spoofing author_name).
+    const deleteToken = crypto.randomUUID();
+
     // Insert the comment
     const { data: comment, error } = await supabase
       .from("revision_notes")
@@ -74,6 +81,7 @@ export async function POST(req: NextRequest) {
         content: content.trim(),
         author: author_name?.trim() || "Client",
         timecode_seconds: Math.round(timecode_seconds * 100) / 100,
+        delete_token: deleteToken,
       })
       .select("*")
       .single();
@@ -124,7 +132,14 @@ export async function POST(req: NextRequest) {
 
 /**
  * DELETE /api/portal/comment
- * Deletes a comment by ID (only if author matches).
+ * Deletes a portal-authored comment by id. Authorization is by an
+ * opaque delete_token issued at POST time; the previous self-asserted
+ * author_name check let any portal visitor with the share token
+ * delete any comment (defaults named "Client" were deletable by all).
+ *
+ * Comments created before delete_token shipped have NULL — they can't
+ * be deleted from the portal. Release owners can still delete them
+ * via the in-app comment thread.
  */
 export async function DELETE(req: NextRequest) {
   const ip = getClientIp(req);
@@ -133,13 +148,13 @@ export async function DELETE(req: NextRequest) {
 
   try {
     const body = await req.json();
-    const { share_token, comment_id, author_name } = body as {
+    const { share_token, comment_id, delete_token } = body as {
       share_token: string;
       comment_id: string;
-      author_name?: string;
+      delete_token?: string;
     };
 
-    if (!share_token || !comment_id) {
+    if (!share_token || !comment_id || !delete_token) {
       return NextResponse.json(
         { error: "Missing required fields" },
         { status: 400 },
@@ -159,18 +174,24 @@ export async function DELETE(req: NextRequest) {
       return NextResponse.json({ error: "Invalid share token" }, { status: 401 });
     }
 
-    // Fetch the comment and verify it belongs to this release + author matches
+    // Fetch the comment with its delete_token. Don't surface whether the
+    // row exists vs. token-mismatched — both return 403 — so a probe
+    // can't enumerate comment ids.
     const { data: comment } = await supabase
       .from("revision_notes")
-      .select("id, author, track_id")
+      .select("id, track_id, delete_token")
       .eq("id", comment_id)
       .maybeSingle();
 
-    if (!comment) {
-      return NextResponse.json({ error: "Comment not found" }, { status: 404 });
+    if (!comment || !comment.delete_token || comment.delete_token !== delete_token) {
+      return NextResponse.json(
+        { error: "Cannot delete this comment" },
+        { status: 403 },
+      );
     }
 
-    // Verify the track belongs to this release
+    // Verify the comment's track belongs to this share's release
+    // (defense in depth — the token alone already authorizes delete).
     const { data: track } = await supabase
       .from("tracks")
       .select("id")
@@ -180,15 +201,6 @@ export async function DELETE(req: NextRequest) {
 
     if (!track) {
       return NextResponse.json({ error: "Comment not found" }, { status: 404 });
-    }
-
-    // Only allow deletion if author matches
-    const authorToCheck = author_name?.trim() || "Client";
-    if (comment.author !== authorToCheck) {
-      return NextResponse.json(
-        { error: "Cannot delete another user's comment" },
-        { status: 403 },
-      );
     }
 
     const { error } = await supabase

--- a/src/components/portal/portal-audio-player.tsx
+++ b/src/components/portal/portal-audio-player.tsx
@@ -85,6 +85,37 @@ function Timestamp({ date, className }: { date: string; className?: string }) {
 }
 
 const CLIENT_NAME_KEY = "portal_client_name";
+const DELETE_TOKEN_KEY_PREFIX = "portal_delete_token_";
+
+/** Read a stored portal-comment delete token from localStorage. */
+function readDeleteToken(commentId: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage.getItem(`${DELETE_TOKEN_KEY_PREFIX}${commentId}`);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist a delete token returned by POST /api/portal/comment. */
+function writeDeleteToken(commentId: string, token: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(`${DELETE_TOKEN_KEY_PREFIX}${commentId}`, token);
+  } catch {
+    /* localStorage full / disabled — delete UX gracefully degrades */
+  }
+}
+
+/** Remove a token after a successful delete. */
+function clearDeleteToken(commentId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(`${DELETE_TOKEN_KEY_PREFIX}${commentId}`);
+  } catch {
+    /* ignore */
+  }
+}
 
 /* ------------------------------------------------------------------ */
 /*  PortalAudioPlayer                                                  */
@@ -548,6 +579,12 @@ export function PortalAudioPlayer({
 
       if (!res.ok) return;
       const data = await res.json();
+      // Persist the server-issued delete_token so this client can
+      // later authorize deleting its own comment. Other portal
+      // visitors don't have it and thus can't delete the comment.
+      if (data?.id && data?.delete_token) {
+        writeDeleteToken(data.id, data.delete_token);
+      }
       setComments((prev) => [data, ...prev]);
       setNewCommentText("");
       setCommentInput(null);
@@ -559,6 +596,9 @@ export function PortalAudioPlayer({
   }
 
   async function handleDeleteComment(commentId: string) {
+    const deleteToken = readDeleteToken(commentId);
+    if (!deleteToken) return; // No token → not the author of this comment
+
     const prev = comments;
     setComments(comments.filter((c) => c.id !== commentId));
     if (highlightedCommentId === commentId) setHighlightedCommentId(null);
@@ -570,12 +610,14 @@ export function PortalAudioPlayer({
         body: JSON.stringify({
           share_token: shareToken,
           comment_id: commentId,
-          author_name: clientName.trim() || "Client",
+          delete_token: deleteToken,
         }),
       });
 
       if (!res.ok) {
         setComments(prev);
+      } else {
+        clearDeleteToken(commentId);
       }
     } catch {
       setComments(prev);
@@ -1098,8 +1140,11 @@ export function PortalAudioPlayer({
                 const color =
                   authorColorMap.get(c.author) ?? AUTHOR_COLORS[0];
                 const isActive = highlightedCommentId === c.id;
-                const canDelete =
-                  c.author === (clientName.trim() || "Client");
+                // The user can delete a comment only if they hold its
+                // server-issued delete token in localStorage. This
+                // matches the server's authorization check and avoids
+                // showing a delete button that would 403.
+                const canDelete = readDeleteToken(c.id) !== null;
                 return (
                   <CommentRow
                     key={c.id}

--- a/src/lib/actions/sign-audio-urls.ts
+++ b/src/lib/actions/sign-audio-urls.ts
@@ -5,10 +5,16 @@ import { getSignedAudioUrls, extractStoragePath } from "@/lib/storage-urls";
 
 /**
  * Server action for client components that need signed audio URLs.
- * Validates the caller is authenticated before signing.
+ *
+ * Authorization: the user-scoped Supabase client below is RLS-bound, so
+ * a query for `track_audio_versions` with `audio_url IN (paths)` only
+ * returns rows the caller is allowed to read. We sign URLs ONLY for
+ * paths backed by a row the caller can see, dropping any path that
+ * isn't theirs from the result.
  *
  * Accepts an array of storage paths (or legacy full URLs).
- * Returns a record mapping each input path to its signed URL.
+ * Returns a record mapping each input path to its signed URL. Paths
+ * the caller is not authorized for are omitted from the response.
  */
 export async function signAudioUrlsAction(
   paths: string[],
@@ -22,11 +28,40 @@ export async function signAudioUrlsAction(
   if (!user) return {};
 
   const normalized = paths.map(extractStoragePath);
-  const signedMap = await getSignedAudioUrls(normalized);
+
+  // Build the set of values to look up. Some legacy rows store the
+  // full public URL in `audio_url` rather than a bare path, so we
+  // probe both forms.
+  const lookupValues = new Set<string>();
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  for (const p of normalized) {
+    lookupValues.add(p);
+    if (supabaseUrl) {
+      lookupValues.add(`${supabaseUrl}/storage/v1/object/public/track-audio/${p}`);
+    }
+  }
+
+  // RLS-enforced ownership check — only rows the caller can read come back.
+  const { data: rows } = await supabase
+    .from("track_audio_versions")
+    .select("audio_url")
+    .in("audio_url", Array.from(lookupValues));
+
+  const allowed = new Set<string>();
+  for (const row of rows ?? []) {
+    allowed.add(extractStoragePath(row.audio_url));
+  }
+
+  // Sign only the allowed paths.
+  const allowedPaths = normalized.filter((p) => allowed.has(p));
+  const signedMap = await getSignedAudioUrls(allowedPaths);
 
   const result: Record<string, string> = {};
   for (let i = 0; i < paths.length; i++) {
-    result[paths[i]] = signedMap.get(normalized[i]) ?? paths[i];
+    if (allowed.has(normalized[i])) {
+      result[paths[i]] = signedMap.get(normalized[i]) ?? paths[i];
+    }
+    // Unauthorized paths are silently omitted from the response.
   }
   return result;
 }

--- a/supabase/migrations/055_portal_comment_delete_token.sql
+++ b/supabase/migrations/055_portal_comment_delete_token.sql
@@ -1,0 +1,25 @@
+-- Adds an opaque per-comment delete token used to authorize portal-side
+-- deletes. The previous DELETE check compared the client-supplied
+-- author_name to revision_notes.author, which any portal visitor with
+-- the share token could spoof (the default author is "Client", so all
+-- default-named comments were deletable by anyone).
+--
+-- New flow:
+--   * POST /api/portal/comment generates a UUID, stores it in this
+--     column, and returns it in the response body. The portal client
+--     stashes it in localStorage keyed by comment id.
+--   * DELETE /api/portal/comment requires the caller to send the same
+--     token; the server compares server-side. No HMAC secret needed.
+--
+-- Existing rows have NULL — they cannot be deleted from the portal.
+-- That's intentional: those comments were created before the fix
+-- shipped, and the release owner can still delete them via the app.
+
+ALTER TABLE revision_notes
+  ADD COLUMN IF NOT EXISTS delete_token uuid;
+
+-- No index needed: lookups always have comment_id (PK) plus the token,
+-- so we just compare the column on the row.
+
+COMMENT ON COLUMN revision_notes.delete_token IS
+  'Opaque UUID set on portal-comment creation; required to delete from portal. NULL for non-portal-authored notes (which use app-side auth).';


### PR DESCRIPTION
## Summary

Fixes three IDOR/auth findings from the codebase audit. All three let unauthorized callers mutate or read data they shouldn't.

## Findings fixed

### C1 — `signAudioUrlsAction` signs any path for any authed user
**[src/lib/actions/sign-audio-urls.ts](src/lib/actions/sign-audio-urls.ts)** — the previous version only checked authentication, then service-role-signed every path the caller submitted. Storage paths follow a guessable pattern (`{userId}/{trackId}/v{n}.{ext}`), so any logged-in user could read other users' raw audio.

Now: query `track_audio_versions` with the user-scoped (RLS-enforced) Supabase client; only paths backed by a visible row are signed. Unauthorized paths are silently omitted.

### C2 — Portal comment DELETE accepted spoofed `author_name`
**[src/app/api/portal/comment/route.ts](src/app/api/portal/comment/route.ts)** — anyone with a share token could delete any comment by passing the same `author_name`. Default-named "Client" comments were deletable by all visitors.

Now: POST generates an opaque `delete_token` UUID, stores it on the row, returns it in the response. The portal client persists it in `localStorage` keyed by comment id. DELETE requires the token; server compares server-side. Migration `055_portal_comment_delete_token.sql` adds the column.

Existing comments have NULL `delete_token` → can't be deleted from the portal. Release owners can still delete via the in-app thread.

### H1 — `/api/attributions/attribute-signup` mutates any user's profile
**[src/app/api/attributions/attribute-signup/route.ts](src/app/api/attributions/attribute-signup/route.ts)** — endpoint trusted body-supplied `new_user_id`. Combined with `/track-click` returning `attribution_id` publicly, any caller could pin any user to any engineer.

Now: target user id derived from the authenticated session. Body's `new_user_id` is no longer accepted.

## Test plan

- [ ] Run migration 055 in dev/preview Supabase
- [ ] Upload a track, confirm waveform plays (`signAudioUrlsAction` happy path)
- [ ] Have user A try to load user B's storage path via the action — confirm empty result
- [ ] Create a portal comment from a fresh browser; confirm `delete_token` set + persisted in localStorage; delete works
- [ ] Open portal in private window; confirm delete button absent on existing comments (no token in storage)
- [ ] Confirm pre-existing comments (without token) return 403 on DELETE
- [ ] Confirm `/api/attributions/attribute-signup` returns 401 without auth

## Migrations
- `supabase/migrations/055_portal_comment_delete_token.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)