### PR TITLE
GA4: switch subscription conversion to the recommended `purchase` event

### DIFF
--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -58,10 +58,13 @@ export async function POST(req: NextRequest) {
           quantity: 1,
         },
       ],
-      // Include the chosen interval in the return URL so the settings
-      // page can fire a GA4 `subscription_started` conversion event
-      // with the right plan dimension (monthly vs annual).
-      success_url: `${origin}/app/settings?checkout=success&interval=${interval}`,
+      // Include the chosen interval + Stripe-supplied session id in
+      // the return URL so the settings page can fire a GA4 `purchase`
+      // conversion event with the right plan dimension and a stable
+      // transaction_id (used by Google Ads for dedup against the
+      // server-side conversion-API call if we ever wire that in).
+      // Stripe substitutes {CHECKOUT_SESSION_ID} server-side.
+      success_url: `${origin}/app/settings?checkout=success&interval=${interval}&session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${origin}/app/settings?checkout=canceled`,
       subscription_data: {
         metadata: { supabase_user_id: user.id },

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -62,23 +62,46 @@ export default function SettingsPage() {
   const resolvedTheme = mounted ? currentTheme : undefined;
 
   // Stripe checkout redirects back to /app/settings?checkout=success
-  // (or canceled) with the chosen interval. Fire a GA4 conversion on
-  // success so ad platforms can optimize for paid signups rather than
-  // just page visits, then strip the query string so a manual refresh
-  // doesn't re-fire the event.
+  // (or canceled) with the chosen interval + checkout session id.
+  // Fire GA4's recommended `purchase` event so ad platforms can
+  // optimize for paid conversions, then strip the query string so
+  // a manual refresh doesn't re-fire.
   useEffect(() => {
     if (typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     const status = params.get("checkout");
     if (status !== "success") return;
-    const interval = params.get("interval") === "annual" ? "annual" : "monthly";
-    trackGA4Event("subscription_started", {
-      plan: "pro",
-      interval,
+    const interval =
+      params.get("interval") === "annual" ? "annual" : "monthly";
+    const sessionId = params.get("session_id") ?? undefined;
+    const value = interval === "annual" ? 129 : 14;
+    const itemId = interval === "annual" ? "pro_annual" : "pro_monthly";
+    const itemName =
+      interval === "annual"
+        ? "Mix Architect Pro (Annual)"
+        : "Mix Architect Pro (Monthly)";
+
+    trackGA4Event("purchase", {
+      // transaction_id lets Google Ads dedupe if we later add a
+      // server-side conversion API call.
+      transaction_id: sessionId,
+      value,
+      currency: "USD",
+      items: [
+        {
+          item_id: itemId,
+          item_name: itemName,
+          item_category: "subscription",
+          item_variant: interval,
+          price: value,
+          quantity: 1,
+        },
+      ],
     });
-    // Drop checkout / interval params from the URL without a reload.
+
     params.delete("checkout");
     params.delete("interval");
+    params.delete("session_id");
     const qs = params.toString();
     window.history.replaceState(
       {},

--- a/src/lib/ga4-track.ts
+++ b/src/lib/ga4-track.ts
@@ -4,9 +4,13 @@
  * Fire-and-forget — never blocks the caller.
  * Usage: trackGA4Event('signup_start', { source: 'landing' })
  */
+// Param type is intentionally loose: GA4's recommended events (e.g.
+// `purchase`) accept nested structures like `items: [{...}]` which
+// gtag forwards verbatim. Locking this to flat primitives breaks
+// those events.
 export function trackGA4Event(
   eventName: string,
-  params?: Record<string, string | number | boolean>,
+  params?: Record<string, unknown>,
 ) {
   if (typeof window !== "undefined" && typeof window.gtag === "function") {
     window.gtag("event", eventName, params);


### PR DESCRIPTION
## Summary

PR #32 used a custom \`subscription_started\` event. Better to use GA4's recommended \`purchase\` event — it's already marked as a key event in your GA4 property, Google Ads has built-in handling for it, and GA4's e-commerce reports light up automatically when its standard parameters are present.

## Changes

### 1. \`lib/ga4-track.ts\` — relax the params type
Was \`Record<string, string | number | boolean>\` which broke the nested \`items: [...]\` array GA4 expects for \`purchase\`. Now \`Record<string, unknown>\`; \`gtag()\` forwards verbatim either way.

### 2. \`/api/stripe/checkout\` — pass the Stripe session id through
\`\`\`diff
- success_url: \`\${origin}/app/settings?checkout=success&interval=\${interval}\`,
+ success_url: \`\${origin}/app/settings?checkout=success&interval=\${interval}&session_id={CHECKOUT_SESSION_ID}\`,
\`\`\`
Stripe substitutes \`{CHECKOUT_SESSION_ID}\` server-side with the actual \`cs_live_…\` value. Used as the GA4 \`transaction_id\` for Google Ads dedup.

### 3. \`/app/settings\` — fire \`purchase\` with the standard e-commerce shape
\`\`\`ts
trackGA4Event("purchase", {
  transaction_id: sessionId,
  value: interval === "annual" ? 129 : 14,
  currency: "USD",
  items: [{
    item_id: interval === "annual" ? "pro_annual" : "pro_monthly",
    item_name: "Mix Architect Pro (Annual/Monthly)",
    item_category: "subscription",
    item_variant: interval,
    price: value,
    quantity: 1,
  }],
});
\`\`\`
Same query-param scrubbing as before — refresh doesn't re-fire.

## Test plan

- [ ] After Vercel deploys, subscribe with a real card on the live site
- [ ] Browser DevTools → Network → filter \`google-analytics\` → confirm a \`collect\` request with \`en=purchase\` and \`epn.value=14\` (or 129 for annual)
- [ ] Confirm URL ends up scrubbed back to plain \`/app/settings\` after the event fires
- [ ] GA4 → Reports → Realtime → event \`purchase\` shows up within ~30 seconds
- [ ] After a day or so, GA4 → Reports → Monetization → e-commerce purchases section populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)