### PR TITLE
GA4: fire subscription_started conversion on Stripe success

### DIFF
--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -58,7 +58,10 @@ export async function POST(req: NextRequest) {
           quantity: 1,
         },
       ],
-      success_url: `${origin}/app/settings?checkout=success`,
+      // Include the chosen interval in the return URL so the settings
+      // page can fire a GA4 `subscription_started` conversion event
+      // with the right plan dimension (monthly vs annual).
+      success_url: `${origin}/app/settings?checkout=success&interval=${interval}`,
       cancel_url: `${origin}/app/settings?checkout=canceled`,
       subscription_data: {
         metadata: { supabase_user_id: user.id },

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -61,6 +61,32 @@ export default function SettingsPage() {
   useEffect(() => setMounted(true), []);
   const resolvedTheme = mounted ? currentTheme : undefined;
 
+  // Stripe checkout redirects back to /app/settings?checkout=success
+  // (or canceled) with the chosen interval. Fire a GA4 conversion on
+  // success so ad platforms can optimize for paid signups rather than
+  // just page visits, then strip the query string so a manual refresh
+  // doesn't re-fire the event.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const status = params.get("checkout");
+    if (status !== "success") return;
+    const interval = params.get("interval") === "annual" ? "annual" : "monthly";
+    trackGA4Event("subscription_started", {
+      plan: "pro",
+      interval,
+    });
+    // Drop checkout / interval params from the URL without a reload.
+    params.delete("checkout");
+    params.delete("interval");
+    const qs = params.toString();
+    window.history.replaceState(
+      {},
+      "",
+      window.location.pathname + (qs ? `?${qs}` : ""),
+    );
+  }, []);
+
   const [loading, setLoading] = useState(true);
   const [saveStatus, setSaveStatus] = useState<
     "idle" | "saving" | "saved" | "error"


### PR DESCRIPTION
## Summary

Without a paid-conversion event GA4 only sees raw page visits and clicks. Ad platforms that ingest GA4 (Google Ads in particular) optimize against whatever conversion you mark — so right now they have no signal for "this person actually subscribed" vs "this person clicked Subscribe and bounced."

This PR fires \`subscription_started\` on the Stripe success redirect so paid-acquisition campaigns can target real conversions.

## Two small changes

### 1. \`/api/stripe/checkout\` — pass the interval through the success URL
\`\`\`diff
- success_url: \`\${origin}/app/settings?checkout=success\`,
+ success_url: \`\${origin}/app/settings?checkout=success&interval=\${interval}\`,
\`\`\`

So we know whether it was monthly or annual at the receiving end, without re-querying Stripe or the DB.

### 2. \`/app/settings\` — detect and fire on mount
\`\`\`ts
useEffect(() => {
  const params = new URLSearchParams(window.location.search);
  if (params.get("checkout") !== "success") return;
  const interval = params.get("interval") === "annual" ? "annual" : "monthly";
  trackGA4Event("subscription_started", { plan: "pro", interval });
  // scrub the query params so refresh doesn't double-fire
  params.delete("checkout");
  params.delete("interval");
  window.history.replaceState({}, "", window.location.pathname + (qs ? \`?\${qs}\` : ""));
}, []);
\`\`\`

## After merge — configure on the GA4 / Ads side

1. **GA4 → Admin → Events** → look for \`subscription_started\` after the first real conversion (it appears once it fires). Click the toggle to mark it as a **Key event** (conversion).
2. **Google Ads → Tools → Conversions → New** → import from GA4 → pick \`subscription_started\` → set value as static \$14 monthly / \$129 annual or leave dynamic if you'll pass values later.
3. **Meta Ads** — similar via the Meta Pixel + Conversions API if you wire that in later (not in scope here).

## Test plan

- [ ] Vercel preview → subscribe with a real card (or use your existing live sub from the smoke test)
- [ ] Check the URL after Stripe redirects → confirm \`?checkout=success&interval=monthly\` (or annual)
- [ ] Open browser DevTools → Network tab → filter for \`google-analytics\` → confirm a \`collect\` request with \`en=subscription_started\` and \`epn.plan=pro\` parameter
- [ ] After the event fires, URL should scrub down to just \`/app/settings\` (no query params)
- [ ] Refresh the page → no second event fires (since query is gone)
- [ ] GA4 DebugView (if enabled) → real-time event appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)