### PR TITLE
Bump worker Node 20 → 22 (fixes Railway crash loop)

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg && \


### PR DESCRIPTION
## Summary

- Worker container is crash-looping on Railway with `Error: Node.js 20 detected without native WebSocket support.`
- Thrown at `new SupabaseClient(...)` during startup because a recent `@supabase/realtime-js` release added a fail-fast check for native WebSocket on Node < 22.
- Worker doesn't use Realtime (it polls), but the client always initializes the realtime sub-client during construction — no config can skip it.
- Bumping the base image to `node:22-slim` exposes the native `WebSocket` global and lets the client construct cleanly. No `ws` polyfill needed.

## Test plan

- [ ] Railway picks up the new image and the worker boots without throwing the WebSocket error
- [ ] Worker logs show `[worker] polling…` (or whatever the normal startup line is) within ~30s
- [ ] Upload a new track end-to-end to confirm the worker is reclaiming + processing jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)