### PR TITLE
Studio Session 9: three-tier pricing + in-app Studio purchase

### DIFF
--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -17,7 +17,7 @@ import { Rule } from "@/components/ui/rule";
 import { TagInput } from "@/components/ui/tag-input";
 import { AutoSaveIndicator } from "@/components/ui/auto-save-indicator";
 import { useSubscription } from "@/lib/subscription-context";
-import { hasProAccess } from "@/lib/entitlements";
+import { hasProAccess, isStudio } from "@/lib/entitlements";
 import { PortalBrandingCard } from "@/components/settings/portal-branding-card";
 import { useUnsavedChanges } from "@/hooks/use-unsaved-changes";
 import { useFeatureVisibility } from "@/lib/features/feature-visibility-context";
@@ -866,28 +866,33 @@ function SubscriptionPanel() {
   const t = useTranslations("settings.subscription");
   const tc = useTranslations("common");
   const sub = useSubscription();
-  const [upgrading, setUpgrading] = useState(false);
+  const [upgradingPlan, setUpgradingPlan] = useState<null | "pro" | "studio">(null);
   const [managingBilling, setManagingBilling] = useState(false);
 
   const isPro = hasProAccess(sub.plan, sub.status);
+  const onStudio = isStudio(sub.plan);
   const isCanceling = isPro && sub.cancelAtPeriodEnd;
   const isAdminGranted = sub.grantedByAdmin;
 
-  async function handleUpgrade() {
-    setUpgrading(true);
+  async function handleUpgrade(plan: "pro" | "studio") {
+    setUpgradingPlan(plan);
     try {
-      const res = await fetch("/api/stripe/checkout", { method: "POST" });
+      const res = await fetch("/api/stripe/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan }),
+      });
       const data = await res.json();
       if (data.url) {
-        trackGA4Event("checkout_start", { plan: "monthly" });
+        trackGA4Event("checkout_start", { plan });
         window.location.href = data.url;
       } else {
         console.error("[settings] checkout error:", data.error);
-        setUpgrading(false);
+        setUpgradingPlan(null);
       }
     } catch (err) {
       console.error("[settings] checkout failed:", err);
-      setUpgrading(false);
+      setUpgradingPlan(null);
     }
   }
 
@@ -932,7 +937,7 @@ function SubscriptionPanel() {
             )}
             <div>
               <div className="text-sm font-semibold text-text">
-                {isPro ? t("pro") : t("free")}
+                {onStudio ? t("studio") : isPro ? t("pro") : t("free")}
                 {isAdminGranted && (
                   <span className="ml-1.5 text-xs font-medium text-signal">{t("complimentary")}</span>
                 )}
@@ -941,7 +946,9 @@ function SubscriptionPanel() {
                 {isPro
                   ? isAdminGranted
                     ? t("unlimitedReleases")
-                    : t("proPrice")
+                    : onStudio
+                      ? t("studioPrice")
+                      : t("proPrice")
                   : t("freeLimit")}
               </div>
             </div>
@@ -955,7 +962,7 @@ function SubscriptionPanel() {
               color: isPro ? "var(--signal-on)" : "var(--muted)",
             }}
           >
-            {isPro ? "PRO" : "FREE"}
+            {onStudio ? "STUDIO" : isPro ? "PRO" : "FREE"}
           </span>
         </div>
 
@@ -977,12 +984,27 @@ function SubscriptionPanel() {
 
         {/* Actions */}
         {!isPro && (
-          <Button variant="primary" onClick={handleUpgrade} disabled={upgrading}>
-            <Sparkles size={16} />
-            {upgrading ? tc("redirecting") : t("upgradeToPro")}
-          </Button>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Button
+              variant="primary"
+              onClick={() => handleUpgrade("pro")}
+              disabled={upgradingPlan !== null}
+            >
+              <Sparkles size={16} />
+              {upgradingPlan === "pro" ? tc("redirecting") : t("upgradeToPro")}
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => handleUpgrade("studio")}
+              disabled={upgradingPlan !== null}
+            >
+              {upgradingPlan === "studio" ? tc("redirecting") : t("upgradeToStudio")}
+            </Button>
+          </div>
         )}
 
