### PR TITLE
Admin: switch / cancel a user's subscription from the detail page

### DIFF
--- a/src/app/admin/subscribers/[userId]/page.tsx
+++ b/src/app/admin/subscribers/[userId]/page.tsx
@@ -15,6 +15,7 @@ import { notFound } from "next/navigation";
 import { AdminToggleButton } from "@/components/admin/AdminToggleButton";
 import { TestAccountToggle } from "@/components/admin/UserDetailHeader";
 import { DeleteUserButton } from "@/components/admin/DeleteUserButton";
+import { SubscriptionPlanControl } from "@/components/admin/SubscriptionPlanControl";
 
 export const dynamic = "force-dynamic";
 
@@ -198,6 +199,22 @@ export default async function UserDetailPage({ params }: Props) {
         <div className="flex flex-wrap items-center gap-2 mt-3">
           <TestAccountToggle userId={userId} initial={isTestAccount} />
           <AdminToggleButton userId={userId} isAdmin={profile.is_admin === true} />
+          <SubscriptionPlanControl
+            userId={userId}
+            subscription={
+              subscription
+                ? {
+                    plan: subscription.plan ?? null,
+                    status: subscription.status ?? null,
+                    granted_by_admin: subscription.granted_by_admin ?? null,
+                    stripe_subscription_id:
+                      subscription.stripe_subscription_id ?? null,
+                    cancel_at_period_end:
+                      subscription.cancel_at_period_end ?? null,
+                  }
+                : null
+            }
+          />
           <DeleteUserButton userId={userId} />
         </div>
 

--- a/src/app/api/admin/cancel-subscription/route.ts
+++ b/src/app/api/admin/cancel-subscription/route.ts
@@ -1,0 +1,199 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+import { stripe } from "@/lib/stripe-server";
+import { isAdmin } from "@/lib/admin";
+import { logAdminAction } from "@/lib/admin-audit-logger";
+import { logActivity } from "@/lib/activity-logger";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
+
+/**
+ * POST /api/admin/cancel-subscription
+ *
+ * Admin tool for ending a user's Pro subscription.
+ *
+ * Handles three cases based on the row's current state:
+ *
+ *   - Admin-granted comp (granted_by_admin = true):
+ *       Direct DB update — no Stripe call. Plan goes to "free",
+ *       status to "canceled", granted_by_admin to false.
+ *
+ *   - Real Stripe subscription, mode="immediate":
+ *       stripe.subscriptions.cancel(...) cancels at Stripe. The
+ *       customer.subscription.deleted webhook updates our DB row.
+ *       The local row is also updated immediately so the admin UI
+ *       reflects the change without waiting for webhook latency.
+ *
+ *   - Real Stripe subscription, mode="at_period_end":
+ *       stripe.subscriptions.update({ cancel_at_period_end: true }).
+ *       Customer keeps access until current_period_end; the
+ *       customer.subscription.updated webhook reconciles state.
+ *
+ * Used for QA (an admin wants to take their own paid account back to
+ * Free to test the upgrade flow) and for handling refund/cancel
+ * requests where you don't want to make the user go through the
+ * customer portal.
+ *
+ * Body: {
+ *   userId: string;
+ *   mode: "immediate" | "at_period_end";
+ *   reason?: string;
+ * }
+ */
+export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
+  const ip = getClientIp(req);
+  const { success } = rateLimit(`admin-cancel-sub:${ip}`, 20, 60_000);
+  if (!success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  try {
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user || !(await isAdmin(user.id))) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const { userId, mode, reason } = body as {
+      userId: string;
+      mode: "immediate" | "at_period_end";
+      reason?: string;
+    };
+
+    if (!userId || (mode !== "immediate" && mode !== "at_period_end")) {
+      return NextResponse.json(
+        {
+          error:
+            "Missing or invalid fields. Required: userId, mode (immediate | at_period_end)",
+        },
+        { status: 400 },
+      );
+    }
+
+    const serviceClient = createSupabaseServiceClient();
+
+    // Look up the existing subscription row.
+    const { data: existing, error: lookupErr } = await serviceClient
+      .from("subscriptions")
+      .select("user_id, plan, status, granted_by_admin, stripe_subscription_id, stripe_customer_id, current_period_end")
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    if (lookupErr) {
+      console.error("[admin/cancel-subscription] lookup error:", lookupErr.message);
+      return NextResponse.json(
+        { error: "Failed to load subscription" },
+        { status: 500 },
+      );
+    }
+
+    if (!existing) {
+      return NextResponse.json(
+        { error: "User has no subscription to cancel" },
+        { status: 404 },
+      );
+    }
+
+    if (existing.plan !== "pro" || existing.status === "canceled") {
+      return NextResponse.json(
+        { error: "User is not on an active Pro plan" },
+        { status: 400 },
+      );
+    }
+
+    let outcome: "comp_removed" | "stripe_canceled_immediate" | "stripe_cancel_scheduled";
+
+    if (existing.granted_by_admin === true) {
+      // Comp account — no Stripe call needed. Just flip the row.
+      const { error: updateErr } = await serviceClient
+        .from("subscriptions")
+        .update({
+          plan: "free",
+          status: "canceled",
+          granted_by_admin: false,
+        })
+        .eq("user_id", userId);
+
+      if (updateErr) {
+        console.error("[admin/cancel-subscription] comp revoke failed:", updateErr.message);
+        return NextResponse.json(
+          { error: "Failed to remove comp account" },
+          { status: 500 },
+        );
+      }
+      outcome = "comp_removed";
+    } else if (existing.stripe_subscription_id) {
+      // Real Stripe subscription — drive cancellation through Stripe so
+      // the customer isn't billed and our records stay consistent.
+      try {
+        if (mode === "immediate") {
+          await stripe.subscriptions.cancel(existing.stripe_subscription_id);
+          // Mirror the change locally so the admin UI updates without
+          // waiting for the customer.subscription.deleted webhook.
+          await serviceClient
+            .from("subscriptions")
+            .update({ status: "canceled", plan: "free", cancel_at_period_end: false })
+            .eq("user_id", userId);
+          outcome = "stripe_canceled_immediate";
+        } else {
+          await stripe.subscriptions.update(existing.stripe_subscription_id, {
+            cancel_at_period_end: true,
+          });
+          await serviceClient
+            .from("subscriptions")
+            .update({ cancel_at_period_end: true })
+            .eq("user_id", userId);
+          outcome = "stripe_cancel_scheduled";
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error("[admin/cancel-subscription] Stripe call failed:", message);
+        return NextResponse.json(
+          { error: `Stripe cancellation failed: ${message}` },
+          { status: 500 },
+        );
+      }
+    } else {
+      // Neither comp nor a Stripe sub — shouldn't happen in practice
+      // (a paid Pro plan always has stripe_subscription_id), but
+      // surface it explicitly rather than silently noop.
+      return NextResponse.json(
+        { error: "Subscription has no Stripe link and is not a comp account" },
+        { status: 400 },
+      );
+    }
+
+    // Audit log + user-facing activity log.
+    const requestInfo = {
+      ip: getClientIp(req),
+      userAgent: req.headers.get("user-agent") ?? undefined,
+    };
+    logAdminAction(
+      user.id,
+      "subscription_canceled_by_admin",
+      { target_user: userId, mode, outcome, reason },
+      requestInfo,
+    );
+    logActivity(
+      userId,
+      "subscription_cancelled",
+      { by_admin: true, admin_id: user.id, mode, outcome, reason },
+      requestInfo,
+    );
+
+    return NextResponse.json({ success: true, outcome });
+  } catch (err) {
+    console.error("[admin/cancel-subscription] error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/admin/SubscriptionPlanControl.tsx
+++ b/src/components/admin/SubscriptionPlanControl.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Gift, X, Clock, AlertTriangle } from "lucide-react";
+
+/**
+ * Plan controls for the admin user-detail page.
+ *
+ * The buttons surface different actions depending on what kind of
+ * subscription the user has:
+ *
+ *   - Free / no row → "Grant Comp Pro" (calls existing
+ *     /api/admin/comp-account, action=grant).
+ *
+ *   - Admin-granted comp → "Remove Comp" (calls
+ *     /api/admin/cancel-subscription — handler short-circuits to a
+ *     DB-only flip when granted_by_admin = true).
+ *
+ *   - Paid Pro (real Stripe sub, active, NOT scheduled to cancel) →
+ *     "Cancel Now" + "Cancel at Period End".
+ *
+ *   - Paid Pro already scheduled to cancel at period end →
+ *     just "Cancel Now" (the user already chose period-end cancel).
+ *
+ * All destructive actions confirm before sending.
+ */
+
+type Subscription = {
+  plan: string | null;
+  status: string | null;
+  granted_by_admin: boolean | null;
+  stripe_subscription_id: string | null;
+  cancel_at_period_end: boolean | null;
+};
+
+type Props = {
+  userId: string;
+  subscription: Subscription | null;
+};
+
+type ActionState = "idle" | "loading" | "error";
+
+export function SubscriptionPlanControl({ userId, subscription }: Props) {
+  const router = useRouter();
+  const [state, setState] = useState<ActionState>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const isActivePro =
+    subscription?.plan === "pro" && subscription?.status === "active";
+  const isComp = isActivePro && subscription?.granted_by_admin === true;
+  const isPaidPro =
+    isActivePro && !!subscription?.stripe_subscription_id && !isComp;
+  const willCancelAtPeriodEnd =
+    isPaidPro && subscription?.cancel_at_period_end === true;
+
+  async function grantComp() {
+    if (!confirm("Grant this user a comp Pro subscription (indefinite)?")) return;
+    setState("loading");
+    setErrorMsg(null);
+    try {
+      const res = await fetch("/api/admin/comp-account", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userId,
+          action: "grant",
+          duration: "indefinite",
+          reason: "Admin testing / support",
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? `HTTP ${res.status}`);
+      }
+      router.refresh();
+      setState("idle");
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed");
+      setState("error");
+    }
+  }
+
+  async function cancel(mode: "immediate" | "at_period_end") {
+    const prompt =
+      mode === "immediate"
+        ? isComp
+          ? "Remove this user's comp Pro subscription? They go back to Free immediately."
+          : "Cancel this user's Stripe subscription NOW? They lose Pro access immediately and are not charged again."
+        : "Schedule cancellation at the end of the current billing period? User keeps Pro access until then.";
+
+    if (!confirm(prompt)) return;
+    setState("loading");
+    setErrorMsg(null);
+    try {
+      const res = await fetch("/api/admin/cancel-subscription", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userId,
+          mode,
+          reason: "Admin action via user detail page",
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? `HTTP ${res.status}`);
+      }
+      router.refresh();
+      setState("idle");
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed");
+      setState("error");
+    }
+  }
+
+  // Free user — offer to grant comp.
+  if (!isActivePro) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={grantComp}
+          disabled={state === "loading"}
+          className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded border border-amber-500/30 text-amber-400 hover:bg-amber-500/10 transition-colors disabled:opacity-50"
+          title="Grant a comp (admin-granted) Pro subscription"
+        >
+          <Gift size={12} />
+          {state === "loading" ? "Granting…" : "Grant Comp Pro"}
+        </button>
+        {errorMsg && (
+          <span className="text-xs text-red-400 inline-flex items-center gap-1">
+            <AlertTriangle size={12} />
+            {errorMsg}
+          </span>
+        )}
+      </>
+    );
+  }
+
+  // Active Pro — offer cancel paths.
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => cancel("immediate")}
+        disabled={state === "loading"}
+        className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded border border-red-500/30 text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50"
+        title={
+          isComp
+            ? "Remove comp Pro — user immediately goes back to Free"
+            : "Cancel this Stripe subscription immediately"
+        }
+      >
+        <X size={12} />
+        {isComp ? "Remove Comp" : "Cancel Now"}
+      </button>
+
+      {isPaidPro && !willCancelAtPeriodEnd && (
+        <button
+          type="button"
+          onClick={() => cancel("at_period_end")}
+          disabled={state === "loading"}
+          className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded border border-amber-500/30 text-amber-400 hover:bg-amber-500/10 transition-colors disabled:opacity-50"
+          title="Let the user keep Pro until the current billing period ends"
+        >
+          <Clock size={12} />
+          Cancel at Period End
+        </button>
+      )}
+
+      {state === "loading" && (
+        <span className="text-xs text-muted">Working…</span>
+      )}
+      {errorMsg && (
+        <span className="text-xs text-red-400 inline-flex items-center gap-1">
+          <AlertTriangle size={12} />
+          {errorMsg}
+        </span>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Adds plan-switch controls to \`/admin/subscribers/[userId]\` so an admin can grant, swap, or remove a user's Pro subscription without leaving the app. Built for the case where you want to take your own paid account back to Free to test the upgrade flow, but also useful for handling refund / cancel requests.

## What gets shown

Three buttons surface depending on the user's current plan state:

| Current state | Visible buttons |
|---|---|
| Free / no row | **Grant Comp Pro** |
| Admin-granted comp | **Remove Comp** |
| Paid Pro (real Stripe sub, active) | **Cancel Now** + **Cancel at Period End** |
| Paid Pro already scheduled to cancel at period end | **Cancel Now** only |

All destructive actions confirm before sending. Errors display inline.

## How it works under the hood

- **Grant Comp Pro** reuses the existing \`/api/admin/comp-account\` route (action=grant, duration=indefinite).
- **Remove Comp** and both cancellation paths hit a new \`/api/admin/cancel-subscription\` endpoint, which:
  - For comp accounts (granted_by_admin=true): direct DB flip, no Stripe call.
  - For real Stripe subs, mode=\`immediate\`: \`stripe.subscriptions.cancel(...)\` + immediate local mirror update.
  - For real Stripe subs, mode=\`at_period_end\`: \`stripe.subscriptions.update({ cancel_at_period_end: true })\` + local mirror.
- The webhook handler still owns final reconciliation when Stripe sends \`customer.subscription.deleted\`/\`updated\` — the local mirror update is just so the admin UI doesn't lag a few seconds behind.

## Follows project conventions

- \`requireSameOrigin\` (PR #21 pattern)
- Rate-limited (20/min/IP)
- \`isAdmin\` gate
- \`logAdminAction\` + \`logActivity\` write to audit + user activity logs

## Test plan

- [ ] Visit \`/admin/subscribers/<your-userid>\` after merge
- [ ] If you're on Pro from the live smoke test: click **Cancel Now** → confirm → page refreshes, status flips to Cancelled
- [ ] Confirm your Stripe Dashboard shows the subscription cancelled
- [ ] On the same user: click **Grant Comp Pro** → status flips to Comp
- [ ] On a comp user: click **Remove Comp** → status flips back to Free
- [ ] Try \`Cancel at Period End\` on a paid sub → row shows \`cancel_at_period_end=true\` + the "(cancels at period end)" note that's already in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)