### PR TITLE
CSP: drop dead nonce + strict-dynamic, use static allowlist

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,18 +1,28 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
-/** Generate a random nonce for CSP inline scripts. */
-function generateNonce(): string {
-  const array = new Uint8Array(16);
-  crypto.getRandomValues(array);
-  return btoa(String.fromCharCode(...array));
-}
-
-/** Build the Content-Security-Policy header value with a per-request nonce. */
-function buildCsp(nonce: string): string {
+/**
+ * Build the Content-Security-Policy header value.
+ *
+ * The previous setup used a per-request nonce + 'strict-dynamic', but
+ * RootLayout never read x-nonce or propagated it to <Script> tags, so
+ * the nonce did nothing — inline scripts (Google Analytics ga4-init)
+ * had no nonce, and the policy was effectively security theater on the
+ * verge of silently breaking under any future Next.js streaming
+ * change. To wire a working nonce we'd have to make RootLayout dynamic
+ * (kills static optimization on marketing/changelog/featured pages).
+ *
+ * Trade-off taken: drop the nonce, keep the tight origin allowlist,
+ * accept 'unsafe-inline' for script-src so the GA init script works.
+ * This still blocks scripts from non-allowed origins and prevents
+ * framing/object-src; we lose the (already-broken) inline-script
+ * protection. When we drop GA or move it to a hash-based approach,
+ * remove 'unsafe-inline' here.
+ */
+function buildCsp(): string {
   return [
     "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' js.stripe.com www.googletagmanager.com`,
+    "script-src 'self' 'unsafe-inline' js.stripe.com www.googletagmanager.com",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' blob: data: sjdodeauawmuzredpxwa.supabase.co *.mzstatic.com",
     "connect-src 'self' sjdodeauawmuzredpxwa.supabase.co *.supabase.co wss://sjdodeauawmuzredpxwa.supabase.co api.stripe.com www.google-analytics.com *.google-analytics.com *.analytics.google.com",
@@ -29,22 +39,13 @@ function buildCsp(nonce: string): string {
 }
 
 export async function middleware(request: NextRequest) {
-  // Generate a per-request nonce for CSP
-  const nonce = generateNonce();
-
-  const requestHeaders = new Headers(request.headers);
-  // Pass nonce to server components via request header
-  requestHeaders.set("x-nonce", nonce);
-
-  const response = NextResponse.next({
-    request: { headers: requestHeaders },
-  });
+  const response = NextResponse.next({ request });
 
   // Expose pathname so server components (e.g. app layout) can read it
   response.headers.set("x-next-pathname", request.nextUrl.pathname);
 
-  // Set the enforced CSP with the nonce
-  response.headers.set("Content-Security-Policy", buildCsp(nonce));
+  // Set the enforced CSP
+  response.headers.set("Content-Security-Policy", buildCsp());
 
   // Only run Supabase auth check on /app routes
   if (request.nextUrl.pathname.startsWith("/app")) {


### PR DESCRIPTION
## Summary

Per audit P0 architecture finding: middleware generated a per-request nonce and emitted `script-src 'nonce-X' 'strict-dynamic' ...`, but `src/app/layout.tsx` never read `x-nonce` or propagated it to `<Script>` tags. Inline analytics (GA `ga4-init`, OpenPanel init) had no nonce, so the strict-dynamic policy was effectively security theater that risked silently breaking under any future Next.js streaming change.

## Decision

Two ways to fix the audit finding:

**(a)** Wire the nonce properly in RootLayout — required calling `headers()`, which makes the layout dynamic and kills static optimization for marketing/changelog/featured pages.

**(b) [taken]** Drop the nonce + strict-dynamic, switch script-src to `'unsafe-inline'`.

We're losing the (already-broken) inline-script-injection defense; we keep:
- Origin allowlist (only `'self'`, `js.stripe.com`, `www.googletagmanager.com`)
- `frame-ancestors 'none'`
- `object-src 'none'`
- `upgrade-insecure-requests`
- All other directives unchanged

## When to revisit

Reintroduce a hash-based or nonce-based defense when:
- Google Analytics is removed, OR
- GA loader is migrated to a hash-friendly pattern (compute SHA256 of the inline init at build time, hardcode in CSP)

## Follow-up tracked separately

- `middleware.ts` → `proxy.ts` rename for Next.js 16 (out of scope for this CSP change)

## Test plan

- [ ] After deploy, open DevTools → Network → headers → check `Content-Security-Policy` reflects new value
- [ ] No CSP violations in console for `/`, `/app`, `/portal/[token]`, `/featured/[slug]`
- [ ] Stripe checkout still loads (`js.stripe.com`)
- [ ] GA fires (`gtag` calls succeed in console; check Realtime in GA UI)
- [ ] Theme picker works (next-themes inline script — was nonced, now passes via `'unsafe-inline'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)