+        {/* Pro→Studio switching goes through the billing portal to avoid a
+            second subscription; a dedicated in-app upgrade is a follow-up. */}
         {isPro && !isAdminGranted && (
           <Button variant="secondary" onClick={handleManageBilling} disabled={managingBilling}>
             <CreditCard size={16} />

--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -164,9 +164,23 @@ export function Pricing() {
     t("pricingProF7"), t("pricingProF8"),
   ];
 
+  const studioPrice =
+    interval === "annual"
+      ? `$${PRICING.STUDIO.annualMonthlyEquivalent}`
+      : `$${PRICING.STUDIO.monthlyPrice}`;
+  const studioAnnualNote =
+    interval === "annual"
+      ? t("billedAnnually", { price: PRICING.STUDIO.annualPrice })
+      : undefined;
+  const studioFeatures = [
+    t("pricingStudioF1"), t("pricingStudioF2"), t("pricingStudioF3"),
+    t("pricingStudioF4"), t("pricingStudioF5"), t("pricingStudioF6"),
+    t("pricingStudioF7"),
+  ];
+
   return (
     <section id="pricing" aria-labelledby="pricing-heading" className="px-6 py-12 md:py-20">
-      <div className="mx-auto max-w-4xl">
+      <div className="mx-auto max-w-6xl">
         <div className="text-center mb-12">
           <h2 id="pricing-heading" className="text-3xl md:text-4xl font-bold text-white">
             {t("pricingHeadline")}
@@ -186,7 +200,7 @@ export function Pricing() {
           }}
         />
 
-        <div className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-6 md:grid-cols-3">
           <PriceCard
             title="FREE"
             price={`$${PRICING.FREE.monthlyPrice}`}
@@ -203,6 +217,15 @@ export function Pricing() {
             ctaLabel={t("startPro")}
             highlighted
             annualNote={annualNote}
+          />
+          <PriceCard
+            title="STUDIO"
+            price={studioPrice}
+            period={t("perMonth")}
+            subtitle={t("pricingStudioDesc")}
+            features={studioFeatures}
+            ctaLabel={t("startStudio")}
+            annualNote={studioAnnualNote}
           />
         </div>
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -694,6 +694,9 @@
       "freeLimit": "1 release included",
       "cancelNote": "Your Pro plan will end on {date}. You can resubscribe from Manage Billing.",
       "upgradeToPro": "Upgrade to Pro",
+      "upgradeToStudio": "Upgrade to Studio",
+      "studio": "Studio",
+      "studioPrice": "$39/month, unlimited team members",
       "manageBilling": "Manage Billing"
     }
   },
@@ -899,6 +902,15 @@
     "pricingProF6": "Payment tracking with export",
     "pricingProF7": "Multi-project dashboard",
     "pricingProF8": "Priority support",
+    "pricingStudioDesc": "A white-labeled studio with your whole team",
+    "pricingStudioF1": "Unlimited team members",
+    "pricingStudioF2": "Everything in Pro, plus:",
+    "pricingStudioF3": "Full white-label client portal",
+    "pricingStudioF4": "Custom portal domain",
+    "pricingStudioF5": "Branded email sender",
+    "pricingStudioF6": "Shared client roster & releases",
+    "pricingStudioF7": "Member roles & permissions",
+    "startStudio": "Start Studio",
 
     "testimonialsHeadline": "Trusted by engineers and artists",
     "testimonial1Quote": "I used to lose track of revisions across email threads and Dropbox folders. Now every mix note, reference, and approval lives in one place.",

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -55,8 +55,42 @@ export default getRequestConfig(async () => {
 
   const messageFile = getMessageFile(locale);
 
+  // Deep-merge the requested locale's messages over the English source so
+  // any key missing from a translation falls back to English instead of
+  // rendering as a raw key path. en is the source of truth; locale values
+  // always win per-leaf.
+  const enMessages = (await import("./messages/en.json")).default;
+  const localeMessages =
+    messageFile === "en"
+      ? enMessages
+      : (await import(`./messages/${messageFile}.json`)).default;
+
   return {
     locale,
-    messages: (await import(`./messages/${messageFile}.json`)).default,
+    messages: deepMergeMessages(
+      enMessages as MessageTree,
+      localeMessages as MessageTree,
+    ),
   };
 });
+
+type MessageTree = { [key: string]: string | MessageTree };
+
+/** Recursively overlay `override` onto `base`; leaf values in `override` win. */
+function deepMergeMessages(base: MessageTree, override: MessageTree): MessageTree {
+  const out: MessageTree = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    const existing = out[key];
+    if (
+      value &&
+      typeof value === "object" &&
+      existing &&
+      typeof existing === "object"
+    ) {
+      out[key] = deepMergeMessages(existing, value);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Makes Studio **purchasable** and updates the pricing surfaces to three tiers.

### Landing pricing page (`components/landing/pricing.tsx`)
Free / Pro / Studio (was two-tier). Studio card with its full feature set; monthly/annual toggle prices it correctly. Pro stays the highlighted "recommended" card; Studio's higher price anchors it. **Verified in a local preview** — screenshot below shows all three cards; annual toggle confirmed (Pro $10.75/mo·$129/yr, Studio $32.50/mo·$390/yr).

### In-app purchase (Settings → Subscription)
- **Free users get two checkout buttons** — *Upgrade to Pro* and *Upgrade to Studio* — each POSTing `{plan}` to `/api/stripe/checkout` (the Session 2 backend). This is what actually makes Studio buyable.
- Plan label + badge now render Studio (`STUDIO`, `$39/mo` line).
- **Pro→Studio is intentionally routed through the billing portal** (Manage Billing), *not* a fresh checkout — a new checkout for an existing subscriber would create a **second subscription**. A dedicated in-app plan-switch (`stripe.subscriptions.update`) is a follow-up.

### i18n
- Studio strings added to `en.json` (source of truth).
- **Also added an English fallback in `i18n/request.ts`** — the app had *no* fallback, so any key missing from a locale rendered as a raw key path. Now each locale deep-merges over `en`, so the new Studio strings (and any future gaps) fall back to English instead of breaking. ⚠️ The 10 non-en locales still need a proper Studio translation pass.

## Verified
- `tsc` + `next build` clean.
- Local preview: 3 cards render, correct monthly + annual prices, on-brand (dark/teal/Geist/flat).

## Follow-ups
- Translate Studio strings into the 10 non-en locales.
- Pro→Studio in-app plan switch (currently via billing portal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)