### PR TITLE
Bump claude-review max-turns 5 → 10

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -62,4 +62,7 @@ jobs:
             One summary comment for cross-cutting concerns. Skip nitpicks
             (formatting, debatable style) — focus on what could break in
             production or hurt paying customers.
-          claude_args: "--max-turns 5 --model claude-sonnet-4-6"
+          # 10 turns: PR #23 hit the 5-turn cap mid-review with a
+          # multi-file documentation PR. 10 leaves headroom for typical
+          # PRs while keeping per-PR cost bounded (~$0.10–$0.50).
+          claude_args: "--max-turns 10 --model claude-sonnet-4-6"


### PR DESCRIPTION
## Summary

PR #23 hit the 5-turn cap with a multi-file documentation PR and returned \`error_max_turns\` instead of finishing the review. 10 turns leaves headroom for typical PRs while keeping per-PR cost bounded (~\$0.10–\$0.50 for this codebase).

## Test plan

- [ ] Open a non-trivial follow-up PR — confirm Claude Code Review completes (no \`error_max_turns\`)
- [ ] Spot-check Anthropic console for actual cost per review run

🤖 Generated with [Claude Code](https://claude.com/claude-code)