### PR TITLE
Studio Session 3: Connect → workspace account, 0% fee, on_behalf_of [HOLD — review before merge]

### DIFF
--- a/src/app/api/stripe/connect/checkout/route.ts
+++ b/src/app/api/stripe/connect/checkout/route.ts
@@ -62,14 +62,44 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Quote has expired" }, { status: 400 });
   }
 
-  // Fetch engineer's connected account
+  // Resolve the destination connected account. Per D1 Option B, client
+  // payments route to the *workspace's* connected account (the studio's),
+  // not the individual engineer's. quote.workspace_id was backfilled in
+  // migration 063; fall back to the quote owner's personal connected
+  // account when it's missing (transition safety / older rows).
+  let destinationAccountId: string | null = null;
+  if (quote.workspace_id) {
+    const { data: ws } = await supabase
+      .from("workspaces")
+      .select("connected_account_id")
+      .eq("id", quote.workspace_id)
+      .maybeSingle();
+    destinationAccountId = ws?.connected_account_id ?? null;
+  }
+  if (!destinationAccountId) {
+    const { data: ownerAccount } = await supabase
+      .from("stripe_connected_accounts")
+      .select("stripe_account_id")
+      .eq("user_id", quote.user_id)
+      .maybeSingle();
+    destinationAccountId = ownerAccount?.stripe_account_id ?? null;
+  }
+
+  if (!destinationAccountId) {
+    return NextResponse.json(
+      { error: "Payment processing not available" },
+      { status: 400 },
+    );
+  }
+
+  // Confirm that account can actually accept charges (onboarding complete).
   const { data: connectedAccount } = await supabase
     .from("stripe_connected_accounts")
-    .select("stripe_account_id, charges_enabled")
-    .eq("user_id", quote.user_id)
+    .select("charges_enabled")
+    .eq("stripe_account_id", destinationAccountId)
     .maybeSingle();
 
-  if (!connectedAccount || !connectedAccount.charges_enabled) {
+  if (!connectedAccount?.charges_enabled) {
     return NextResponse.json(
       { error: "Payment processing not available" },
       { status: 400 },
@@ -144,9 +174,15 @@ export async function POST(req: NextRequest) {
         quantity: Math.round(Number(item.quantity)),
       })),
       payment_intent_data: {
-        application_fee_amount: Math.round(Number(quote.total) * 0.01 * 100), // 1% platform fee
+        // 0% platform fee — Mix Architect takes no cut of client payments.
+        // `on_behalf_of` makes the connected account the merchant of
+        // record, so it bears the standard Stripe processing fee and any
+        // disputes (not the platform). Without on_behalf_of the platform
+        // is the settlement merchant and eats the ~2.9%+30¢ fee, which a
+        // 1% application fee didn't even cover.
+        on_behalf_of: destinationAccountId,
         transfer_data: {
-          destination: connectedAccount.stripe_account_id,
+          destination: destinationAccountId,
         },
       },
       customer_email: quote.client_email ?? undefined,


### PR DESCRIPTION
## ⚠️ Hold for review — live payment-path change

This is the one change I built but did **not** merge while you were out, because it alters live client-payment behavior and the first real (test-mode) transaction should be watched before it ships.

## Summary

Implements D1 Option B + the 0% fee model you approved.

**Routing (Option B):** client payments route to the **workspace's** connected account (`quote.workspace_id → workspaces.connected_account_id`) instead of the individual engineer's. Falls back to the quote owner's personal account if `workspace_id`/`connected_account_id` is missing (transition safety). For solo users today the workspace account *equals* their own (backfilled in migration 063), so the destination is unchanged — only the fee + merchant-of-record change take effect now.

**Fee model:**
- **Dropped the 1% `application_fee` entirely** → Mix Architect takes 0% of client payments.
- **Added `on_behalf_of`** → the connected account becomes the merchant of record and bears the standard Stripe processing fee (~2.9% + 30¢) and disputes. Previously the platform was the settlement merchant, paid that fee, and only clawed back 1% — net **−2.2% per transaction**. Now: engineer/studio pays standard processing (normal/expected), platform nets $0, "we take no cut" is literally true.

## Why hold

`on_behalf_of` changes:
- the customer's **statement descriptor** → the connected account's name,
- **fee + dispute liability** → onto the connected account.

Both are intended (white-label + Option B), but they're real changes to money movement.

## Review / test plan (before merge)

- [ ] In **test mode**, run a quote checkout through a test connected account → confirm payment succeeds, funds land on the connected account, and **no application fee** is taken by the platform.
- [ ] Confirm the connected account's balance shows the Stripe processing fee deducted (i.e. the recipient bore it, not the platform).
- [ ] Confirm the customer's receipt/statement descriptor reflects the connected account.
- [ ] Refund path still works; dispute lands on the connected account.
- [ ] Solo (no-team) payment still routes to the same account as before (only fee/MoR changed).

Verified: `tsc` clean, `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)