### PR TITLE
Audio-context split: move currentTime/duration to subscription hooks

### DIFF
--- a/src/components/portal/portal-audio-player.tsx
+++ b/src/components/portal/portal-audio-player.tsx
@@ -2,7 +2,12 @@
 
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { cn } from "@/lib/cn";
-import { useAudio, type AudioTrackMeta } from "@/lib/audio-context";
+import {
+  useAudio,
+  useAudioCurrentTime,
+  useAudioDuration,
+  type AudioTrackMeta,
+} from "@/lib/audio-context";
 import { useTheme } from "next-themes";
 import {
   SkipBack,
@@ -140,8 +145,13 @@ export function PortalAudioPlayer({
   const isThisTrackActive = audio.activeVersion?.track_id === trackId;
   const audioElement = audio.audioElement;
   const isPlaying = isThisTrackActive ? audio.isPlaying : false;
-  const currentTime = isThisTrackActive ? audio.currentTime : 0;
-  const duration = isThisTrackActive ? audio.duration : 0;
+  // Subscribe directly to the audio element for time. The
+  // isThisTrackActive gate keeps the displayed cursor at 0 for
+  // tracks that aren't the currently-playing one.
+  const sharedCurrentTime = useAudioCurrentTime();
+  const sharedDuration = useAudioDuration();
+  const currentTime = isThisTrackActive ? sharedCurrentTime : 0;
+  const duration = isThisTrackActive ? sharedDuration : 0;
 
   // Version state
   const [activeVersionId, setActiveVersionId] = useState<string | null>(() => {

--- a/src/components/portal/portal-mini-player.tsx
+++ b/src/components/portal/portal-mini-player.tsx
@@ -3,7 +3,11 @@
 import { X, Repeat } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { FilledPlay, FilledPause } from "@/components/ui/filled-icon";
-import { useAudio } from "@/lib/audio-context";
+import {
+  useAudio,
+  useAudioCurrentTime,
+  useAudioDuration,
+} from "@/lib/audio-context";
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60);
@@ -16,13 +20,13 @@ export function PortalMiniPlayer() {
     activeVersion,
     trackMeta,
     isPlaying,
-    currentTime,
-    duration,
     isLooping,
     togglePlayPause,
     toggleLoop,
     stop,
   } = useAudio();
+  const currentTime = useAudioCurrentTime();
+  const duration = useAudioDuration();
 
   // Hide when nothing is loaded
   if (!activeVersion || !trackMeta) return null;

--- a/src/components/ui/audio-player.tsx
+++ b/src/components/ui/audio-player.tsx
@@ -5,7 +5,12 @@ import { cn } from "@/lib/cn";
 import { Timestamp } from "@/components/ui/timestamp";
 import { Button } from "@/components/ui/button";
 import { createSupabaseBrowserClient } from "@/lib/supabaseBrowserClient";
-import { useAudio, type AudioTrackMeta } from "@/lib/audio-context";
+import {
+  useAudio,
+  useAudioCurrentTime,
+  useAudioDuration,
+  type AudioTrackMeta,
+} from "@/lib/audio-context";
 import { useTheme } from "next-themes";
 import { sendNotification } from "@/lib/notifications/client";
 import { logActivityClient } from "@/lib/activity-logger-client";
@@ -169,7 +174,12 @@ export function AudioPlayer({
 
   // Shared audio context
   const audio = useAudio();
-  const { audioElement, isPlaying, currentTime, duration, isBuffering } = audio;
+  const { audioElement, isPlaying, isBuffering } = audio;
+  // Time + duration come from dedicated subscriptions so non-time
+  // consumers (mini-player on other pages, shell, etc.) don't
+  // re-render on every `timeupdate`.
+  const currentTime = useAudioCurrentTime();
+  const duration = useAudioDuration();
 
   // Version state — sync with context if it's already playing a version for this track
   const [activeVersionId, setActiveVersionId] = useState<string | null>(() => {

--- a/src/components/ui/mini-player.tsx
+++ b/src/components/ui/mini-player.tsx
@@ -4,7 +4,11 @@ import Link from "next/link";
 import { X, Repeat, Loader2 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { FilledPlay, FilledPause } from "@/components/ui/filled-icon";
-import { useAudio } from "@/lib/audio-context";
+import {
+  useAudio,
+  useAudioCurrentTime,
+  useAudioDuration,
+} from "@/lib/audio-context";
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60);
@@ -17,14 +21,14 @@ export function MiniPlayer() {
     activeVersion,
     trackMeta,
     isPlaying,
-    currentTime,
-    duration,
     isLooping,
     isBuffering,
     togglePlayPause,
     toggleLoop,
     stop,
   } = useAudio();
+  const currentTime = useAudioCurrentTime();
+  const duration = useAudioDuration();
 
   // Hide when nothing is loaded
   if (!activeVersion || !trackMeta) return null;

--- a/src/lib/audio-context.tsx
+++ b/src/lib/audio-context.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 import type { AudioVersionData } from "@/components/ui/audio-player";
@@ -35,8 +36,6 @@ type AudioContextValue = {
   trackMeta: AudioTrackMeta | null;
   /** Playback state */
   isPlaying: boolean;
-  currentTime: number;
-  duration: number;
   /** Whether playback loops back to the start on track end */
   isLooping: boolean;
   /** True when the user has requested playback but the element is
@@ -54,6 +53,23 @@ type AudioContextValue = {
   /** Toggle loop on/off */
   toggleLoop: () => void;
 };
+
+/* ------------------------------------------------------------------ */
+/*  Note: currentTime and duration are NOT in the context value above. */
+/*                                                                     */
+/*  The previous design fed `currentTime` from the audio element's    */
+/*  `timeupdate` event (~4×/sec) into React state in the context. That */
+/*  forced every `useAudio()` consumer to re-render that often — six   */
+/*  components in production: audio-player, portal-audio-player,       */
+/*  mini-player, portal-mini-player, flow-simulator, shell. None of    */
+/*  them except the four players actually need the time, but they all  */
+/*  paid the cost.                                                     */
+/*                                                                     */
+/*  The four players read time via the dedicated hooks below, which    */
+/*  use `useSyncExternalStore` to subscribe directly to the audio      */
+/*  element. Subscribers get notified on `timeupdate`/`durationchange` */
+/*  but other consumers don't re-render at all on those events.        */
+/* ------------------------------------------------------------------ */
 
 /* ------------------------------------------------------------------ */
 /*  Context                                                            */
@@ -82,8 +98,6 @@ export function AudioProvider({ children }: { children: ReactNode }) {
   const [activeVersion, setActiveVersion] = useState<AudioVersionData | null>(null);
   const [trackMeta, setTrackMeta] = useState<AudioTrackMeta | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [duration, setDuration] = useState(0);
   const [isLooping, setIsLooping] = useState(false);
   // True from the moment the user clicks play until audio is actually
   // audible, OR when playback stalls mid-track waiting on more data.
@@ -157,21 +171,12 @@ export function AudioProvider({ children }: { children: ReactNode }) {
         }
       }
     };
-    const onTimeUpdate = () => setCurrentTime(el.currentTime);
-    const onLoadedMetadata = () => setDuration(el.duration);
-    const onDurationChange = () => {
-      if (el.duration && isFinite(el.duration)) setDuration(el.duration);
-    };
-
     el.addEventListener("play", onPlay);
     el.addEventListener("playing", onPlaying);
     el.addEventListener("pause", onPause);
     el.addEventListener("waiting", onWaiting);
     el.addEventListener("canplay", onCanPlay);
     el.addEventListener("ended", onEnded);
-    el.addEventListener("timeupdate", onTimeUpdate);
-    el.addEventListener("loadedmetadata", onLoadedMetadata);
-    el.addEventListener("durationchange", onDurationChange);
 
     return () => {
       el.removeEventListener("play", onPlay);
@@ -180,9 +185,6 @@ export function AudioProvider({ children }: { children: ReactNode }) {
       el.removeEventListener("waiting", onWaiting);
       el.removeEventListener("canplay", onCanPlay);
       el.removeEventListener("ended", onEnded);
-      el.removeEventListener("timeupdate", onTimeUpdate);
-      el.removeEventListener("loadedmetadata", onLoadedMetadata);
-      el.removeEventListener("durationchange", onDurationChange);
       // Cleanup FPS monitor on unmount
       if (fpsMonitorRef.current) {
         fpsMonitorRef.current.stop();
@@ -211,7 +213,6 @@ export function AudioProvider({ children }: { children: ReactNode }) {
       const currentUrl = el.currentSrc || el.src || "";
       if (currentUrl && currentUrl === version.audio_url) {
         setActiveVersion(version);
-        setDuration(version.duration_seconds ?? el.duration ?? 0);
         return;
       }
 
@@ -219,8 +220,6 @@ export function AudioProvider({ children }: { children: ReactNode }) {
       el.src = version.audio_url;
       el.load();
       setActiveVersion(version);
-      setCurrentTime(0);
-      setDuration(version.duration_seconds ?? 0);
     },
     [],
   );
@@ -264,8 +263,9 @@ export function AudioProvider({ children }: { children: ReactNode }) {
   const seekTo = useCallback((time: number) => {
     const el = audioRef.current;
     if (!el) return;
+    // Setting currentTime triggers a `seeked` event on the element,
+    // which the time-subscription hooks below pick up automatically.
     el.currentTime = time;
-    setCurrentTime(time);
   }, []);
 
   const stop = useCallback(() => {
@@ -279,8 +279,6 @@ export function AudioProvider({ children }: { children: ReactNode }) {
     setTrackMeta(null);
     setIsPlaying(false);
     setIsBuffering(false);
-    setCurrentTime(0);
-    setDuration(0);
   }, []);
 
   const toggleLoop = useCallback(() => {
@@ -288,16 +286,15 @@ export function AudioProvider({ children }: { children: ReactNode }) {
   }, []);
 
   // Memoize the context value to prevent unnecessary consumer re-renders.
-  // Split into two values: stable (rarely changes) and volatile (currentTime).
-  // This prevents the entire consumer tree from re-rendering on every timeupdate.
+  // currentTime/duration are deliberately NOT here — they're read via
+  // useAudioCurrentTime / useAudioDuration so only consumers that
+  // actually need the time pay the re-render cost on `timeupdate`.
   const contextValue = useMemo(
     () => ({
       audioElement: audioRef.current!,
       activeVersion,
       trackMeta,
       isPlaying,
-      currentTime,
-      duration,
       isLooping,
       isBuffering,
       loadVersion,
@@ -306,7 +303,7 @@ export function AudioProvider({ children }: { children: ReactNode }) {
       stop,
       toggleLoop,
     }),
-    [activeVersion, trackMeta, isPlaying, currentTime, duration, isLooping, isBuffering, loadVersion, togglePlayPause, seekTo, stop, toggleLoop],
+    [activeVersion, trackMeta, isPlaying, isLooping, isBuffering, loadVersion, togglePlayPause, seekTo, stop, toggleLoop],
   );
 
   // SSR guard — render nothing useful on server
@@ -330,8 +327,6 @@ const SSR_FALLBACK: AudioContextValue = {
   activeVersion: null,
   trackMeta: null,
   isPlaying: false,
-  currentTime: 0,
-  duration: 0,
   isLooping: false,
   isBuffering: false,
   loadVersion: () => {},
@@ -346,4 +341,73 @@ export function useAudio() {
   // During SSR the provider hasn't mounted yet — return a safe no-op fallback.
   if (!ctx) return SSR_FALLBACK;
   return ctx;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Time subscription hooks                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Subscribe to the audio element's currentTime via useSyncExternalStore.
+ * Re-renders the calling component on `timeupdate` (~4×/sec during
+ * playback) and `seeked`. Only components that actually need the
+ * playhead position should call this.
+ */
+export function useAudioCurrentTime(): number {
+  const ctx = useContext(AudioContext);
+  const el = ctx?.audioElement;
+
+  const subscribe = useCallback(
+    (notify: () => void) => {
+      if (!el) return () => {};
+      el.addEventListener("timeupdate", notify);
+      el.addEventListener("seeked", notify);
+      return () => {
+        el.removeEventListener("timeupdate", notify);
+        el.removeEventListener("seeked", notify);
+      };
+    },
+    [el],
+  );
+
+  const getSnapshot = useCallback(() => (el ? el.currentTime : 0), [el]);
+  // SSR: no element yet, just return 0.
+  const getServerSnapshot = useCallback(() => 0, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+/**
+ * Subscribe to the audio element's duration. Updates on
+ * `loadedmetadata` and `durationchange`. Stable during playback, so
+ * components that only need duration don't re-render at all once the
+ * track is loaded.
+ */
+export function useAudioDuration(): number {
+  const ctx = useContext(AudioContext);
+  const el = ctx?.audioElement;
+
+  const subscribe = useCallback(
+    (notify: () => void) => {
+      if (!el) return () => {};
+      el.addEventListener("durationchange", notify);
+      el.addEventListener("loadedmetadata", notify);
+      el.addEventListener("emptied", notify);
+      return () => {
+        el.removeEventListener("durationchange", notify);
+        el.removeEventListener("loadedmetadata", notify);
+        el.removeEventListener("emptied", notify);
+      };
+    },
+    [el],
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (!el) return 0;
+    const d = el.duration;
+    return Number.isFinite(d) ? d : 0;
+  }, [el]);
+  const getServerSnapshot = useCallback(() => 0, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## Summary

Per audit Critical-perf finding: `currentTime` was a `useState` value on the shared `AudioContext`, fed by the audio element's `timeupdate` event (~4×/sec during playback). Every `useAudio()` consumer re-rendered that often whether or not it needed the time — six components in production: `audio-player`, `portal-audio-player`, `mini-player`, `portal-mini-player`, `flow-simulator`, `shell`.

This PR removes `currentTime` and `duration` from the context and exposes them via two dedicated `useSyncExternalStore` hooks.

## Changes

**`src/lib/audio-context.tsx`**
- Drops `currentTime` / `duration` from `AudioContextValue`, `SSR_FALLBACK`, and the provider's `useState` calls
- Removes the `timeupdate` / `loadedmetadata` / `durationchange` listeners that fed React state
- Adds:
  - `useAudioCurrentTime()` — subscribes to `timeupdate` + `seeked`
  - `useAudioDuration()` — subscribes to `loadedmetadata` + `durationchange` + `emptied`
- Both read directly from the audio element via `useSyncExternalStore`

**Consumers updated**
- `src/components/ui/audio-player.tsx`
- `src/components/ui/mini-player.tsx`
- `src/components/portal/portal-audio-player.tsx`
- `src/components/portal/portal-mini-player.tsx`

**Untouched** (only use stable state — no time fields):
- `src/components/ui/shell.tsx` (just `activeVersion`)
- `src/components/flow-simulator/flow-simulator.tsx` (uses its own flow audio engine, not shared `useAudio()`)

## Expected impact

During playback, the four players still re-render on `timeupdate` (they need to). `shell.tsx` and any other `useAudio()` consumers that don't read time stop re-rendering 4×/sec — the perf-reporter dashboard should show a measurable drop in the per-second render count for app shell while audio is playing.

## Test plan

- [ ] Wait for Vercel preview, open `/app` and play a track — confirm transport timecode increments and the seekbar moves smoothly
- [ ] Open the mini-player on a release page (different route from track page); confirm progress bar updates
- [ ] Open `/portal/[token]` and play a track; confirm portal player + portal mini-player both update
- [ ] Click on the waveform to seek — confirm cursor jumps to the new position immediately
- [ ] React DevTools profiler: with the app shell visible during playback, confirm only the player + mini-player re-render on each `timeupdate`, not the entire `AudioProvider` subtree

## Risk

Touches every consumer of `currentTime`/`duration`. TypeScript catches any missed migration site at compile time (the types removed from `AudioContextValue` would surface). All four migration sites verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)