### PR TITLE
Bundle weight: drop screen-mockup use-client + dynamic-import wavesurfer

### DIFF
--- a/src/components/portal/portal-audio-player.tsx
+++ b/src/components/portal/portal-audio-player.tsx
@@ -16,7 +16,8 @@ import {
   Repeat,
   AlertTriangle,
 } from "lucide-react";
-import WaveSurfer from "wavesurfer.js";
+import type WaveSurfer from "wavesurfer.js";
+import { loadWaveSurfer } from "@/lib/wavesurfer-loader";
 import { trackGA4Event } from "@/lib/ga4-track";
 import {
   getWaveColors,
@@ -352,8 +353,14 @@ export function PortalAudioPlayer({
 
     const container = containerRef.current;
     let ws: WaveSurfer | null = null;
-    const raf = requestAnimationFrame(() => {
-      if (!container || !container.isConnected) return;
+    let cancelled = false;
+    const raf = requestAnimationFrame(async () => {
+      if (cancelled || !container || !container.isConnected) return;
+
+      // Dynamic import keeps wavesurfer out of the initial portal
+      // bundle. Cached at the loader's module scope.
+      const WaveSurfer = await loadWaveSurfer();
+      if (cancelled || !container.isConnected || !activeVersion) return;
 
       const colors = getWaveColors();
 
@@ -436,6 +443,7 @@ export function PortalAudioPlayer({
     });
 
     return () => {
+      cancelled = true;
       cancelAnimationFrame(raf);
       if (ws) ws.destroy();
       wavesurferRef.current = null;

--- a/src/components/ui/audio-player.tsx
+++ b/src/components/ui/audio-player.tsx
@@ -24,7 +24,8 @@ import {
   X,
   Repeat,
 } from "lucide-react";
-import WaveSurfer from "wavesurfer.js";
+import type WaveSurfer from "wavesurfer.js";
+import { loadWaveSurfer } from "@/lib/wavesurfer-loader";
 import { perf } from "@/lib/perf";
 import { perfReporter } from "@/lib/perf-reporter";
 import {
@@ -522,8 +523,14 @@ export function AudioPlayer({
     let retryTimeout: ReturnType<typeof setTimeout> | null = null;
     const container = containerRef.current;
 
-    function createWaveSurfer() {
+    async function createWaveSurfer() {
       if (cancelled || !container || !container.isConnected || !activeVersion) return;
+
+      // Dynamically import wavesurfer so it's not in the initial
+      // bundle for users who don't visit a track page. Cached at the
+      // loader's module scope, so subsequent navigations are instant.
+      const WaveSurfer = await loadWaveSurfer();
+      if (cancelled || !container.isConnected || !activeVersion) return;
 
       const colors = getWaveColors();
       perf.setAudioFileInfo({

--- a/src/components/ui/screen-mockup.tsx
+++ b/src/components/ui/screen-mockup.tsx
@@ -1,8 +1,13 @@
-"use client";
-
 /* ═══════════════════════════════════════════════════════════
    SCREEN MOCKUP — Help article visual aids using real components
    74 mockups (18 articles)
+
+   Renders as a Server Component: every mockup is pure presentational
+   JSX with no hooks, no event handlers (the two onClick refs are
+   no-op placeholders inside mock data), and no client-only imports.
+   When this was "use client", the entire 3,909-line module shipped
+   to every visitor of /app/help — about 80–120 KB of JS for content
+   that has no interactivity.
    ═══════════════════════════════════════════════════════════ */
 
 import {

--- a/src/lib/wavesurfer-loader.ts
+++ b/src/lib/wavesurfer-loader.ts
@@ -1,0 +1,28 @@
+/**
+ * Lazy loader for the wavesurfer.js bundle.
+ *
+ * Both the main audio-player and the portal audio-player previously
+ * statically imported wavesurfer.js, dragging ~50 KB minified into
+ * every track-detail / portal initial bundle whether or not a user
+ * scrolled to a track with audio. Switching to dynamic import keeps
+ * wavesurfer out of the initial bundle and only loads it when the
+ * player actually mounts.
+ *
+ * Usage:
+ *   const WaveSurfer = await loadWaveSurfer();
+ *   const ws = WaveSurfer.create({ ... });
+ *
+ * The dynamic import is cached at module scope, so the second player
+ * (mini-player → main player navigation, etc.) hits the cached chunk
+ * instantly.
+ */
+type WaveSurferModule = typeof import("wavesurfer.js");
+
+let cached: Promise<WaveSurferModule> | null = null;
+
+export function loadWaveSurfer(): Promise<WaveSurferModule["default"]> {
+  if (!cached) {
+    cached = import("wavesurfer.js");
+  }
+  return cached.then((m) => m.default);
+}


### PR DESCRIPTION
## Summary

Two bundle-weight wins from the audit. Both are low-risk, high-leverage.

## Changes

### 1. `screen-mockup.tsx` is now a Server Component

3,909 lines, marked `"use client"`, with zero `useState` / `useEffect` / `useReducer` / `useRef` calls and zero event handlers (the two `onClick` references are no-op placeholders inside mock data). Every visitor to `/app/help` shipped ~80–120 KB of pure presentational JSX for no reason.

Imports verified server-compatible (`Panel`, `Button`, `Pill`, `StatusDot`, `StatTile`, `EmptyState`, `DataGrid`, `Rule`, `AccentPanel`, `lucide-react` — none have `"use client"`).

### 2. `wavesurfer.js` is now dynamic-imported

Both `audio-player.tsx` (line 27) and `portal-audio-player.tsx` (line 19) statically imported wavesurfer, dragging ~50 KB minified into the initial bundle of every track-detail and portal page — including the cold case where the user lands on the page but never plays audio.

`FeaturedAudioPlayer` already showed the right pattern. This PR adds a shared loader (`src/lib/wavesurfer-loader.ts`) that caches the import promise at module scope so subsequent navigations between players hit the cached chunk instantly.

Race-safety: an `if (cancelled) return` check is added after the dynamic-import `await` in both effects, so a fast unmount-during-loading doesn't leak an instance.

## Test plan

- [ ] `/app/help` loads and renders mockups correctly (Server Component)
- [ ] DevTools network tab on `/app/releases/[id]/tracks/[id]` shows `wavesurfer*.js` chunk loaded *after* the page shell, not in the initial bundle
- [ ] Track detail player still creates waveform, plays, seeks
- [ ] Portal page (`/portal/[token]`) still creates waveform, plays, comments work
- [ ] Rapidly switching between two tracks doesn't leak a player instance (race check)
- [ ] Bundle analyzer (or `next build` output) shows reduced first-load JS for `/app/help` and track-detail routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)