### PR TITLE
Await fire-and-forget email/trigger calls in Stripe webhook

### DIFF
--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -143,13 +143,18 @@ export async function POST(req: NextRequest) {
             await syncPaymentStatus(effectiveReleaseId);
           }
 
-          // Fire workflow triggers (fire-and-forget)
+          // Fire workflow triggers. Awaited so Vercel doesn't kill
+          // the in-flight call when the handler returns 200 to Stripe.
           if (quoteUserId && effectiveReleaseId) {
-            fireTrigger("payment_received", {
-              userId: quoteUserId,
-              releaseId: effectiveReleaseId,
-              quoteId,
-            }).catch(console.error);
+            try {
+              await fireTrigger("payment_received", {
+                userId: quoteUserId,
+                releaseId: effectiveReleaseId,
+                quoteId,
+              });
+            } catch (err) {
+              console.error("[stripe/webhook] fireTrigger payment_received failed:", err);
+            }
           }
 
           // Send payment confirmation email to engineer
@@ -249,8 +254,11 @@ export async function POST(req: NextRequest) {
           console.log("[stripe/webhook] subscription activated for user:", userId);
           logActivity(userId, "subscription_started", { plan: "pro" });
 
-          // Send subscription confirmed email (fire-and-forget)
-          sendSubscriptionEmail(supabase, userId, "subscription_confirmed");
+          // Send subscription confirmed email. Awaited so Vercel
+          // doesn't terminate the Resend call after the handler
+          // returns 200 to Stripe — that's why this email was
+          // silently missing in production.
+          await sendSubscriptionEmail(supabase, userId, "subscription_confirmed");
         }
         break;
       }
@@ -372,8 +380,10 @@ export async function POST(req: NextRequest) {
               stripe_customer_id: customerId,
             });
 
-            // Send subscription cancelled email (fire-and-forget)
-            sendSubscriptionEmail(supabase, existingSub.user_id, "subscription_cancelled");
+            // Send subscription cancelled email. Awaited so the
+            // Resend call completes before Vercel terminates the
+            // function (same reason as the confirmation email above).
+            await sendSubscriptionEmail(supabase, existingSub.user_id, "subscription_cancelled");
           }
         }
         break;
@@ -396,8 +406,9 @@ export async function POST(req: NextRequest) {
 
         if (!sub?.user_id || sub.granted_by_admin) break;
 
-        // Send payment reminder email (fire-and-forget)
-        sendPaymentEmail(supabase, sub.user_id, "payment_reminder");
+        // Send payment reminder email. Awaited so the Resend call
+        // completes before Vercel terminates the function.
+        await sendPaymentEmail(supabase, sub.user_id, "payment_reminder");
         break;
       }
 


### PR DESCRIPTION
## Summary

The Stripe webhook was kicking off four side effects without awaiting them. On Vercel Fluid Compute, the runtime can terminate in-flight promises after the function returns 200 to Stripe — which is exactly what was happening for the live subscription welcome email.

## What was missing

Mike subscribed live on 2026-06-20. Diagnostics:

- ✅ Subscription row in DB: \`plan=pro\`, \`status=active\`, \`stripe_subscription_id=sub_1TkVCPK…\`, populated at 20:09:08 — webhook ran correctly through the upsert
- ✅ Resend domain verified (SPF + DKIM + DMARC all green in DNS)
- ✅ \`RESEND_API_KEY\` in Vercel since May 1
- ❌ **Resend API key shows \`Total uses: 0\`** — Resend never received the call

The handler hit \`sendSubscriptionEmail(...)\` on line 253 *without await*, returned 200 to Stripe, and Vercel killed the function before the email service finished its work.

## The fix

Adds \`await\` to four call sites:

| Line | Call | Effect |
|---|---|---|
| 148 | \`fireTrigger("payment_received", ...)\` | Quote-payment workflow triggers fire reliably |
| 253 | \`sendSubscriptionEmail("subscription_confirmed")\` | **The bug** — welcome email after subscription |
| 376 | \`sendSubscriptionEmail("subscription_cancelled")\` | Cancellation confirmation email |
| 400 | \`sendPaymentEmail("payment_reminder")\` | Failed-payment retry reminder |

The \`fireTrigger\` callsite gets a try/catch wrapper since it didn't have one internally — a failing trigger shouldn't fail the whole webhook (Stripe would retry forever). The three email helpers already wrap their own logic in try/catch, so they just need the await.

Webhook response time goes up by ~200–500ms per call — well under Stripe's 30s timeout, but for two events that both run an email (the rare \`customer.subscription.created\` → upsert → email path) the cumulative is still <1s.

## Test plan

After Vercel deploys:

1. From admin: \`/admin/subscribers/<your-userId>\` → **Cancel Now** → flips Mike back to Free
2. Refund the live \$14 in Stripe (Payments → that charge → Refund)
3. Re-subscribe through live site with a real card
4. Within 30s, check:
   - Resend Dashboard → Emails: should show **1 send** for category \`subscription_confirmed\`
   - Your inbox: welcome email arrived
   - \`email_log\` table: row with \`status='sent'\`
5. Cancel again from admin, refund again, done

## Follow-up worth doing later

The same pattern (\`fireTrigger\` / \`sendTransactionalEmail\` called without await) likely exists elsewhere in the codebase — \`/api/portal/comment\`, server actions in \`src/actions/quotes.ts\`, etc. Worth a sweep. Not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)