### PR TITLE
Security: revoke SECURITY DEFINER fn EXECUTE from anon (closes free-Pro hole)

### DIFF
--- a/supabase/migrations/065_revoke_definer_anon_execute.sql
+++ b/supabase/migrations/065_revoke_definer_anon_execute.sql
@@ -1,0 +1,44 @@
+-- Security fix: revoke EXECUTE on SECURITY DEFINER functions from the
+-- anon/authenticated roles.
+--
+-- Prior migrations (058, 059, 061, 062) only did `REVOKE EXECUTE ...
+-- FROM public`. But Supabase's project default privileges grant EXECUTE
+-- to `anon` and `authenticated` *directly*, so those grants survived the
+-- public revoke — every SECURITY DEFINER function stayed callable via
+-- /rest/v1/rpc/<fn> with the public anon key.
+--
+-- Most critically: `grant_free_pro(p_user_id)` (SECURITY DEFINER,
+-- inserts a pro/granted_by_admin subscription) was reachable by `anon`,
+-- so anyone with the in-browser anon key could grant any account free
+-- Pro. `revoke_free_pro` and `consume_rate_limit` were similarly exposed.
+--
+-- Confirmed with has_function_privilege('anon', oid, 'EXECUTE') = true
+-- before this migration; false after (service-role retained throughout).
+
+-- ─── Service-role-only: no end-user role should call these ──────────
+REVOKE EXECUTE ON FUNCTION public.grant_free_pro(uuid)                       FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.revoke_free_pro(uuid)                      FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.consume_rate_limit(text, integer, integer) FROM anon, authenticated;
+
+-- ─── Trigger-only functions: invoked by the trigger system as the ──
+-- table owner, never via RPC (a direct call errors — `new`/`tg_*` are
+-- unassigned outside trigger context). Postgres does not check the
+-- triggering user's EXECUTE privilege, so revoking is safe.
+REVOKE EXECUTE ON FUNCTION public.check_spec_mismatch()              FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.log_distribution_initial_status()  FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.log_distribution_status_change()   FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_feature_submission_status() FROM anon, authenticated;
+-- NOTE: handle_new_user() (the auth.users signup trigger) retains a
+-- legacy PUBLIC grant and still shows as anon-executable. Left as-is:
+-- it's non-exploitable (direct RPC errors — no `new` record), and it's
+-- the signup path, so we don't risk it for a cosmetic advisor item.
+REVOKE EXECUTE ON FUNCTION public.handle_new_user()                  FROM anon, authenticated;
+
+-- ─── App functions called by signed-in users (keep authenticated), ──
+-- never by anon → revoke anon only.
+REVOKE EXECUTE ON FUNCTION public.can_create_release(uuid)     FROM anon;
+REVOKE EXECUTE ON FUNCTION public.upvote_feature_request(uuid) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.claim_pending_invites()      FROM anon;
+REVOKE EXECUTE ON FUNCTION public.user_workspace_ids()         FROM anon;
+REVOKE EXECUTE ON FUNCTION public.owned_workspace_ids()        FROM anon;
+REVOKE EXECUTE ON FUNCTION public.get_user_display_name(uuid)  FROM anon;


### PR DESCRIPTION
## Summary

While applying migrations 063/064 to prod via the Supabase MCP, the security advisor surfaced — and I confirmed — that **every `SECURITY DEFINER` function was still callable by `anon`** despite prior `REVOKE ... FROM public` statements. Root cause: Supabase's project **default privileges grant `EXECUTE` to `anon`/`authenticated` directly**, so revoking from `public` never removed end-user access.

**Critical, live, exploitable:** `grant_free_pro(p_user_id)` (SECURITY DEFINER, inserts a `pro` / `granted_by_admin` subscription) was reachable at `POST /rest/v1/rpc/grant_free_pro` with the public in-browser anon key — anyone could grant any account free Pro. `revoke_free_pro` and `consume_rate_limit` were similarly exposed.

## Fix (already applied to prod; this captures it in source)

`REVOKE EXECUTE` on the SECURITY DEFINER functions from `anon`/`authenticated`:
- **Service-role-only** (revoke anon + authenticated): `grant_free_pro`, `revoke_free_pro`, `consume_rate_limit`.
- **Trigger-only** (revoke anon + authenticated; trigger firing doesn't need caller EXECUTE): `check_spec_mismatch`, `log_distribution_initial_status`, `log_distribution_status_change`, `notify_feature_submission_status`, `handle_new_user`.
- **App functions** (revoke anon, keep `authenticated`): `can_create_release`, `upvote_feature_request`, `claim_pending_invites`, `user_workspace_ids`, `owned_workspace_ids`, `get_user_display_name`.

Verified with `has_function_privilege`: `anon=false` after, `service_role` retained throughout, `authenticated` retained where the app needs it.

## Notes
- `handle_new_user()` (signup trigger) retains a legacy `PUBLIC` grant so still shows anon-executable, but it's **non-exploitable** (trigger-only — a direct RPC call errors with no `new` record). Left untouched to avoid any risk to the signup path for a cosmetic advisor item.
- Broader pre-existing advisor items not addressed here (out of scope): `changelog_suggesters` SECURITY DEFINER view, mutable `search_path` on a few `*_updated_at` trigger fns, `email_log`/`admin_*` RLS-enabled-no-policy (intentional, service-role-only), leaked-password-protection auth setting. Happy to do a follow-up pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)