### PR TITLE
Add Terms of Service page + wire footer link

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -38,11 +38,11 @@ export default async function PrivacyPage() {
 
           <Section title="1. About This Policy">
             <p>
-              This Privacy Policy explains how <strong>Tiix</strong>{" "}
-              (&quot;Mix Architect,&quot; &quot;we,&quot; &quot;us,&quot; or
-              &quot;our&quot;) collects, uses, shares, and protects information
-              when you use mixarchitect.com, the Mix Architect web application,
-              and related services (the &quot;Services&quot;).
+              This Privacy Policy explains how{" "}
+              <strong>Mix Architect</strong> (&quot;we,&quot; &quot;us,&quot;
+              or &quot;our&quot;) collects, uses, shares, and protects
+              information when you use mixarchitect.com, the Mix Architect web
+              application, and related services (the &quot;Services&quot;).
             </p>
             <p>
               By using the Services, you agree to the practices described here
@@ -442,8 +442,8 @@ export default async function PrivacyPage() {
             </p>
             <p>
               The data controller for the purposes of EU/UK data-protection law
-              is Tiix, located in Los Angeles County, California, United
-              States.
+              is Mix Architect, located in Los Angeles County, California,
+              United States.
             </p>
           </Section>
         </article>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,513 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { LandingNav } from "@/components/landing/nav";
+import { LandingFooter } from "@/components/landing/footer";
+import { getLocale, getMessages } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Mix Architect",
+  description:
+    "How Mix Architect collects, uses, shares, and protects your information.",
+  robots: { index: true, follow: true },
+};
+
+// Update this whenever the substance of this policy changes.
+const EFFECTIVE_DATE = "June 20, 2026";
+
+export default async function PrivacyPage() {
+  const [locale, messages] = await Promise.all([getLocale(), getMessages()]);
+
+  return (
+    <NextIntlClientProvider
+      locale={locale}
+      messages={{ landing: (messages as Record<string, unknown>).landing }}
+    >
+      <main className="min-h-screen bg-[#0A0A0A] text-white/85">
+        <LandingNav />
+
+        <article className="mx-auto max-w-3xl px-6 py-16 md:py-24">
+          <header className="mb-12">
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-3">
+              Privacy Policy
+            </h1>
+            <p className="text-sm text-white/50">
+              Effective Date: {EFFECTIVE_DATE}
+            </p>
+          </header>
+
+          <Section title="1. About This Policy">
+            <p>
+              This Privacy Policy explains how <strong>Tiix</strong>{" "}
+              (&quot;Mix Architect,&quot; &quot;we,&quot; &quot;us,&quot; or
+              &quot;our&quot;) collects, uses, shares, and protects information
+              when you use mixarchitect.com, the Mix Architect web application,
+              and related services (the &quot;Services&quot;).
+            </p>
+            <p>
+              By using the Services, you agree to the practices described here
+              and to our{" "}
+              <Link href="/terms" className="text-[#14B8A6] hover:underline">
+                Terms of Service
+              </Link>
+              . If you do not agree, please do not use the Services.
+            </p>
+          </Section>
+
+          <Section title="2. Information We Collect">
+            <SubSection title="2.1 Account Information">
+              <p>
+                When you create an account, we collect your email address and
+                authentication credentials (passwords are stored as salted
+                hashes by our authentication provider; we never see your
+                plaintext password). You may optionally provide a display name,
+                profile photo, and persona type.
+              </p>
+            </SubSection>
+
+            <SubSection title="2.2 Content You Upload or Create">
+              <p>
+                We store the content you create through the Services, including
+                audio files, cover art, project briefs, mix references,
+                timestamped comments, version histories, distribution metadata,
+                and any other material you upload. This content is private to
+                you and the collaborators or clients you explicitly share it
+                with.
+              </p>
+            </SubSection>
+
+            <SubSection title="2.3 Payment Information">
+              <p>
+                Payments are processed by <strong>Stripe, Inc.</strong> Stripe
+                collects and stores your full payment card details — we never
+                see your card number, expiration date, or CVC. We do store and
+                retain identifiers we receive from Stripe, such as your Stripe
+                customer ID, subscription ID, and payment status, which we use
+                to manage your subscription and process refunds.
+              </p>
+              <p>
+                For engineers who collect payments from clients via Stripe
+                Connect, we additionally store your connected Stripe account
+                ID, account status, and payout settings as reported by Stripe.
+              </p>
+            </SubSection>
+
+            <SubSection title="2.4 Communications With Us">
+              <p>
+                If you contact support, submit a feature request, or fill out a
+                form, we keep a record of that correspondence and any
+                information you provide.
+              </p>
+            </SubSection>
+
+            <SubSection title="2.5 Automatic Usage and Device Data">
+              <p>When you use the Services, we automatically collect:</p>
+              <List
+                items={[
+                  "IP address, used for security, rate limiting, and approximate geolocation;",
+                  "Browser type, operating system, device type, and screen size;",
+                  "Pages visited, features used, and approximate session timing;",
+                  "Performance metrics (page load timing, waveform render speed, audio buffering events) used to debug and improve the product;",
+                  "Error reports including stack traces and the URL where an error occurred, sent to our error-monitoring provider.",
+                ]}
+              />
+            </SubSection>
+
+            <SubSection title="2.6 Cookies and Similar Technology">
+              <p>
+                We use cookies and similar technologies for the following
+                categories of purposes:
+              </p>
+              <List
+                items={[
+                  "Strictly necessary: authentication session cookies (set by Supabase) to keep you logged in. Without these the Services cannot function.",
+                  "Analytics: cookies set by Google Analytics 4 and OpenPanel to measure aggregate usage and improve the product.",
+                  "Payment processing: cookies set by Stripe Checkout during the checkout flow.",
+                ]}
+              />
+              <p>
+                See Section 9 below for more detail on cookies and how to
+                control them.
+              </p>
+            </SubSection>
+          </Section>
+
+          <Section title="3. How We Use Your Information">
+            <p>We use the information we collect to:</p>
+            <List
+              items={[
+                "Provide, maintain, and operate the Services for you;",
+                "Process subscription payments and route engineer-client payments through Stripe Connect;",
+                "Send transactional emails (welcome messages, payment receipts, comment notifications, password resets);",
+                "Send product-related communications you have not opted out of (changelogs, important announcements);",
+                "Detect, investigate, and prevent abuse, fraud, security issues, and violations of our Terms;",
+                "Debug errors and improve performance using stack traces and performance metrics;",
+                "Understand aggregate usage patterns to inform product decisions;",
+                "Comply with legal obligations and respond to lawful requests from regulators and law enforcement;",
+                "Enforce our Terms and protect our rights and the rights of users.",
+              ]}
+            />
+            <p>
+              We do <strong>not</strong> sell your personal information to
+              third parties for advertising, and we do not train artificial
+              intelligence models on your User Content.
+            </p>
+          </Section>
+
+          <Section title="4. How We Share Information">
+            <p>
+              We share information only as described in this section. We never
+              sell personal information.
+            </p>
+
+            <SubSection title="4.1 Service Providers (Sub-Processors)">
+              <p>
+                We rely on third-party service providers to operate the
+                Services. They process information on our behalf, subject to
+                contracts that require them to protect your data:
+              </p>
+              <List
+                items={[
+                  "Supabase — database, authentication, and file storage. Data is hosted in the United States.",
+                  "Vercel — hosting and content delivery for the web application.",
+                  "Stripe — payment processing for subscriptions and Stripe Connect engineer payouts.",
+                  "Resend — transactional email delivery.",
+                  "Sentry — error monitoring (captures stack traces, browser context, and the user ID associated with an error).",
+                  "Google Analytics 4 — web traffic analytics.",
+                  "OpenPanel — product usage analytics.",
+                  "Anthropic — AI summarization of admin analytics dashboards (used internally; not applied to your User Content).",
+                ]}
+              />
+              <p>
+                Where these providers offer their own privacy policies, those
+                terms also apply to the portions of your data they handle.
+              </p>
+            </SubSection>
+
+            <SubSection title="4.2 Collaborators and Portal Visitors">
+              <p>
+                When you invite a release collaborator or share a project
+                through the client portal, the people you share with can see
+                the content you explicitly include in that share (audio
+                versions, briefs, comments, etc.). You control who you share
+                with.
+              </p>
+            </SubSection>
+
+            <SubSection title="4.3 Engineer-Client Payments">
+              <p>
+                When a client pays an engineer through the Stripe Connect flow,
+                Stripe shares limited transaction information with both the
+                engineer and the client as needed to complete the payment, send
+                receipts, and handle disputes.
+              </p>
+            </SubSection>
+
+            <SubSection title="4.4 Legal Process">
+              <p>
+                We may disclose information if required to do so by law or
+                valid legal process (such as a subpoena or court order), or if
+                we believe in good faith that disclosure is necessary to
+                investigate fraud, protect the safety of any person, or enforce
+                our Terms.
+              </p>
+            </SubSection>
+
+            <SubSection title="4.5 Business Transfers">
+              <p>
+                If we are involved in a merger, acquisition, financing, or sale
+                of business assets, your information may be transferred as part
+                of that transaction. We will provide notice (e.g., via email or
+                in-app) before any material change in the controller of your
+                personal information.
+              </p>
+            </SubSection>
+          </Section>
+
+          <Section title="5. Portal Visitors (Anonymous Clients)">
+            <p>
+              The client delivery portal is designed so that the clients of
+              engineers using the Services can review tracks without creating
+              an account.
+            </p>
+            <p>For portal visitors specifically:</p>
+            <List
+              items={[
+                "We collect the name you provide when you leave a comment or approve a track. If you don't provide a name, your comment is labeled \"Client\".",
+                "We collect your IP address for rate limiting and abuse detection.",
+                "We do not require an email address from portal visitors.",
+                "We store a small opaque token in your browser's local storage so that you can edit or delete your own comments later. Clearing your browser data removes this token.",
+              ]}
+            />
+            <p>
+              Portal comments are visible to the engineer (and any release
+              collaborators) but not to other portal visitors of unrelated
+              releases.
+            </p>
+          </Section>
+
+          <Section title="6. Your Rights and Choices">
+            <SubSection title="6.1 General">
+              <p>
+                You can access and edit most of your information directly in
+                your account settings. You can also export your data, change
+                your email preferences, and close your account from there.
+              </p>
+            </SubSection>
+
+            <SubSection title="6.2 California Residents (CCPA / CPRA)">
+              <p>
+                If you are a California resident, you have specific rights
+                regarding your personal information:
+              </p>
+              <List
+                items={[
+                  "The right to know what personal information we collect, use, share, or sell about you;",
+                  "The right to delete personal information we have collected from you, subject to legal exceptions;",
+                  "The right to correct inaccurate personal information;",
+                  "The right to opt out of the sale or sharing of personal information — we do not sell personal information, so this right is automatically respected;",
+                  "The right to limit the use and disclosure of sensitive personal information;",
+                  "The right not to be discriminated against for exercising any of these rights.",
+                ]}
+              />
+              <p>
+                To exercise any of these rights, email{" "}
+                <Anchor href="mailto:legal@mixarchitect.com">
+                  legal@mixarchitect.com
+                </Anchor>
+                . We will verify your request by asking you to confirm
+                ownership of the account email address. Authorized agents may
+                submit requests on your behalf with proof of authorization.
+              </p>
+            </SubSection>
+
+            <SubSection title="6.3 EU, UK, and Other Jurisdictions">
+              <p>
+                If you are in the European Economic Area, the United Kingdom,
+                or another jurisdiction with comprehensive data-protection
+                laws, you may have rights including access, correction,
+                deletion, restriction of processing, data portability, and
+                objection to processing.
+              </p>
+              <p>
+                To exercise these rights, email{" "}
+                <Anchor href="mailto:legal@mixarchitect.com">
+                  legal@mixarchitect.com
+                </Anchor>
+                . You also have the right to lodge a complaint with the
+                supervisory authority in your country.
+              </p>
+            </SubSection>
+
+            <SubSection title="6.4 How We Respond to Requests">
+              <p>
+                We aim to respond to verified requests within 30 days. Where
+                allowed by law, we may charge a reasonable fee or refuse to act
+                on requests that are manifestly unfounded, excessive, or
+                repetitive.
+              </p>
+            </SubSection>
+          </Section>
+
+          <Section title="7. Email Communications and Unsubscribing">
+            <p>
+              We send two categories of email through Resend:
+            </p>
+            <List
+              items={[
+                "Transactional emails (subscription confirmation, password resets, payment receipts, comment notifications, security alerts). You cannot opt out of essential transactional emails while your account is active because they are necessary to operate the Services.",
+                "Product communications (changelogs, important product news). You can disable these in your account email preferences. Each marketing-style email includes an unsubscribe link.",
+              ]}
+            />
+          </Section>
+
+          <Section title="8. Data Security">
+            <p>
+              We take security seriously and use reasonable administrative,
+              technical, and physical safeguards to protect your information.
+              These include:
+            </p>
+            <List
+              items={[
+                "HTTPS encryption in transit for all traffic between your browser and our Services;",
+                "Encryption at rest for database storage (provided by Supabase) and audio file storage;",
+                "Row-Level Security (RLS) policies that prevent users from accessing each other's data at the database level;",
+                "Signed, expiring URLs for private audio file access;",
+                "Rate limiting on sensitive endpoints and webhook signature verification on incoming payment events;",
+                "Regular review of our access controls and dependency vulnerabilities.",
+              ]}
+            />
+            <p>
+              No method of transmission or storage is 100% secure. While we
+              work hard to protect your data, we cannot guarantee absolute
+              security.
+            </p>
+          </Section>
+
+          <Section title="9. Cookies and Tracking Detail">
+            <p>
+              You can configure your browser to block cookies, but doing so may
+              break parts of the Services that depend on the authentication
+              cookie (you will not be able to stay logged in).
+            </p>
+            <p>Specific tools we use:</p>
+            <List
+              items={[
+                "Authentication cookie (set by Supabase) — strictly necessary; allows you to remain logged in.",
+                "Google Analytics 4 — measures aggregate page views, sessions, and conversion events. You can opt out using Google's browser opt-out plugin (https://tools.google.com/dlpage/gaoptout).",
+                "OpenPanel — measures product engagement and feature usage with first-party cookies (proxied through our domain). You can opt out by enabling Do Not Track in your browser; we honor that signal where applicable.",
+                "Stripe — sets cookies during the checkout flow to support fraud prevention. See Stripe's cookie policy at https://stripe.com/cookies-policy/legal.",
+              ]}
+            />
+          </Section>
+
+          <Section title="10. Data Retention">
+            <p>
+              We retain personal information only as long as we need it for the
+              purposes described in this policy.
+            </p>
+            <List
+              items={[
+                "Account information: while your account is active, plus up to 30 days after closure for support and dispute resolution.",
+                "User Content (audio files, projects, comments, etc.): deleted within a reasonable period after you delete it or close your account, subject to backup retention windows.",
+                "Payment records and subscription history: retained as required by financial-record-keeping laws (typically 7 years).",
+                "Server logs and error reports: typically retained for 90 days.",
+                "Email logs: retained for 90 days for deliverability troubleshooting.",
+                "Backups: full backups may be retained longer for disaster recovery and are deleted on a rolling basis.",
+              ]}
+            />
+          </Section>
+
+          <Section title="11. International Data Transfers">
+            <p>
+              Mix Architect is operated from the United States, and our primary
+              service providers (Supabase, Vercel, Stripe) process data
+              primarily in the United States. If you access the Services from
+              outside the United States, your information will be transferred
+              to, and processed in, the United States and other countries that
+              may have different data-protection laws than your home country.
+            </p>
+            <p>
+              Where required, we rely on lawful transfer mechanisms (such as
+              Standard Contractual Clauses) to provide adequate protection for
+              your personal information.
+            </p>
+          </Section>
+
+          <Section title="12. Children&apos;s Privacy">
+            <p>
+              The Services are not directed to children under the age of 13
+              (or 16 in jurisdictions where that age applies), and we do not
+              knowingly collect personal information from them. If you believe
+              we have collected information from a child, please contact{" "}
+              <Anchor href="mailto:legal@mixarchitect.com">
+                legal@mixarchitect.com
+              </Anchor>{" "}
+              and we will delete it.
+            </p>
+          </Section>
+
+          <Section title="13. Do Not Track">
+            <p>
+              Our Services do not currently respond to all browser &quot;Do Not
+              Track&quot; signals because there is no industry consensus on
+              what they mean. We disable analytics cookies for users in
+              browsers that send a clear Do Not Track signal where technically
+              feasible.
+            </p>
+          </Section>
+
+          <Section title="14. Changes to This Policy">
+            <p>
+              We may update this Privacy Policy from time to time. If we make
+              material changes that affect how we use your personal
+              information, we will provide notice at least 14 days before the
+              changes take effect by email or in-app notification.
+            </p>
+            <p>
+              We will update the &quot;Effective Date&quot; at the top of this
+              page when changes are made. Your continued use of the Services
+              after the effective date constitutes acceptance of the updated
+              policy.
+            </p>
+          </Section>
+
+          <Section title="15. Contact Us">
+            <p>
+              Questions about this Privacy Policy or our data practices? Email{" "}
+              <Anchor href="mailto:legal@mixarchitect.com">
+                legal@mixarchitect.com
+              </Anchor>
+              .
+            </p>
+            <p>
+              The data controller for the purposes of EU/UK data-protection law
+              is Tiix, located in Los Angeles County, California, United
+              States.
+            </p>
+          </Section>
+        </article>
+
+        <LandingFooter />
+      </main>
+    </NextIntlClientProvider>
+  );
+}
+
+/* ── Local components ─────────────────────────────────────── */
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl md:text-2xl font-semibold text-white mb-4">
+        {title}
+      </h2>
+      <div className="space-y-4 leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+function SubSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-base font-semibold text-white/90 mt-4">{title}</h3>
+      <div className="space-y-3">{children}</div>
+    </div>
+  );
+}
+
+function List({ items }: { items: string[] }) {
+  return (
+    <ul className="list-disc pl-6 space-y-1.5 marker:text-white/40">
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function Anchor({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a href={href} className="text-[#14B8A6] hover:underline">
+      {children}
+    </a>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,571 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { LandingNav } from "@/components/landing/nav";
+import { LandingFooter } from "@/components/landing/footer";
+import { getLocale, getMessages } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+
+export const metadata: Metadata = {
+  title: "Terms of Service | Mix Architect",
+  description:
+    "The terms and conditions that govern your use of Mix Architect.",
+  robots: { index: true, follow: true },
+};
+
+// Update this whenever the substance of these Terms changes.
+const EFFECTIVE_DATE = "June 20, 2026";
+
+export default async function TermsPage() {
+  const [locale, messages] = await Promise.all([getLocale(), getMessages()]);
+
+  return (
+    <NextIntlClientProvider
+      locale={locale}
+      messages={{ landing: (messages as Record<string, unknown>).landing }}
+    >
+      <main className="min-h-screen bg-[#0A0A0A] text-white/85">
+        <LandingNav />
+
+        <article className="mx-auto max-w-3xl px-6 py-16 md:py-24">
+          <header className="mb-12">
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-3">
+              Terms of Service
+            </h1>
+            <p className="text-sm text-white/50">
+              Effective Date: {EFFECTIVE_DATE}
+            </p>
+          </header>
+
+          <Section title="1. Agreement to These Terms">
+            <p>
+              These Terms of Service (the &quot;Terms&quot;) are a legal
+              agreement between you and{" "}
+              <strong>[LEGAL ENTITY NAME]</strong> (&quot;Mix Architect,&quot;
+              &quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) governing your
+              access to and use of mixarchitect.com, the Mix Architect web
+              application, and any related services we offer (together, the
+              &quot;Services&quot;).
+            </p>
+            <p>
+              By creating an account, accessing, or using the Services, you
+              confirm that you have read, understood, and agree to be bound by
+              these Terms and our{" "}
+              <Link href="/privacy" className="text-[#14B8A6] hover:underline">
+                Privacy Policy
+              </Link>
+              . If you do not agree, do not use the Services.
+            </p>
+          </Section>
+
+          <Section title="2. Description of the Service">
+            <p>
+              Mix Architect is a software platform that helps music engineers,
+              mix engineers, producers, and recording artists plan releases,
+              build mix briefs, review audio with timestamped comments, deliver
+              tracks to clients, and bill for project work. Features may
+              include:
+            </p>
+            <List
+              items={[
+                "Release planning, timelines, and project organization",
+                "Audio file upload, version tracking, and waveform-based review",
+                "Comment threads tied to specific timestamps in a track",
+                "A shareable client portal for collecting feedback and approvals",
+                "Loudness and audio specification analysis",
+                "Format conversion (e.g., WAV to MP3, AAC, FLAC)",
+                "Subscription billing through Stripe",
+                "Engineer payment collection via Stripe Connect",
+                "Distribution tracking across streaming platforms",
+              ]}
+            />
+            <p>
+              We may add, modify, or remove features at any time. For material
+              changes that affect paid-tier functionality, we will give
+              reasonable advance notice.
+            </p>
+          </Section>
+
+          <Section title="3. Eligibility and Your Account">
+            <p>
+              You must be at least 18 years old (or the legal age of majority in
+              your jurisdiction) and able to enter into a binding contract to
+              use the Services. By creating an account, you represent that you
+              meet these requirements.
+            </p>
+            <p>You are responsible for:</p>
+            <List
+              items={[
+                "Providing accurate registration information and keeping it current",
+                "Keeping your login credentials secure",
+                "All activity that occurs under your account",
+                "Promptly notifying us of any unauthorized use of your account",
+              ]}
+            />
+            <p>
+              We may suspend or terminate accounts that violate these Terms,
+              applicable law, or that show signs of abuse, fraud, or misuse.
+            </p>
+          </Section>
+
+          <Section title="4. Subscriptions and Billing">
+            <SubSection title="4.1 Plans">
+              <p>
+                We offer a Free plan and a paid Pro plan, available on monthly
+                or annual billing. Current pricing and features are listed at{" "}
+                <Link href="/" className="text-[#14B8A6] hover:underline">
+                  mixarchitect.com
+                </Link>{" "}
+                and may change. We will give existing paid subscribers
+                reasonable notice before any price increase.
+              </p>
+            </SubSection>
+            <SubSection title="4.2 Billing">
+              <p>
+                Paid subscriptions are billed in advance via Stripe on a
+                recurring basis (monthly or annually) until canceled. By
+                providing a payment method, you authorize us (through Stripe) to
+                charge it on each renewal date for the then-current
+                subscription fee plus any applicable taxes.
+              </p>
+            </SubSection>
+            <SubSection title="4.3 Cancellation">
+              <p>
+                You may cancel your paid subscription at any time from your
+                account settings. Cancellation takes effect at the end of the
+                current billing period; you retain paid features until then.
+              </p>
+            </SubSection>
+            <SubSection title="4.4 Refunds">
+              <p>
+                We do not offer refunds for partial billing periods, unused
+                features, or unused time. If you believe you were charged in
+                error, contact us at{" "}
+                <Anchor href="mailto:[CONTACT EMAIL]">[CONTACT EMAIL]</Anchor>{" "}
+                within 30 days of the charge and we will review the request in
+                good faith.
+              </p>
+            </SubSection>
+            <SubSection title="4.5 Failed Payments">
+              <p>
+                If a payment fails, we will retry per Stripe&apos;s standard
+                cadence. After repeated failures, we may downgrade your account
+                to the Free plan, which removes access to paid features.
+              </p>
+            </SubSection>
+            <SubSection title="4.6 Taxes">
+              <p>
+                Stated prices exclude applicable taxes (sales tax, VAT, GST,
+                etc.). Where required, we will add taxes at checkout based on
+                your billing location.
+              </p>
+            </SubSection>
+          </Section>
+
+          <Section title="5. Engineer Payment Collection (Stripe Connect)">
+            <p>
+              Mix Architect provides tools that engineers can use to invoice
+              clients and receive payments through Stripe Connect.
+            </p>
+            <List
+              items={[
+                "Engineers connect their own Stripe accounts to receive client payments.",
+                "Clients pay through the platform; funds are routed by Stripe to the engineer's connected account, less Stripe's processing fees and any platform fee disclosed before the engineer accepts the engagement.",
+                "The professional engagement (scope, deliverables, timelines, refund terms) is solely between the engineer and the client. Mix Architect is a software platform; we are not a party to any engagement contract and do not provide engineering services.",
+                "Payment disputes, chargebacks, refunds, and tax obligations are governed by Stripe's Connect terms and the engineer-client agreement. We may, at our discretion, assist with mediation but are not obligated to do so.",
+              ]}
+            />
+          </Section>
+
+          <Section title="6. Your Content">
+            <SubSection title="6.1 What &quot;User Content&quot; Means">
+              <p>
+                &quot;User Content&quot; includes any audio files, project
+                briefs, mix references, comments, cover art, metadata, and other
+                material you upload, create, or share through the Services.
+              </p>
+            </SubSection>
+            <SubSection title="6.2 You Own Your Content">
+              <p>
+                You retain all ownership rights in your User Content. We claim
+                no ownership over the music, masters, mixes, or other creative
+                work you bring to the platform.
+              </p>
+            </SubSection>
+            <SubSection title="6.3 License You Grant to Us">
+              <p>
+                To operate the Services for you, you grant Mix Architect a
+                worldwide, non-exclusive, royalty-free, transferable license to
+                host, store, copy, process, transcode, generate waveform
+                visualizations from, analyze loudness of, and display your User
+                Content. This license is limited to providing the Services to
+                you and to anyone you explicitly authorize (e.g., release
+                members, portal recipients). It terminates when you delete the
+                content or close your account, except as necessary to comply
+                with legal obligations or resolve disputes.
+              </p>
+            </SubSection>
+            <SubSection title="6.4 Your Representations About Content">
+              <p>
+                By uploading or sharing any content through the Services, you
+                represent and warrant that:
+              </p>
+              <List
+                items={[
+                  "You own it OR have obtained all licenses, rights, consents, and permissions necessary to upload, share, and use it through the Services for the purposes contemplated;",
+                  "Your content does not infringe any third-party rights, including copyright, trademark, publicity, or privacy rights;",
+                  "Your content does not contain illegal, defamatory, obscene, or otherwise unlawful material;",
+                  "Any individuals depicted in cover art or referenced in metadata have given consent to that use.",
+                ]}
+              />
+            </SubSection>
+            <SubSection title="6.5 Backups Are Your Responsibility">
+              <p>
+                While we use reasonable measures to protect your content
+                against loss, the Services are <strong>not</strong> intended as
+                a primary backup or archival solution for masters or other
+                irreplaceable files. You should maintain independent backups of
+                anything important.
+              </p>
+            </SubSection>
+          </Section>
+
+          <Section title="7. Acceptable Use">
+            <p>You agree not to:</p>
+            <List
+              items={[
+                "Upload or share content you don't have the rights to;",
+                "Use the Services for any unlawful, fraudulent, or abusive purpose;",
+                "Send spam, unsolicited messages, or harassment through the client portal or any other feature;",
+                "Attempt to gain unauthorized access to other accounts, systems, or data;",
+                "Reverse engineer, decompile, disassemble, or scrape the Services;",
+                "Use the Services to develop, train, or improve a competing product or service;",
+                "Resell, sublicense, rent, or otherwise transfer access to your account;",
+                "Bypass usage limits, abuse rate limits, or interfere with the normal operation of the Services;",
+                "Upload malware, viruses, or any code intended to damage, disable, or impair the Services or any user.",
+              ]}
+            />
+            <p>
+              Violation of this section may result in immediate account
+              suspension or termination at our discretion.
+            </p>
+          </Section>
+
+          <Section title="8. Intellectual Property">
+            <SubSection title="8.1 Our Intellectual Property">
+              <p>
+                The Services — including all software, design, user
+                interfaces, documentation, branding, logos, and trademarks —
+                are owned by Mix Architect or our licensors and are protected
+                by copyright, trademark, and other intellectual property laws.
+                We grant you a limited, non-exclusive, non-transferable,
+                revocable license to use the Services for their intended
+                purpose, subject to these Terms.
+              </p>
+            </SubSection>
+            <SubSection title="8.2 Feedback">
+              <p>
+                If you send us feedback, suggestions, feature requests, or
+                ideas, you grant us a perpetual, irrevocable, worldwide,
+                royalty-free license to use them without obligation or
+                attribution.
+              </p>
+            </SubSection>
+          </Section>
+
+          <Section title="9. Copyright Complaints (DMCA)">
+            <p>
+              We respect intellectual property rights and respond to notices of
+              alleged copyright infringement under the U.S. Digital Millennium
+              Copyright Act (DMCA).
+            </p>
+            <p>
+              If you believe content on the Services infringes your copyright,
+              send a notice to our designated DMCA agent at{" "}
+              <Anchor href="mailto:[DMCA AGENT EMAIL]">
+                [DMCA AGENT EMAIL]
+              </Anchor>{" "}
+              containing:
+            </p>
+            <List
+              items={[
+                "A description of the copyrighted work claimed to be infringed;",
+                "The location of the allegedly infringing material on the Services (URL or specific identifier);",
+                "Your contact information (name, address, telephone number, email);",
+                "A statement that you have a good-faith belief that the use is not authorized by the copyright owner, its agent, or the law;",
+                "A statement, under penalty of perjury, that the information in the notice is accurate and that you are the copyright owner or authorized to act on their behalf;",
+                "Your physical or electronic signature.",
+              ]}
+            />
+            <p>
+              We may remove or disable access to material we believe in good
+              faith to be infringing and may terminate the accounts of repeat
+              infringers.
+            </p>
+          </Section>
+
+          <Section title="10. Third-Party Services">
+            <p>
+              The Services rely on third-party providers, including but not
+              limited to Supabase (database and storage), Vercel (hosting),
+              Stripe (payments and Stripe Connect), Resend (email), and Sentry
+              (error monitoring). Your use of these providers&apos; portions of
+              the Services is also subject to their respective terms and
+              privacy policies. We are not responsible for the acts or
+              omissions of third-party providers beyond our reasonable
+              control.
+            </p>
+          </Section>
+
+          <Section title="11. Privacy">
+            <p>
+              Our{" "}
+              <Link href="/privacy" className="text-[#14B8A6] hover:underline">
+                Privacy Policy
+              </Link>{" "}
+              describes what data we collect, how we use it, and your rights
+              with respect to it. By using the Services, you also agree to the
+              Privacy Policy.
+            </p>
+          </Section>
+
+          <Section title="12. Disclaimers">
+            <p className="uppercase tracking-wide text-sm">
+              THE SERVICES ARE PROVIDED &quot;AS IS&quot; AND &quot;AS
+              AVAILABLE&quot; WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+              IMPLIED. TO THE FULLEST EXTENT PERMITTED BY LAW, MIX ARCHITECT
+              DISCLAIMS ALL WARRANTIES, INCLUDING WARRANTIES OF
+              MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+              NON-INFRINGEMENT, AND ANY WARRANTIES ARISING OUT OF COURSE OF
+              DEALING OR USAGE OF TRADE.
+            </p>
+            <p>We do not warrant that:</p>
+            <List
+              items={[
+                "The Services will be uninterrupted, error-free, or perfectly secure;",
+                "Stored content will be permanently retained or available without interruption;",
+                "Any specific commercial, creative, or financial result will be achieved;",
+                "Defects or errors will be corrected on any particular timeline.",
+              ]}
+            />
+            <p>
+              You use the Services at your own risk and are responsible for
+              evaluating their suitability for your purposes.
+            </p>
+          </Section>
+
+          <Section title="13. Limitation of Liability">
+            <p className="uppercase tracking-wide text-sm">
+              TO THE MAXIMUM EXTENT PERMITTED BY LAW, MIX ARCHITECT AND ITS
+              AFFILIATES, OFFICERS, EMPLOYEES, AGENTS, AND LICENSORS WILL NOT
+              BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL,
+              OR PUNITIVE DAMAGES, OR FOR ANY LOSS OF PROFITS, REVENUE, DATA,
+              GOODWILL, OR BUSINESS OPPORTUNITIES, EVEN IF WE HAVE BEEN
+              ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+            </p>
+            <p className="uppercase tracking-wide text-sm">
+              OUR TOTAL CUMULATIVE LIABILITY FOR ANY CLAIM ARISING OUT OF OR
+              RELATING TO THE SERVICES WILL NOT EXCEED THE GREATER OF (A) THE
+              AMOUNTS YOU PAID TO US IN THE TWELVE (12) MONTHS IMMEDIATELY
+              PRECEDING THE EVENT GIVING RISE TO THE CLAIM, OR (B) ONE HUNDRED
+              U.S. DOLLARS ($100).
+            </p>
+            <p>
+              These limitations apply regardless of the legal theory (contract,
+              tort, statute, or otherwise) and apply even if a limited remedy
+              fails of its essential purpose. Some jurisdictions do not allow
+              limitation of certain damages — in those jurisdictions, our
+              liability is limited to the maximum extent permitted by
+              applicable law.
+            </p>
+          </Section>
+
+          <Section title="14. Indemnification">
+            <p>
+              You agree to defend, indemnify, and hold harmless Mix Architect
+              and its affiliates, officers, employees, agents, and licensors
+              from any claims, demands, damages, losses, liabilities, costs, or
+              expenses (including reasonable attorneys&apos; fees) arising out
+              of or related to:
+            </p>
+            <List
+              items={[
+                "Your User Content;",
+                "Your use of the Services;",
+                "Your violation of these Terms;",
+                "Your violation of any third-party right, including any intellectual property or privacy right;",
+                "Any engagement, contract, or dispute between you and another user of the Services.",
+              ]}
+            />
+          </Section>
+
+          <Section title="15. Termination">
+            <p>
+              You may close your account at any time through your account
+              settings.
+            </p>
+            <p>
+              We may suspend or terminate your account if you violate these
+              Terms, fail to pay amounts due, abuse the Services, or as
+              otherwise reasonably necessary to protect the Services or other
+              users. Where practical, we will provide notice before
+              termination.
+            </p>
+            <p>Upon termination of your account:</p>
+            <List
+              items={[
+                "Your access to the Services ends.",
+                "Outstanding paid subscription fees are not refunded except as expressly stated in Section 4.4.",
+                "Your User Content may be deleted after a reasonable grace period.",
+                "Sections that by their nature should survive — including ownership of User Content, the license you granted in Section 6.3 for content already distributed to authorized collaborators, indemnification, limitation of liability, governing law, and these termination provisions — survive.",
+              ]}
+            />
+          </Section>
+
+          <Section title="16. Changes to These Terms">
+            <p>
+              We may update these Terms from time to time. For material changes
+              that affect your rights or obligations, we will provide notice at
+              least 14 days before the changes take effect, by email to the
+              address on your account or by an in-app notification.
+            </p>
+            <p>
+              Your continued use of the Services after the effective date
+              constitutes acceptance of the updated Terms. If you do not agree,
+              your remedy is to stop using the Services and close your account.
+            </p>
+          </Section>
+
+          <Section title="17. Governing Law and Disputes">
+            <p>
+              These Terms are governed by the laws of the State of{" "}
+              <strong>[STATE]</strong>, without regard to its conflict-of-law
+              principles. Any dispute arising out of or relating to these Terms
+              or the Services will be resolved exclusively in the state or
+              federal courts located in <strong>[COUNTY]</strong>,{" "}
+              <strong>[STATE]</strong>, and you consent to personal jurisdiction
+              and venue in those courts.
+            </p>
+            <p>
+              If you are a consumer located in the European Union, the United
+              Kingdom, or another jurisdiction with mandatory
+              consumer-protection laws, nothing in this section overrides those
+              laws.
+            </p>
+          </Section>
+
+          <Section title="18. General Provisions">
+            <SubSection title="18.1 Entire Agreement">
+              <p>
+                These Terms, together with the{" "}
+                <Link
+                  href="/privacy"
+                  className="text-[#14B8A6] hover:underline"
+                >
+                  Privacy Policy
+                </Link>{" "}
+                and any policies referenced in them, constitute the entire
+                agreement between you and Mix Architect regarding the Services
+                and supersede any prior agreements.
+              </p>
+            </SubSection>
+            <SubSection title="18.2 Severability">
+              <p>
+                If any provision is found unenforceable, the remaining
+                provisions remain in full force.
+              </p>
+            </SubSection>
+            <SubSection title="18.3 No Waiver">
+              <p>
+                Our failure to enforce any provision is not a waiver of our
+                right to enforce it later.
+              </p>
+            </SubSection>
+            <SubSection title="18.4 Assignment">
+              <p>
+                You may not assign or transfer these Terms or your account
+                without our prior written consent. We may assign these Terms in
+                connection with a merger, acquisition, or sale of substantially
+                all of our assets.
+              </p>
+            </SubSection>
+            <SubSection title="18.5 Notices">
+              <p>
+                We may send notices to you at the email address associated with
+                your account or through in-app notification. You should send
+                notices to us at{" "}
+                <Anchor href="mailto:[CONTACT EMAIL]">[CONTACT EMAIL]</Anchor>.
+              </p>
+            </SubSection>
+          </Section>
+
+          <Section title="19. Contact">
+            <p>
+              Questions about these Terms? Contact us at{" "}
+              <Anchor href="mailto:[CONTACT EMAIL]">[CONTACT EMAIL]</Anchor>.
+            </p>
+          </Section>
+        </article>
+
+        <LandingFooter />
+      </main>
+    </NextIntlClientProvider>
+  );
+}
+
+/* ── Local components ─────────────────────────────────────── */
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl md:text-2xl font-semibold text-white mb-4">
+        {title}
+      </h2>
+      <div className="space-y-4 leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+function SubSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-base font-semibold text-white/90 mt-4">{title}</h3>
+      <div className="space-y-3">{children}</div>
+    </div>
+  );
+}
+
+function List({ items }: { items: string[] }) {
+  return (
+    <ul className="list-disc pl-6 space-y-1.5 marker:text-white/40">
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function Anchor({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a href={href} className="text-[#14B8A6] hover:underline">
+      {children}
+    </a>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -40,11 +40,10 @@ export default async function TermsPage() {
             <p>
               These Terms of Service (the &quot;Terms&quot;) are a legal
               agreement between you and{" "}
-              <strong>Tiix</strong> (&quot;Mix Architect,&quot;
-              &quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) governing your
-              access to and use of mixarchitect.com, the Mix Architect web
-              application, and any related services we offer (together, the
-              &quot;Services&quot;).
+              <strong>Mix Architect</strong> (&quot;we,&quot; &quot;us,&quot;
+              or &quot;our&quot;) governing your access to and use of
+              mixarchitect.com, the Mix Architect web application, and any
+              related services we offer (together, the &quot;Services&quot;).
             </p>
             <p>
               By creating an account, accessing, or using the Services, you

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -40,7 +40,7 @@ export default async function TermsPage() {
             <p>
               These Terms of Service (the &quot;Terms&quot;) are a legal
               agreement between you and{" "}
-              <strong>[LEGAL ENTITY NAME]</strong> (&quot;Mix Architect,&quot;
+              <strong>Tiix</strong> (&quot;Mix Architect,&quot;
               &quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) governing your
               access to and use of mixarchitect.com, the Mix Architect web
               application, and any related services we offer (together, the
@@ -140,7 +140,7 @@ export default async function TermsPage() {
                 We do not offer refunds for partial billing periods, unused
                 features, or unused time. If you believe you were charged in
                 error, contact us at{" "}
-                <Anchor href="mailto:[CONTACT EMAIL]">[CONTACT EMAIL]</Anchor>{" "}
+                <Anchor href="mailto:legal@mixarchitect.com">legal@mixarchitect.com</Anchor>{" "}
                 within 30 days of the charge and we will review the request in
                 good faith.
               </p>
@@ -281,8 +281,8 @@ export default async function TermsPage() {
             <p>
               If you believe content on the Services infringes your copyright,
               send a notice to our designated DMCA agent at{" "}
-              <Anchor href="mailto:[DMCA AGENT EMAIL]">
-                [DMCA AGENT EMAIL]
+              <Anchor href="mailto:legal@mixarchitect.com">
+                legal@mixarchitect.com
               </Anchor>{" "}
               containing:
             </p>
@@ -438,11 +438,11 @@ export default async function TermsPage() {
           <Section title="17. Governing Law and Disputes">
             <p>
               These Terms are governed by the laws of the State of{" "}
-              <strong>[STATE]</strong>, without regard to its conflict-of-law
+              <strong>California</strong>, without regard to its conflict-of-law
               principles. Any dispute arising out of or relating to these Terms
               or the Services will be resolved exclusively in the state or
-              federal courts located in <strong>[COUNTY]</strong>,{" "}
-              <strong>[STATE]</strong>, and you consent to personal jurisdiction
+              federal courts located in <strong>Los Angeles County</strong>,{" "}
+              <strong>California</strong>, and you consent to personal jurisdiction
               and venue in those courts.
             </p>
             <p>
@@ -493,7 +493,7 @@ export default async function TermsPage() {
                 We may send notices to you at the email address associated with
                 your account or through in-app notification. You should send
                 notices to us at{" "}
-                <Anchor href="mailto:[CONTACT EMAIL]">[CONTACT EMAIL]</Anchor>.
+                <Anchor href="mailto:legal@mixarchitect.com">legal@mixarchitect.com</Anchor>.
               </p>
             </SubSection>
           </Section>
@@ -501,7 +501,7 @@ export default async function TermsPage() {
           <Section title="19. Contact">
             <p>
               Questions about these Terms? Contact us at{" "}
-              <Anchor href="mailto:[CONTACT EMAIL]">[CONTACT EMAIL]</Anchor>.
+              <Anchor href="mailto:legal@mixarchitect.com">legal@mixarchitect.com</Anchor>.
             </p>
           </Section>
         </article>

--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -48,7 +48,13 @@ export async function LandingFooter() {
 
           <div className="flex items-center gap-4 text-xs text-zinc-400">
             <LocaleSwitcher locale={locale} />
-            <span className="min-h-[44px] inline-flex items-center cursor-default">{t("navTerms")}</span>
+            <Link
+              href="/terms"
+              className="min-h-[44px] inline-flex items-center hover:text-white/70 transition-colors"
+            >
+              {t("navTerms")}
+            </Link>
+            {/* Privacy stays a non-link span until /privacy ships. */}
             <span className="min-h-[44px] inline-flex items-center cursor-default">{t("navPrivacy")}</span>
           </div>
         </div>

--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -54,8 +54,12 @@ export async function LandingFooter() {
             >
               {t("navTerms")}
             </Link>
-            {/* Privacy stays a non-link span until /privacy ships. */}
-            <span className="min-h-[44px] inline-flex items-center cursor-default">{t("navPrivacy")}</span>
+            <Link
+              href="/privacy"
+              className="min-h-[44px] inline-flex items-center hover:text-white/70 transition-colors"
+            >
+              {t("navPrivacy")}
+            </Link>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Adds \`/terms\` — a comprehensive SaaS Terms of Service doc tailored to what Mix Architect actually does: audio upload (copyright concerns), DMCA, Stripe Connect engineer payouts, subscription billing, client portal sharing, distribution tracking.

⚠️ **Not legal advice.** Starting template based on common SaaS Terms patterns. Should be reviewed by a lawyer before launch — especially the user-content / DMCA / Stripe Connect sections.

## What's covered

19 sections, including:
- Subscription billing (Stripe, monthly/annual, cancellation, refunds, taxes, failed payments)
- Stripe Connect engineer payouts (we're a platform, not a party to the engineer-client engagement)
- User Content (ownership stays with you, license you grant us to host/process)
- Your representations (you have rights to what you upload — copyright)
- DMCA copyright complaint procedure
- Acceptable use prohibitions
- Disclaimers + limitation of liability + indemnification (standard SaaS)
- Termination + survival
- Governing law + venue

## Placeholders to fill in

Search for \`[BRACKETED]\` text and replace before publishing publicly:

| Placeholder | What goes there |
|---|---|
| \`[LEGAL ENTITY NAME]\` | Your registered business name (LLC, Inc., etc.) |
| \`[CONTACT EMAIL]\` | General contact for billing / legal questions |
| \`[DMCA AGENT EMAIL]\` | Designated DMCA agent (can be same as contact) |
| \`[STATE]\` | Governing law jurisdiction (e.g., \"California\") |
| \`[COUNTY]\` | Venue for disputes (e.g., \"Los Angeles County\") |

The effective date is hardcoded to **June 20, 2026** — bump it whenever you make substantive changes.

## Footer link

The footer \"Terms\" item was a non-clickable \`<span>\`. Now it's a \`<Link href=\"/terms\">\`. The \"Privacy\" item stays a span until /privacy ships (next PR).

## Test plan

- [ ] Vercel preview: visit \`/\` → click Terms in footer → lands on \`/terms\` with full content
- [ ] Page styling matches landing aesthetic (dark bg, teal accents, white text)
- [ ] Scroll all 19 sections — confirm placeholders are visually obvious in [BRACKETS]
- [ ] Internal links work (Privacy Policy link points to \`/privacy\` — will 404 until next PR, but doesn't error)
- [ ] Mobile-friendly (max-w-3xl + padding, should read fine on phones)

## Next up

A matching \`/privacy\` page so the footer Privacy link can be wired, and so ad platforms have a privacy URL to point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)