### PR TITLE
Add track_audio_versions + notifications to realtime publication

### DIFF
--- a/supabase/migrations/060_realtime_publication.sql
+++ b/supabase/migrations/060_realtime_publication.sql
@@ -1,0 +1,39 @@
+-- Ensure the tables the browser subscribes to via supabase.channel(...)
+-- are members of the supabase_realtime publication.
+--
+-- Without this, the websocket subscription connects fine but never
+-- receives any UPDATE/INSERT events because Postgres logical
+-- replication doesn't broadcast changes for non-published tables.
+--
+-- Symptom this caused: worker writes track_audio_versions.spec_analysis_status
+-- = 'complete' after analyzing an upload, but the audio-player on the
+-- track-detail page never picks up the change — pills stay stuck on
+-- "Analyzing" / "Measurements processing" until a full page reload
+-- (and even then, only if there's no stale cache layer in between).
+--
+-- Idempotent: ALTER PUBLICATION ADD TABLE fails if the table is
+-- already present, so wrap each in a DO block that checks first.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'track_audio_versions'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.track_audio_versions;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'notifications'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.notifications;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Two tables in the app subscribe to realtime updates via \`supabase.channel(...)\`:

- \`track_audio_versions\` — audio-player flips the version pill from "Analyzing" → "complete" when the worker finishes loudness + peaks.
- \`notifications\` — bell icon lights up on new notifications.

Neither was in the \`supabase_realtime\` publication in prod. They were presumably added once via the Supabase dashboard and that change was never captured in source. When the publication state drifted, browser WebSocket subscriptions connected fine but received zero events — so the audio-player stayed on "Analyzing" forever despite worker logs showing "complete" and the DB row being correctly updated.

This migration adds both via idempotent \`DO\` blocks. Already applied to prod manually during the diagnosis.

## Test plan

- [x] \`SELECT 1 FROM pg_publication_tables WHERE pubname = 'supabase_realtime' AND tablename IN ('track_audio_versions', 'notifications')\` returns both rows in prod
- [ ] Upload a fresh audio version → "Analyzing" pill flips to measurements within seconds (no manual reload)
- [ ] Re-running 060 doesn't error (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)