### PR TITLE
Studio Session 5: Pro portal branding — logo + accent [needs migration 064]

### DIFF
--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -18,6 +18,7 @@ import { TagInput } from "@/components/ui/tag-input";
 import { AutoSaveIndicator } from "@/components/ui/auto-save-indicator";
 import { useSubscription } from "@/lib/subscription-context";
 import { hasProAccess } from "@/lib/entitlements";
+import { PortalBrandingCard } from "@/components/settings/portal-branding-card";
 import { useUnsavedChanges } from "@/hooks/use-unsaved-changes";
 import { useFeatureVisibility } from "@/lib/features/feature-visibility-context";
 import {
@@ -302,6 +303,9 @@ export default function SettingsPage() {
 
         {/* Subscription */}
         <SubscriptionPanel />
+
+        {/* Portal branding (Pro/Studio) */}
+        <PortalBrandingCard />
 
         {/* Region & Currency */}
         <Panel>

--- a/src/app/portal/[shareToken]/page.tsx
+++ b/src/app/portal/[shareToken]/page.tsx
@@ -1,5 +1,6 @@
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { signAudioVersions } from "@/lib/storage-urls";
+import { isAtLeastPro } from "@/lib/entitlements";
 import { notFound } from "next/navigation";
 import { PortalClient } from "./portal-client";
 import type { Metadata } from "next";
@@ -80,7 +81,7 @@ export default async function PortalPage({ params }: Props) {
 
   const { data: release, error: releaseErr } = await supabase
     .from("releases")
-    .select("id, user_id, title, artist, release_type, format, cover_art_url, global_direction, payment_status, fee_total, fee_currency, paid_amount, client_name, client_email, delivery_notes, status, target_date, genre_tags, payment_notes, pinned, distributor, record_label, upc, copyright_holder, copyright_year, phonogram_copyright, catalog_number, created_at, updated_at")
+    .select("id, user_id, workspace_id, title, artist, release_type, format, cover_art_url, global_direction, payment_status, fee_total, fee_currency, paid_amount, client_name, client_email, delivery_notes, status, target_date, genre_tags, payment_notes, pinned, distributor, record_label, upc, copyright_holder, copyright_year, phonogram_copyright, catalog_number, created_at, updated_at")
     .eq("id", portalShare.release_id)
     .maybeSingle();
 
@@ -187,6 +188,31 @@ export default async function PortalPage({ params }: Props) {
     engineerName = userDefaults?.company_name ?? null;
   } catch {
     // Silently fail — engineer name is optional
+  }
+
+  /* ── 4c. Portal branding (Pro/Studio workspaces only) ─────────── */
+
+  let portalAccent: string | null = null;
+  let portalLogoUrl: string | null = null;
+  if (release.workspace_id) {
+    const [{ data: ws }, { data: branding }] = await Promise.all([
+      supabase.from("workspaces").select("plan").eq("id", release.workspace_id).maybeSingle(),
+      supabase
+        .from("workspace_branding")
+        .select("logo_path, accent_color")
+        .eq("workspace_id", release.workspace_id)
+        .maybeSingle(),
+    ]);
+    // Only honor branding for Pro/Studio (a downgraded workspace keeps its
+    // row but loses the entitlement).
+    if (ws && isAtLeastPro(ws.plan) && branding) {
+      if (branding.accent_color) portalAccent = branding.accent_color;
+      if (branding.logo_path) {
+        portalLogoUrl = supabase.storage
+          .from("workspace-logos")
+          .getPublicUrl(branding.logo_path).data.publicUrl;
+      }
+    }
   }
 
   /* ── 5. Build visibility + approval maps ──────────────────────── */
@@ -349,6 +375,8 @@ export default async function PortalPage({ params }: Props) {
       globalRefs={portalShare.show_references ? globalRefs : []}
       quotes={portalQuotes}
       hasStripeConnected={hasStripeConnected}
+      accentColor={portalAccent}
+      logoUrl={portalLogoUrl}
     />
   );
 }

--- a/src/app/portal/[shareToken]/portal-client.tsx
+++ b/src/app/portal/[shareToken]/portal-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, type CSSProperties } from "react";
 import { PortalHeader } from "@/components/portal/portal-header";
 import { PortalTrackCard } from "@/components/portal/portal-track-card";
 import { PortalFooter } from "@/components/portal/portal-footer";
@@ -33,6 +33,10 @@ type PortalClientProps = {
   globalRefs: BriefReference[];
   quotes?: PortalQuote[];
   hasStripeConnected?: boolean;
+  /** Workspace accent color (Pro/Studio branding), or null for default teal. */
+  accentColor?: string | null;
+  /** Workspace logo URL (Pro/Studio branding), or null. */
+  logoUrl?: string | null;
 };
 
 export function PortalClient({
@@ -44,6 +48,8 @@ export function PortalClient({
   globalRefs,
   quotes = [],
   hasStripeConnected = false,
+  accentColor = null,
+  logoUrl = null,
 }: PortalClientProps) {
   const [tracks, setTracks] = useState(initialTracks);
 
@@ -76,7 +82,15 @@ export function PortalClient({
     (share.show_references && globalRefs.length > 0);
 
   return (
-    <main id="main-content" tabIndex={-1} className="portal-page min-h-screen bg-bg py-12 px-4 md:px-6 pb-24 focus:outline-none">
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="portal-page min-h-screen bg-bg py-12 px-4 md:px-6 pb-24 focus:outline-none"
+      // Override the teal accent with the workspace's color (Pro/Studio
+      // branding). Cascades to every `bg-signal` / `text-signal` /
+      // var(--signal) descendant on the portal.
+      style={accentColor ? ({ "--signal": accentColor } as CSSProperties) : undefined}
+    >
       <div className="max-w-3xl mx-auto">
         {/* ═══ Zone 1: Release Header ═══ */}
         <PortalHeader
@@ -84,6 +98,7 @@ export function PortalClient({
           trackCount={tracks.length}
           engineerName={release.engineer_name}
           approvalCounts={approvalCounts}
+          logoUrl={logoUrl}
         />
 
         {/* ═══ Global Mix Brief (collapsible) ═══ */}
@@ -337,7 +352,7 @@ function QuotePaymentRow({
           onClick={handlePay}
           disabled={loading}
           className="shrink-0 px-4 py-1.5 rounded-md text-xs font-semibold text-white transition-colors"
-          style={{ backgroundColor: loading ? "#999" : "#0D9488" }}
+          style={{ backgroundColor: loading ? "#999" : "var(--signal)" }}
         >
           {loading ? "..." : "Pay Now"}
         </button>

--- a/src/components/portal/portal-header.tsx
+++ b/src/components/portal/portal-header.tsx
@@ -16,6 +16,8 @@ type PortalHeaderProps = {
   trackCount: number;
   engineerName: string | null;
   approvalCounts: ApprovalCounts;
+  /** Workspace logo URL (Pro/Studio branding), shown as a letterhead. */
+  logoUrl?: string | null;
 };
 
 export function PortalHeader({
@@ -23,6 +25,7 @@ export function PortalHeader({
   trackCount,
   engineerName,
   approvalCounts,
+  logoUrl = null,
 }: PortalHeaderProps) {
   const typeLabel =
     release.release_type === "ep"
@@ -82,6 +85,15 @@ export function PortalHeader({
 
       {/* Full header */}
       <header className="text-center mb-10">
+        {/* Studio logo (Pro/Studio branding) — letterhead above the artwork */}
+        {logoUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={logoUrl}
+            alt={engineerName ? `${engineerName} logo` : "Studio logo"}
+            className="h-10 max-w-[180px] object-contain mx-auto mb-6"
+          />
+        )}
         {release.cover_art_url && (
           <img
             src={release.cover_art_url}

--- a/src/components/settings/portal-branding-card.tsx
+++ b/src/components/settings/portal-branding-card.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { Upload, X, Check, ImageIcon, Lock, Loader2 } from "lucide-react";
+import { createSupabaseBrowserClient } from "@/lib/supabaseBrowserClient";
+import { useSubscription } from "@/lib/subscription-context";
+import { getEntitlements } from "@/lib/entitlements";
+
+const DEFAULT_ACCENT = "#0D9488";
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+const LOGO_BUCKET = "workspace-logos";
+const MAX_LOGO_BYTES = 2 * 1024 * 1024;
+const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp"];
+
+/**
+ * Pro/Studio portal branding: studio logo + accent color applied to the
+ * client portal. Gated on the `branding` entitlement — Free sees an
+ * upgrade prompt.
+ */
+export function PortalBrandingCard() {
+  const sub = useSubscription();
+  const brandingLevel = getEntitlements(sub.plan).branding;
+  const gated = brandingLevel === "none";
+
+  const [loading, setLoading] = useState(true);
+  const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [logoPath, setLogoPath] = useState<string | null>(null);
+  const [logoUrl, setLogoUrl] = useState<string | null>(null);
+  const [accent, setAccent] = useState<string>(DEFAULT_ACCENT);
+  const [savedAccent, setSavedAccent] = useState<string>(DEFAULT_ACCENT);
+  const [uploading, setUploading] = useState(false);
+  const [savingAccent, setSavingAccent] = useState(false);
+  const [error, setError] = useState("");
+
+  const publicUrl = useCallback((path: string) => {
+    const supabase = createSupabaseBrowserClient();
+    const { data } = supabase.storage.from(LOGO_BUCKET).getPublicUrl(path);
+    return `${data.publicUrl}?t=${Date.now()}`;
+  }, []);
+
+  // Load the owner's workspace + existing branding.
+  useEffect(() => {
+    if (gated) {
+      setLoading(false);
+      return;
+    }
+    const supabase = createSupabaseBrowserClient();
+    (async () => {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) return;
+        setUserId(user.id);
+
+        const { data: ws } = await supabase
+          .from("workspaces")
+          .select("id")
+          .eq("owner_user_id", user.id)
+          .order("created_at", { ascending: true })
+          .limit(1)
+          .maybeSingle();
+        if (!ws) return;
+        setWorkspaceId(ws.id);
+
+        const { data: branding } = await supabase
+          .from("workspace_branding")
+          .select("logo_path, accent_color")
+          .eq("workspace_id", ws.id)
+          .maybeSingle();
+
+        if (branding?.logo_path) {
+          setLogoPath(branding.logo_path);
+          setLogoUrl(publicUrl(branding.logo_path));
+        }
+        if (branding?.accent_color && HEX_RE.test(branding.accent_color)) {
+          setAccent(branding.accent_color);
+          setSavedAccent(branding.accent_color);
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [gated, publicUrl]);
+
+  async function upsertBranding(fields: { logo_path?: string | null; accent_color?: string }) {
+    if (!workspaceId) return;
+    const supabase = createSupabaseBrowserClient();
+    const { error: upsertErr } = await supabase.from("workspace_branding").upsert(
+      {
+        workspace_id: workspaceId,
+        logo_path: fields.logo_path !== undefined ? fields.logo_path : logoPath,
+        accent_color: fields.accent_color !== undefined ? fields.accent_color : savedAccent,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "workspace_id" },
+    );
+    if (upsertErr) throw upsertErr;
+  }
+
+  async function handleUpload(file: File) {
+    setError("");
+    if (file.size > MAX_LOGO_BYTES) {
+      setError("Logo must be under 2MB.");
+      return;
+    }
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setError("Use a PNG, JPG, or WebP image.");
+      return;
+    }
+    if (!userId) return;
+    setUploading(true);
+    const supabase = createSupabaseBrowserClient();
+    try {
+      const rawExt = file.type.split("/")[1];
+      const ext = (rawExt === "jpeg" ? "jpg" : rawExt ?? "").replace(/[^a-z0-9]/gi, "") || "png";
+      const path = `${userId}/logo.${ext}`;
+      const { error: uploadErr } = await supabase.storage
+        .from(LOGO_BUCKET)
+        .upload(path, file, { upsert: true });
+      if (uploadErr) throw uploadErr;
+      await upsertBranding({ logo_path: path });
+      setLogoPath(path);
+      setLogoUrl(publicUrl(path));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed.");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleRemoveLogo() {
+    setError("");
+    try {
+      await upsertBranding({ logo_path: null });
+      setLogoPath(null);
+      setLogoUrl(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove logo.");
+    }
+  }
+
+  async function handleSaveAccent() {
+    setError("");
+    if (!HEX_RE.test(accent)) {
+      setError("Enter a valid hex color, e.g. #0D9488.");
+      return;
+    }
+    setSavingAccent(true);
+    try {
+      await upsertBranding({ accent_color: accent });
+      setSavedAccent(accent);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save color.");
+    } finally {
+      setSavingAccent(false);
+    }
+  }
+
+  /* ── Gated (Free) ───────────────────────────────────────────────── */
+  if (gated) {
+    return (
+      <div className="rounded-xl border border-border p-6" style={{ background: "var(--panel)" }}>
+        <div className="flex items-center gap-2">
+          <Lock size={16} className="text-muted" />
+          <h2 className="text-sm font-semibold text-text">Portal branding</h2>
+        </div>
+        <p className="mt-2 text-sm text-muted">
+          Add your logo and accent color to the client portal. Available on Pro and Studio.
+        </p>
+        <Link
+          href="/app/settings?upgrade=branding"
+          className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors"
+          style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+        >
+          Upgrade to Pro
+        </Link>
+      </div>
+    );
+  }
+
+  /* ── Active (Pro/Studio) ────────────────────────────────────────── */
+  const accentDirty = accent !== savedAccent;
+
+  return (
+    <div className="rounded-xl border border-border p-6 space-y-6" style={{ background: "var(--panel)" }}>
+      <div>
+        <h2 className="text-sm font-semibold text-text">Portal branding</h2>
+        <p className="mt-1 text-sm text-muted">
+          Your logo and accent color appear on the client portal.
+        </p>
+      </div>
+
+      {error && <p className="text-xs text-red-500">{error}</p>}
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-muted">
+          <Loader2 size={14} className="animate-spin" /> Loading…
+        </div>
+      ) : (
+        <>
+          {/* Logo */}
+          <div className="space-y-2">
+            <span className="text-xs font-medium text-muted uppercase tracking-wider">Logo</span>
+            <div className="flex items-center gap-4">
+              <div
+                className="w-28 h-16 rounded-md border border-border flex items-center justify-center overflow-hidden shrink-0"
+                style={{ background: "var(--panel-2)" }}
+              >
+                {logoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={logoUrl} alt="Studio logo" className="max-w-full max-h-full object-contain" />
+                ) : (
+                  <ImageIcon size={20} className="text-muted opacity-30" />
+                )}
+              </div>
+              <div className="flex flex-col gap-2">
+                <label
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md cursor-pointer transition-colors w-fit"
+                  style={{ background: "var(--panel-2)", color: "var(--text-muted)" }}
+                >
+                  <Upload size={14} />
+                  {uploading ? "Uploading…" : logoUrl ? "Replace" : "Upload logo"}
+                  <input
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp"
+                    className="hidden"
+                    disabled={uploading}
+                    onChange={(e) => {
+                      const f = e.target.files?.[0];
+                      if (f) handleUpload(f);
+                    }}
+                  />
+                </label>
+                {logoUrl && (
+                  <button
+                    type="button"
+                    onClick={handleRemoveLogo}
+                    className="inline-flex items-center gap-1 text-xs text-red-500 hover:text-red-400 transition-colors w-fit"
+                  >
+                    <X size={12} /> Remove
+                  </button>
+                )}
+                <span className="text-[10px] text-faint">PNG, JPG, or WebP · max 2MB</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Accent color */}
+          <div className="space-y-2">
+            <span className="text-xs font-medium text-muted uppercase tracking-wider">Accent color</span>
+            <div className="flex items-center gap-3">
+              <input
+                type="color"
+                value={HEX_RE.test(accent) ? accent : DEFAULT_ACCENT}
+                onChange={(e) => setAccent(e.target.value.toUpperCase())}
+                className="w-10 h-10 rounded-md border border-border cursor-pointer bg-transparent p-0"
+                aria-label="Accent color picker"
+              />
+              <input
+                type="text"
+                value={accent}
+                onChange={(e) => setAccent(e.target.value.toUpperCase())}
+                placeholder={DEFAULT_ACCENT}
+                className="input text-sm w-32"
+                maxLength={7}
+              />
+              <button
+                type="button"
+                onClick={handleSaveAccent}
+                disabled={!accentDirty || savingAccent}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors disabled:opacity-40"
+                style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+              >
+                {savingAccent ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
+                Save
+              </button>
+            </div>
+            <p className="text-[10px] text-faint">
+              Used for buttons and highlights on the portal. Default is Mix Architect teal.
+            </p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/064_workspace_branding.sql
+++ b/supabase/migrations/064_workspace_branding.sql
@@ -1,0 +1,86 @@
+-- Studio tier — Session 5: Pro portal branding.
+--
+-- Per-workspace logo + accent color applied to the client portal.
+-- Gated in the app on the `branding` entitlement (Pro: "basic",
+-- Studio: "full"; Free: "none"). The data layer here is plan-agnostic;
+-- enforcement is in the settings UI + at portal render time.
+
+-- ─── 1. workspace_branding table ───────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.workspace_branding (
+  workspace_id uuid PRIMARY KEY REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  -- Storage path in the workspace-logos bucket (e.g. "{user_id}/logo.png"),
+  -- or null if no logo set.
+  logo_path    text,
+  -- Hex accent color (e.g. "#0D9488"), or null to use the default teal.
+  accent_color text,
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.workspace_branding ENABLE ROW LEVEL SECURITY;
+
+-- Members can read their workspace's branding (settings UI); only the
+-- owner can write it. The portal reads via the service-role client, so
+-- these policies don't gate public portal display.
+DROP POLICY IF EXISTS workspace_branding_select ON public.workspace_branding;
+CREATE POLICY workspace_branding_select ON public.workspace_branding
+  FOR SELECT USING (workspace_id IN (SELECT public.user_workspace_ids()));
+
+DROP POLICY IF EXISTS workspace_branding_insert ON public.workspace_branding;
+CREATE POLICY workspace_branding_insert ON public.workspace_branding
+  FOR INSERT WITH CHECK (workspace_id IN (SELECT public.owned_workspace_ids()));
+
+DROP POLICY IF EXISTS workspace_branding_update ON public.workspace_branding;
+CREATE POLICY workspace_branding_update ON public.workspace_branding
+  FOR UPDATE USING (workspace_id IN (SELECT public.owned_workspace_ids()))
+  WITH CHECK (workspace_id IN (SELECT public.owned_workspace_ids()));
+
+DROP POLICY IF EXISTS workspace_branding_delete ON public.workspace_branding;
+CREATE POLICY workspace_branding_delete ON public.workspace_branding
+  FOR DELETE USING (workspace_id IN (SELECT public.owned_workspace_ids()));
+
+-- ─── 2. workspace-logos storage bucket ─────────────────────────────
+-- INTENTIONALLY PUBLIC: a studio logo is a public brand asset, shown to
+-- anonymous portal visitors. Public read gives a stable URL with no
+-- signing. Writes are still owner-scoped via RLS below. (The RLS audit
+-- script already recognizes intentionally-public buckets.)
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'workspace-logos',
+  'workspace-logos',
+  true,
+  2 * 1024 * 1024,  -- 2 MB
+  ARRAY['image/png', 'image/jpeg', 'image/webp']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public = true,
+  file_size_limit = 2 * 1024 * 1024,
+  allowed_mime_types = ARRAY['image/png', 'image/jpeg', 'image/webp'];
+
+-- Owner-scoped writes; path convention is "{user_id}/<file>".
+DROP POLICY IF EXISTS workspace_logos_insert_own ON storage.objects;
+CREATE POLICY workspace_logos_insert_own
+  ON storage.objects FOR INSERT
+  WITH CHECK (
+    bucket_id = 'workspace-logos'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+DROP POLICY IF EXISTS workspace_logos_update_own ON storage.objects;
+CREATE POLICY workspace_logos_update_own
+  ON storage.objects FOR UPDATE
+  USING (
+    bucket_id = 'workspace-logos'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  )
+  WITH CHECK (
+    bucket_id = 'workspace-logos'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+DROP POLICY IF EXISTS workspace_logos_delete_own ON storage.objects;
+CREATE POLICY workspace_logos_delete_own
+  ON storage.objects FOR DELETE
+  USING (
+    bucket_id = 'workspace-logos'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );


### PR DESCRIPTION
## Summary

First releasable branding increment (Phase 2). Pro/Studio workspaces set a **logo + accent color** that apply to the client portal; Free sees an upgrade prompt. **Inert until migration 064 is applied and a workspace sets branding** — portals render exactly as today otherwise.

### Migration 064
- `workspace_branding(workspace_id, logo_path, accent_color)` + RLS (members read, owner writes — uses the Session 1 helpers).
- `workspace-logos` storage bucket — **intentionally public** (a studio logo is a public brand asset shown to anonymous portal visitors), owner-scoped writes, 2 MB + image-mime caps.

### Settings UI
New `PortalBrandingCard` under the subscription panel: logo upload + accent picker (native swatch + `#RRGGBB` hex input, validated). Gated on `getEntitlements(plan).branding` — Free gets an upgrade card. Self-contained (resolves the owner's workspace + loads/saves via the browser client under RLS).

### Portal application
- Portal page fetches branding by `release.workspace_id`, honored **only for Pro/Studio** (a downgrade keeps the row but loses the entitlement).
- `PortalClient` overrides `--signal` with the accent on the root → every `bg-signal`/`text-signal`/`var(--signal)` descendant follows.
- `PortalHeader` renders the logo as a letterhead above the artwork.
- Replaced the one hardcoded `#0D9488` (Pay Now button) with `var(--signal)`.

The "Powered by Mix Architect" credit is unchanged (stays on Free + Pro; Studio removal is Session 7).

## Your action (when back)
1. **Apply migration 064** in the Supabase SQL editor (creates the table, bucket, and policies). I'll paste the SQL.
2. **Review the portal rendering** — on a Pro account, set a logo + accent in Settings, open a share portal, confirm the logo shows and the accent applies (Pay Now button, progress bar, etc.). It's user-facing, so worth a look before merge.

## Design calls I made (flag if you'd change any)
- Branding settings card lives under the subscription panel in Settings.
- Logo renders as a small centered "letterhead" (≤40px tall) above the release artwork — keeps the release cover as the artwork, the studio logo as the brand mark.
- `workspace-logos` bucket is public (vs signed URLs) — simplest for a public brand asset.

Verified: `tsc` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)