### PR TITLE
Hide testimonials section on landing (placeholder quotes)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,12 @@ import { Hero } from "@/components/landing/hero";
 import { FeatureShowcase } from "@/components/landing/feature-showcase";
 import { AudioToolsGrid } from "@/components/landing/audio-tools-grid";
 import { Pricing } from "@/components/landing/pricing";
-import { FounderNote } from "@/components/landing/founder-note";
+// FounderNote (the "Trusted by engineers and artists" testimonials
+// block) is intentionally not rendered yet — its current quotes are
+// placeholder copy. Re-import and add <FounderNote /> back to the
+// page below once real customer quotes are in
+// src/i18n/messages/*.json under landing.testimonial1*/testimonial2*.
+// import { FounderNote } from "@/components/landing/founder-note";
 import { FinalCTA } from "@/components/landing/final-cta";
 import { LandingFooter } from "@/components/landing/footer";
 import { FeaturedReleaseSection } from "@/components/landing/featured-release-section";
@@ -43,7 +48,7 @@ export default async function HomePage() {
         <AudioToolsGrid />
         <Pricing />
         {featuredRelease && <FeaturedReleaseSection release={featuredRelease} />}
-        <FounderNote />
+        {/* <FounderNote /> — hidden until we have real customer quotes. */}
         <FinalCTA />
         <LandingFooter />
       </main>


### PR DESCRIPTION
## Summary

The \`FounderNote\` block on the landing page renders two placeholder testimonials ("Marcus Chen" and "Aria Voss"). Before running paid ads we don't want fake social proof on the page — it's a credibility hit and may flag on some ad platforms' review.

Hides the section by commenting out the render + import. Component file (\`src/components/landing/founder-note.tsx\`) and the localized strings under \`landing.testimonial1*\`/\`landing.testimonial2*\` in all 11 locales stay in place — re-enabling once real quotes exist is two lines.

## Test plan

- [ ] After Vercel preview: visit \`/\` → confirm Pricing flows directly to the FinalCTA, no "Trusted by engineers and artists" block
- [ ] Visit \`/?locale=fr\` (or any locale) → same; section gone everywhere
- [ ] Lighthouse run — no broken layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)