### PR TITLE
Studio Session 2: plan plumbing + entitlements helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_..."
 # Stripe Pro plan price IDs (one annual, one monthly).
 STRIPE_PRO_PRICE_ID_MONTHLY="price_..."
 STRIPE_PRO_PRICE_ID_ANNUAL="price_..."
+# Stripe Studio plan price IDs ($39/mo, $390/yr).
+STRIPE_STUDIO_PRICE_ID_MONTHLY="price_..."
+STRIPE_STUDIO_PRICE_ID_ANNUAL="price_..."
 # Stripe Connect (engineer payout flow).
 STRIPE_CLIENT_ID="ca_..."
 STRIPE_CONNECT_REDIRECT_URI="${NEXT_PUBLIC_APP_URL}/api/stripe/connect/callback"

--- a/src/app/api/admin/cancel-subscription/route.ts
+++ b/src/app/api/admin/cancel-subscription/route.ts
@@ -7,6 +7,7 @@ import { logAdminAction } from "@/lib/admin-audit-logger";
 import { logActivity } from "@/lib/activity-logger";
 import { dbRateLimit, getClientIp } from "@/lib/rate-limit";
 import { requireSameOrigin } from "@/lib/origin-check";
+import { isAtLeastPro } from "@/lib/entitlements";
 
 /**
  * POST /api/admin/cancel-subscription
@@ -101,9 +102,9 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    if (existing.plan !== "pro" || existing.status === "canceled") {
+    if (!isAtLeastPro(existing.plan) || existing.status === "canceled") {
       return NextResponse.json(
-        { error: "User is not on an active Pro plan" },
+        { error: "User is not on an active paid plan" },
         { status: 400 },
       );
     }

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,13 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { stripe } from "@/lib/stripe-server";
-import { getStripePriceId, type BillingInterval } from "@/lib/pricing";
+import { getStripePriceId, type BillingInterval, type PaidPlan } from "@/lib/pricing";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
 /**
  * POST /api/stripe/checkout
- * Creates a Stripe Checkout session for upgrading to Pro.
- * Accepts an optional `interval` body param: "monthly" | "annual" (default: "monthly").
+ * Creates a Stripe Checkout session for upgrading to a paid plan.
+ * Body params (both optional):
+ *   - plan: "pro" | "studio"         (default: "pro")
+ *   - interval: "monthly" | "annual" (default: "monthly")
  */
 export async function POST(req: NextRequest) {
   const ip = getClientIp(req);
@@ -18,6 +20,19 @@ export async function POST(req: NextRequest) {
     const body = await req.json().catch(() => ({}));
     const interval: BillingInterval =
       body.interval === "annual" ? "annual" : "monthly";
+    // Allowlist the plan — never trust the body to name an arbitrary price.
+    const plan: PaidPlan = body.plan === "studio" ? "studio" : "pro";
+
+    const priceId = getStripePriceId(plan, interval);
+    if (!priceId) {
+      // Price env var for this plan/interval isn't configured (e.g. the
+      // Studio product hasn't been created yet). Fail clearly rather
+      // than handing Stripe an empty price id.
+      return NextResponse.json(
+        { error: `Pricing for the ${plan} plan is not configured.` },
+        { status: 503 },
+      );
+    }
 
     const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
     const {
@@ -54,7 +69,7 @@ export async function POST(req: NextRequest) {
       mode: "subscription",
       line_items: [
         {
-          price: getStripePriceId(interval),
+          price: priceId,
           quantity: 1,
         },
       ],
@@ -66,10 +81,13 @@ export async function POST(req: NextRequest) {
       // Stripe substitutes {CHECKOUT_SESSION_ID} server-side.
       success_url: `${origin}/app/settings?checkout=success&interval=${interval}&session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${origin}/app/settings?checkout=canceled`,
+      // Stamp the plan into both the session and the subscription so the
+      // webhook can record the right plan. The subscription_data copy
+      // survives onto the Subscription object for later events.
       subscription_data: {
-        metadata: { supabase_user_id: user.id },
+        metadata: { supabase_user_id: user.id, plan },
       },
-      metadata: { supabase_user_id: user.id },
+      metadata: { supabase_user_id: user.id, plan },
     });
 
     console.log("[stripe/checkout] session created:", session.id);

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -20,6 +20,7 @@ import {
 import { buildPaymentConfirmationEmail } from "@/lib/email-templates/quote-emails";
 import { syncPaymentStatus } from "@/lib/payment-sync";
 import { fireTrigger } from "@/lib/workflow-engine";
+import { planFromPriceId } from "@/lib/pricing";
 
 /**
  * In Stripe API v2025+, current_period_end lives on the subscription
@@ -232,6 +233,11 @@ export async function POST(req: NextRequest) {
           break;
         }
 
+        // Which plan was bought? The checkout route stamps it into
+        // metadata; default to "pro" for any older/uninstrumented
+        // session so existing behavior is preserved.
+        const checkoutPlan = session.metadata?.plan === "studio" ? "studio" : "pro";
+
         // Fetch the subscription to get period end
         let periodEnd: string | null = null;
         if (subscriptionId) {
@@ -246,7 +252,7 @@ export async function POST(req: NextRequest) {
             user_id: userId,
             stripe_customer_id: customerId,
             stripe_subscription_id: subscriptionId || null,
-            plan: "pro",
+            plan: checkoutPlan,
             status: "active",
             current_period_end: periodEnd,
             cancel_at_period_end: false,
@@ -258,8 +264,8 @@ export async function POST(req: NextRequest) {
         if (error) {
           console.error("[stripe/webhook] upsert failed:", error);
         } else {
-          console.log("[stripe/webhook] subscription activated for user:", userId);
-          logActivity(userId, "subscription_started", { plan: "pro" });
+          console.log("[stripe/webhook] subscription activated for user:", userId, checkoutPlan);
+          logActivity(userId, "subscription_started", { plan: checkoutPlan });
 
           // Send subscription confirmed email. Awaited so Vercel
           // doesn't terminate the Resend call after the handler
@@ -280,7 +286,7 @@ export async function POST(req: NextRequest) {
         // Look up the subscription row by stripe_customer_id
         const { data: existingSub } = await supabase
           .from("subscriptions")
-          .select("id, user_id, granted_by_admin")
+          .select("id, user_id, granted_by_admin, plan")
           .eq("stripe_customer_id", customerId)
           .maybeSingle();
 
@@ -309,11 +315,23 @@ export async function POST(req: NextRequest) {
         const mappedStatus = statusMap[subscription.status] || "active";
         const periodEnd = getPeriodEnd(subscription);
 
+        // Resolve the plan from the subscription's current price (robust
+        // to portal-driven Pro↔Studio switches, which change the price
+        // but not the original checkout metadata). Fall back to the
+        // subscription metadata, then the existing row, then "pro".
+        const priceId = subscription.items?.data?.[0]?.price?.id;
+        const resolvedPlan =
+          planFromPriceId(priceId) ??
+          (subscription.metadata?.plan === "studio" ? "studio" : null) ??
+          (existingSub.plan === "studio" || existingSub.plan === "pro"
+            ? existingSub.plan
+            : "pro");
+
         const { error } = await supabase
           .from("subscriptions")
           .update({
             status: mappedStatus,
-            plan: subscription.status === "canceled" ? "free" : "pro",
+            plan: subscription.status === "canceled" ? "free" : resolvedPlan,
             current_period_end: periodEnd,
             cancel_at_period_end: subscription.cancel_at_period_end,
           })
@@ -325,7 +343,7 @@ export async function POST(req: NextRequest) {
           console.log("[stripe/webhook] subscription updated:", customerId, mappedStatus);
           if (existingSub.user_id) {
             if (mappedStatus === "active") {
-              logActivity(existingSub.user_id, "subscription_renewed", { plan: "pro" });
+              logActivity(existingSub.user_id, "subscription_renewed", { plan: resolvedPlan });
               // Resolve any open churn signals when subscription becomes active again
               resolveChurnSignals(existingSub.user_id);
             } else if (mappedStatus === "past_due") {

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -7,6 +7,7 @@ import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { Shell } from "@/components/ui/shell";
 import { createNotification } from "@/lib/notifications/service";
+import { normalizePlan } from "@/lib/entitlements";
 
 export default async function AppLayout({ children }: { children: ReactNode }) {
   const supabase = await createSupabaseServerClient();
@@ -131,7 +132,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
   })();
 
   const subscription = {
-    plan: (subRes.data?.plan as "free" | "pro") ?? "free",
+    plan: normalizePlan(subRes.data?.plan),
     status: (subRes.data?.status as "active" | "canceled" | "past_due" | "trialing" | "incomplete") ?? "active",
     cancelAtPeriodEnd: subRes.data?.cancel_at_period_end ?? false,
     currentPeriodEnd: subRes.data?.current_period_end ?? null,

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -10,6 +10,7 @@ import { Plus, Sparkles, Music, Search } from "lucide-react";
 import { formatMoney } from "@/lib/format-money";
 import { getLocale, getTranslations } from "next-intl/server";
 import type { DashboardRelease } from "@/types/release";
+import { hasProAccess } from "@/lib/entitlements";
 
 const VALID_FILTERS = ["outstanding", "earned"] as const;
 type PaymentFilter = (typeof VALID_FILTERS)[number];
@@ -91,7 +92,8 @@ export default async function DashboardPage({ searchParams }: Props) {
   const releases = allReleases?.filter((r) => !sharedReleaseIds.has(r.id as string)) ?? null;
   const sharedReleases = allReleases?.filter((r) => sharedReleaseIds.has(r.id as string)) ?? [];
 
-  const isPro = subPlan === "pro" && (subStatus === "active" || subStatus === "trialing");
+  // Pro-or-better access (Pro or Studio) gates the unlimited-release perk.
+  const isPro = hasProAccess(subPlan, subStatus);
   const ownedReleaseCount = releases?.length ?? 0;
   const atFreeLimit = !isPro && ownedReleaseCount >= 1;
 

--- a/src/app/app/releases/new/page.tsx
+++ b/src/app/app/releases/new/page.tsx
@@ -10,6 +10,7 @@ import { Rule } from "@/components/ui/rule";
 import { TagInput } from "@/components/ui/tag-input";
 import { ArrowLeft, Sparkles, LayoutTemplate, Star, ArrowRight } from "lucide-react";
 import { useSubscription } from "@/lib/subscription-context";
+import { hasProAccess } from "@/lib/entitlements";
 import { logActivityClient } from "@/lib/activity-logger-client";
 import { trackGA4Event } from "@/lib/ga4-track";
 import { cn } from "@/lib/cn";
@@ -162,7 +163,7 @@ export default function NewReleasePage() {
   const sub = useSubscription();
   const { persona } = useFeatureVisibility();
   const tour = useTourContext();
-  const isFree = sub.plan !== "pro" || (sub.status !== "active" && sub.status !== "trialing");
+  const isFree = !hasProAccess(sub.plan, sub.status);
 
   // Fetch dynamic genre suggestions (defaults + user's previously used genres)
   useEffect(() => {

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -17,6 +17,7 @@ import { Rule } from "@/components/ui/rule";
 import { TagInput } from "@/components/ui/tag-input";
 import { AutoSaveIndicator } from "@/components/ui/auto-save-indicator";
 import { useSubscription } from "@/lib/subscription-context";
+import { hasProAccess } from "@/lib/entitlements";
 import { useUnsavedChanges } from "@/hooks/use-unsaved-changes";
 import { useFeatureVisibility } from "@/lib/features/feature-visibility-context";
 import {
@@ -864,7 +865,7 @@ function SubscriptionPanel() {
   const [upgrading, setUpgrading] = useState(false);
   const [managingBilling, setManagingBilling] = useState(false);
 
-  const isPro = sub.plan === "pro" && (sub.status === "active" || sub.status === "trialing");
+  const isPro = hasProAccess(sub.plan, sub.status);
   const isCanceling = isPro && sub.cancelAtPeriodEnd;
   const isAdminGranted = sub.grantedByAdmin;
 

--- a/src/components/admin/SubscriptionPlanControl.tsx
+++ b/src/components/admin/SubscriptionPlanControl.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Gift, X, Clock, AlertTriangle } from "lucide-react";
+import { isAtLeastPro } from "@/lib/entitlements";
 
 /**
  * Plan controls for the admin user-detail page.
@@ -47,7 +48,7 @@ export function SubscriptionPlanControl({ userId, subscription }: Props) {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const isActivePro =
-    subscription?.plan === "pro" && subscription?.status === "active";
+    isAtLeastPro(subscription?.plan) && subscription?.status === "active";
   const isComp = isActivePro && subscription?.granted_by_admin === true;
   const isPaidPro =
     isActivePro && !!subscription?.stripe_subscription_id && !isComp;

--- a/src/lib/entitlements.ts
+++ b/src/lib/entitlements.ts
@@ -1,0 +1,107 @@
+/* ------------------------------------------------------------------ */
+/*  Plan entitlements — single source of truth for plan → features    */
+/* ------------------------------------------------------------------ */
+//
+// Every plan-gated decision should route through here rather than
+// comparing `plan === "pro"` inline. That's what keeps Studio correctly
+// treated as "Pro or better" everywhere: a scattered `=== "pro"` check
+// would under-entitle a Studio user (gated like Free for Pro features).
+//
+// Server-safe (no client/browser deps) so it can back route handlers,
+// server actions, and RSC pages as well as client components.
+
+export type Plan = "free" | "pro" | "studio";
+export type SubStatus =
+  | "active"
+  | "canceled"
+  | "past_due"
+  | "trialing"
+  | "incomplete";
+
+const RANK: Record<Plan, number> = { free: 0, pro: 1, studio: 2 };
+
+/** Coerce any DB/string value to a known Plan, defaulting to "free". */
+export function normalizePlan(plan: string | null | undefined): Plan {
+  return plan === "pro" || plan === "studio" ? plan : "free";
+}
+
+/** Pro tier or above (Pro or Studio). */
+export function isAtLeastPro(plan: string | null | undefined): boolean {
+  return RANK[normalizePlan(plan)] >= RANK.pro;
+}
+
+export function isStudio(plan: string | null | undefined): boolean {
+  return normalizePlan(plan) === "studio";
+}
+
+/** A subscription status that grants active access. */
+export function isActiveStatus(status: string | null | undefined): boolean {
+  return status === "active" || status === "trialing";
+}
+
+/**
+ * Active Pro-or-better access = the plan is Pro/Studio AND the
+ * subscription is in an access-granting state. This is the predicate
+ * that replaces the scattered `plan === "pro" && (active|trialing)`.
+ */
+export function hasProAccess(
+  plan: string | null | undefined,
+  status: string | null | undefined,
+): boolean {
+  return isAtLeastPro(plan) && isActiveStatus(status);
+}
+
+export type Entitlements = {
+  /** Max releases. Infinity for Pro/Studio. */
+  releaseLimit: number;
+  /** Member seats in the workspace. Infinity for Studio. */
+  seats: number;
+  /** Portal branding level. */
+  branding: "none" | "basic" | "full";
+  /** Studio-only white-label capabilities. */
+  customDomain: boolean;
+  brandedEmail: boolean;
+  removePoweredBy: boolean;
+  teamWorkspace: boolean;
+};
+
+/**
+ * Feature entitlements for a plan. Note this is plan-only — callers
+ * that also care about subscription status should gate with
+ * hasProAccess() / isActiveStatus() as well (a past_due Pro plan still
+ * has Pro *entitlements* by shape, but shouldn't get active access).
+ */
+export function getEntitlements(plan: string | null | undefined): Entitlements {
+  switch (normalizePlan(plan)) {
+    case "studio":
+      return {
+        releaseLimit: Infinity,
+        seats: Infinity,
+        branding: "full",
+        customDomain: true,
+        brandedEmail: true,
+        removePoweredBy: true,
+        teamWorkspace: true,
+      };
+    case "pro":
+      return {
+        releaseLimit: Infinity,
+        seats: 1,
+        branding: "basic",
+        customDomain: false,
+        brandedEmail: false,
+        removePoweredBy: false,
+        teamWorkspace: false,
+      };
+    default:
+      return {
+        releaseLimit: 1,
+        seats: 1,
+        branding: "none",
+        customDomain: false,
+        brandedEmail: false,
+        removePoweredBy: false,
+        teamWorkspace: false,
+      };
+  }
+}

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -2,6 +2,8 @@
 /*  Centralized pricing constants                                      */
 /* ------------------------------------------------------------------ */
 
+import type { Plan } from "@/lib/entitlements";
+
 export const PRICING = {
   FREE: {
     name: "Free",
@@ -34,6 +36,23 @@ export const PRICING = {
       "Priority support",
     ],
   },
+  STUDIO: {
+    name: "Studio",
+    description: "A white-labeled studio with your whole team",
+    monthlyPrice: 39,
+    annualPrice: 390,
+    annualMonthlyEquivalent: 32.5, // $390 / 12
+    annualSavingsPercent: 17, // Math.round((1 - 390/468) * 100)
+    features: [
+      "Unlimited team members",
+      "Everything in Pro, plus:",
+      "Full white-label client portal",
+      "Custom portal domain",
+      "Branded email sender",
+      "Shared client roster & releases",
+      "Member roles & permissions",
+    ],
+  },
 } as const;
 
 /* ------------------------------------------------------------------ */
@@ -43,33 +62,57 @@ export const PRICING = {
 export const STRIPE_PRICES = {
   PRO_MONTHLY: process.env.STRIPE_PRO_PRICE_ID_MONTHLY ?? "",
   PRO_ANNUAL: process.env.STRIPE_PRO_PRICE_ID_ANNUAL ?? "",
+  STUDIO_MONTHLY: process.env.STRIPE_STUDIO_PRICE_ID_MONTHLY ?? "",
+  STUDIO_ANNUAL: process.env.STRIPE_STUDIO_PRICE_ID_ANNUAL ?? "",
 } as const;
 
 /** Billing interval type */
 export type BillingInterval = "monthly" | "annual";
 
-/** Get the Stripe Price ID for a given interval */
-export function getStripePriceId(interval: BillingInterval): string {
+/** The paid plans that have Stripe prices (Free has none). */
+export type PaidPlan = "pro" | "studio";
+
+/** Get the Stripe Price ID for a given paid plan + interval. */
+export function getStripePriceId(plan: PaidPlan, interval: BillingInterval): string {
+  if (plan === "studio") {
+    return interval === "annual"
+      ? STRIPE_PRICES.STUDIO_ANNUAL
+      : STRIPE_PRICES.STUDIO_MONTHLY;
+  }
   return interval === "annual"
     ? STRIPE_PRICES.PRO_ANNUAL
     : STRIPE_PRICES.PRO_MONTHLY;
 }
 
-/** Display price for a given interval */
-export function getDisplayPrice(interval: BillingInterval): {
-  amount: number;
-  period: string;
-  totalAnnual?: number;
-} {
+/**
+ * Resolve a Stripe Price ID back to a plan. Used by the webhook to
+ * tell Pro from Studio on customer.subscription.* events (which carry
+ * the price but no checkout metadata — e.g. a portal upgrade). Returns
+ * null for an unrecognized price id.
+ */
+export function planFromPriceId(priceId: string | null | undefined): PaidPlan | null {
+  if (!priceId) return null;
+  if (priceId === STRIPE_PRICES.STUDIO_MONTHLY || priceId === STRIPE_PRICES.STUDIO_ANNUAL) {
+    return "studio";
+  }
+  if (priceId === STRIPE_PRICES.PRO_MONTHLY || priceId === STRIPE_PRICES.PRO_ANNUAL) {
+    return "pro";
+  }
+  return null;
+}
+
+/** Display price for a given plan + interval. */
+export function getDisplayPrice(
+  plan: PaidPlan,
+  interval: BillingInterval,
+): { amount: number; period: string; totalAnnual?: number } {
+  const tier = plan === "studio" ? PRICING.STUDIO : PRICING.PRO;
   if (interval === "annual") {
     return {
-      amount: PRICING.PRO.annualMonthlyEquivalent,
+      amount: tier.annualMonthlyEquivalent,
       period: "/mo",
-      totalAnnual: PRICING.PRO.annualPrice,
+      totalAnnual: tier.annualPrice,
     };
   }
-  return {
-    amount: PRICING.PRO.monthlyPrice,
-    period: "/mo",
-  };
+  return { amount: tier.monthlyPrice, period: "/mo" };
 }

--- a/src/lib/subscription-context.tsx
+++ b/src/lib/subscription-context.tsx
@@ -2,10 +2,11 @@
 
 import { createContext, useContext, useState, useEffect } from "react";
 import { createSupabaseBrowserClient } from "@/lib/supabaseBrowserClient";
+import { normalizePlan, type Plan, type SubStatus } from "@/lib/entitlements";
 
 export type SubscriptionState = {
-  plan: "free" | "pro";
-  status: "active" | "canceled" | "past_due" | "trialing" | "incomplete";
+  plan: Plan;
+  status: SubStatus;
   cancelAtPeriodEnd: boolean;
   currentPeriodEnd: string | null;
   grantedByAdmin: boolean;
@@ -48,7 +49,7 @@ export function SubscriptionProvider({
         .then(({ data }: { data: { plan?: string; status?: string; cancel_at_period_end?: boolean; current_period_end?: string | null; granted_by_admin?: boolean } | null }) => {
           if (data) {
             setState({
-              plan: (data.plan as "free" | "pro") ?? "free",
+              plan: normalizePlan(data.plan),
               status: (data.status as SubscriptionState["status"]) ?? "active",
               cancelAtPeriodEnd: data.cancel_at_period_end ?? false,
               currentPeriodEnd: data.current_period_end ?? null,


### PR DESCRIPTION
## Summary

Adds `'studio'` as a first-class plan **end-to-end**, routed through a new central **entitlements helper** so Studio is correctly treated as "Pro or better" everywhere. (A scattered `plan === 'pro'` check would under-entitle Studio users — gate them like Free for Pro features. This was the coupling reason to do entitlements alongside the plan value.)

**Inert until you create the Studio Stripe product + set the price env vars** — no Studio checkout is reachable, and existing Free/Pro behavior is unchanged. Pure scaffolding for the tier.

### New: `src/lib/entitlements.ts` (single source of truth)
- `Plan` / `SubStatus` types, `normalizePlan`, `isAtLeastPro`, `isStudio`, `isActiveStatus`, `hasProAccess`.
- `getEntitlements(plan)` → `releaseLimit`, `seats`, `branding`, `customDomain`, `brandedEmail`, `removePoweredBy`, `teamWorkspace`.

### Plumbing
- **pricing.ts** — `PRICING.STUDIO` ($39/$390) + `STRIPE_PRICES.STUDIO_*`; `getStripePriceId(plan, interval)`; `planFromPriceId()`; `getDisplayPrice(plan, interval)`. `.env.example` updated.
- **checkout** — allowlisted `plan` body param (default `pro`); 503s clearly if that plan's price env is missing (e.g. Studio not created yet); stamps `plan` into session + subscription metadata.
- **webhook** — `checkout.session.completed` records the plan from metadata (defaults to `pro`, backward compatible); `customer.subscription.updated` resolves plan from the subscription's **price id** (robust to portal Pro↔Studio switches), falling back to metadata → existing row → `pro`.
- **Gate sites** routed through the helper (behavior-preserving for free/pro, now studio-aware): `app/page`, `releases/new`, `settings`, `app/layout`, `subscription-context`, admin `cancel-subscription`, `SubscriptionPlanControl`.

### Verification
- `tsc --noEmit` clean; `next build` clean.

### Not here (later sessions)
- Payment routing → workspace account, `on_behalf_of`, 0% fee (Session 3 — separate PR, held for your review).
- Three-tier pricing page + plan labels / admin display counts (Session 9).

## Your action when back
Create the **Studio product** in Stripe ($39/mo + $390/yr prices), then set `STRIPE_STUDIO_PRICE_ID_MONTHLY` / `_ANNUAL` in Vercel. Until then this is dormant. I'll give exact steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)