### PR TITLE
Auto-notifications: comp grant (user) + new signup (admins)

### DIFF
--- a/src/app/api/admin/comp-account/route.ts
+++ b/src/app/api/admin/comp-account/route.ts
@@ -6,6 +6,55 @@ import { logActivity } from "@/lib/activity-logger";
 import { logAdminAction } from "@/lib/admin-audit-logger";
 import { dbRateLimit, getClientIp } from "@/lib/rate-limit";
 import { requireSameOrigin } from "@/lib/origin-check";
+import { createNotification } from "@/lib/notifications/service";
+import {
+  sendTransactionalEmail,
+  buildUnsubscribeUrl,
+  getUserEmail,
+  getUserDisplayName,
+} from "@/lib/email/service";
+import { buildCompGrantedEmail } from "@/lib/email-templates/transactional";
+
+/**
+ * Notify a user that they've been granted a complimentary Pro account:
+ * an in-app notification + a confirmation email. Never throws — a
+ * notification failure must not fail the grant itself.
+ */
+async function notifyCompGranted(userId: string) {
+  try {
+    await createNotification({
+      userId,
+      type: "payment_update",
+      title: "Complimentary Pro unlocked",
+      body: "An admin upgraded your account to Pro — unlimited releases and all Pro features are now active.",
+    });
+
+    const email = await getUserEmail(userId);
+    if (!email) return;
+    const displayName = await getUserDisplayName(userId);
+
+    const svc = createSupabaseServiceClient();
+    const { data: prefs } = await svc
+      .from("email_preferences")
+      .select("unsubscribe_token")
+      .eq("user_id", userId)
+      .maybeSingle();
+    const unsubscribeUrl = prefs?.unsubscribe_token
+      ? buildUnsubscribeUrl(prefs.unsubscribe_token, "subscription_confirmed")
+      : undefined;
+
+    const { subject, html } = buildCompGrantedEmail({ displayName, unsubscribeUrl });
+    await sendTransactionalEmail({
+      userId,
+      to: email,
+      category: "subscription_confirmed",
+      subject,
+      html,
+    });
+  } catch (err) {
+    console.error("[admin/comp-account] grant notification failed (non-fatal):", err);
+  }
+}
 
 /**
  * POST /api/admin/comp-account
@@ -96,6 +145,10 @@ export async function POST(req: NextRequest) {
         duration: duration || "indefinite",
         expires_at: expiresAt || undefined,
       }, { ip: getClientIp(req), userAgent: req.headers.get("user-agent") ?? undefined });
+
+      // Notify the user (in-app + email). Awaited so the email send isn't
+      // killed when the handler returns; non-fatal on failure.
+      await notifyCompGranted(userId);
     } else {
       // Revoke: set plan back to free
       const { error } = await serviceClient

--- a/src/app/api/admin/log-activity/route.ts
+++ b/src/app/api/admin/log-activity/route.ts
@@ -3,9 +3,48 @@ import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { logActivity, type ActivityEventType } from "@/lib/activity-logger";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { requireSameOrigin } from "@/lib/origin-check";
-import { sendTransactionalEmail, buildUnsubscribeUrl } from "@/lib/email/service";
+import { sendTransactionalEmail, buildUnsubscribeUrl, getUserEmail } from "@/lib/email/service";
 import { buildWelcomeEmail } from "@/lib/email-templates/transactional";
+import { buildAdminEmail } from "@/lib/email-templates/admin-notification";
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+
+/**
+ * Email all admins that a new user signed up. Internal ops alert — sent
+ * directly (not through the user-preference system), never throws.
+ */
+async function notifyAdminsOfSignup(newUserEmail: string, newUserName: string) {
+  try {
+    const key = process.env.RESEND_API_KEY;
+    if (!key) return;
+    const svc = createSupabaseServiceClient();
+    const { data: admins } = await svc.from("profiles").select("id").eq("is_admin", true);
+    if (!admins || admins.length === 0) return;
+
+    const emails = (
+      await Promise.all(admins.map((a) => getUserEmail(a.id as string)))
+    ).filter((e): e is string => !!e);
+    if (emails.length === 0) return;
+
+    const { Resend } = require("resend") as typeof import("resend");
+    const resend = new Resend(key);
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://mixarchitect.com";
+    const { subject, html } = buildAdminEmail({
+      subject: `New signup: ${newUserEmail}`,
+      heading: "New user signed up",
+      body: `${newUserName} (${newUserEmail}) just created a Mix Architect account.`,
+      ctaLabel: "View subscribers",
+      ctaUrl: `${appUrl}/admin/subscribers`,
+    });
+    await resend.emails.send({
+      from: "Mix Architect <team@mixarchitect.com>",
+      to: emails,
+      subject,
+      html,
+    });
+  } catch (err) {
+    console.error("[log-activity] admin signup alert failed (non-fatal):", err);
+  }
+}
 
 const ALLOWED_EVENTS: Set<string> = new Set([
   "login",
@@ -50,48 +89,44 @@ export async function POST(req: NextRequest) {
 
     logActivity(user.id, eventType as ActivityEventType, metadata, { ip: getClientIp(req), userAgent: req.headers.get("user-agent") ?? undefined });
 
-    // Send welcome email on signup (fire-and-forget)
+    // Signup side effects: welcome email to the user + admin alert.
+    // Awaited (not fire-and-forget) so Vercel doesn't terminate the sends
+    // when the handler returns.
     if (eventType === "signup" && user.email) {
-      (async () => {
-        try {
-          const svc = createSupabaseServiceClient();
+      const displayName =
+        user.user_metadata?.display_name ?? user.email.split("@")[0];
 
-          // Ensure email_preferences row exists for this new user
-          await svc
-            .from("email_preferences")
-            .upsert({ user_id: user.id }, { onConflict: "user_id" });
+      // Welcome email to the new user.
+      try {
+        const svc = createSupabaseServiceClient();
+        await svc
+          .from("email_preferences")
+          .upsert({ user_id: user.id }, { onConflict: "user_id" });
 
-          // Get unsubscribe token
-          const { data: prefs } = await svc
-            .from("email_preferences")
-            .select("unsubscribe_token")
-            .eq("user_id", user.id)
-            .maybeSingle();
+        const { data: prefs } = await svc
+          .from("email_preferences")
+          .select("unsubscribe_token")
+          .eq("user_id", user.id)
+          .maybeSingle();
 
-          const unsubscribeUrl = prefs?.unsubscribe_token
-            ? buildUnsubscribeUrl(prefs.unsubscribe_token, "welcome")
-            : undefined;
+        const unsubscribeUrl = prefs?.unsubscribe_token
+          ? buildUnsubscribeUrl(prefs.unsubscribe_token, "welcome")
+          : undefined;
 
-          const displayName =
-            user.user_metadata?.display_name ??
-            user.email!.split("@")[0];
+        const { subject, html } = buildWelcomeEmail({ displayName, unsubscribeUrl });
+        await sendTransactionalEmail({
+          userId: user.id,
+          to: user.email,
+          category: "welcome",
+          subject,
+          html,
+        });
+      } catch (err) {
+        console.error("[log-activity] welcome email error:", err);
+      }
 
-          const { subject, html } = buildWelcomeEmail({
-            displayName,
-            unsubscribeUrl,
-          });
-
-          await sendTransactionalEmail({
-            userId: user.id,
-            to: user.email!,
-            category: "welcome",
-            subject,
-            html,
-          });
-        } catch (err) {
-          console.error("[log-activity] welcome email error:", err);
-        }
-      })();
+      // Alert admins that a new user joined.
+      await notifyAdminsOfSignup(user.email, displayName);
     }
 
     return NextResponse.json({ ok: true });

--- a/src/lib/email-templates/transactional.ts
+++ b/src/lib/email-templates/transactional.ts
@@ -349,3 +349,31 @@ export function buildSubscriptionCancelledEmail({
     ),
   };
 }
+
+// ─── 9. Complimentary Pro granted (admin comp) ───────────────────────
+
+export function buildCompGrantedEmail({
+  displayName,
+  unsubscribeUrl,
+}: {
+  displayName: string;
+  unsubscribeUrl?: string;
+}) {
+  return {
+    subject: "You've been upgraded to Mix Architect Pro",
+    html: wrap(
+      `
+      ${heading("Complimentary Pro unlocked")}
+      ${paragraph(`Hi ${escapeHtml(displayName)}, we've upgraded your account to Mix Architect Pro — on us. Here's what's now unlocked:`)}
+      <ul style="margin:8px 0 16px;padding-left:20px;font-size:14px;color:#666;line-height:1.8">
+        <li>Unlimited releases and tracks</li>
+        <li>Web-based client delivery portal</li>
+        <li>Release templates &amp; payment tracking</li>
+        <li>Priority support</li>
+      </ul>
+      ${cta("Open Mix Architect", "https://mixarchitect.com/app")}
+    `,
+      unsubscribeUrl,
+    ),
+  };
+}


### PR DESCRIPTION
## Summary
Two requested auto-notifications, both pure code (no schema changes).

### 1. Admin grants a comp → notify the user
In `POST /api/admin/comp-account` (action=grant), after the grant succeeds:
- **In-app notification** to the user (`payment_update` type — renders in the bell with the billing icon, no nav needed).
- **Confirmation email** — new `buildCompGrantedEmail` template ("Complimentary Pro unlocked"), sent through the transactional pipeline under the existing `subscription_confirmed` category so preferences / unsubscribe / `email_log` all work with no new column.
- Awaited (so the send isn't killed on return) and wrapped non-fatal (a notify failure never fails the grant).

### 2. New user signs up → email the admins
In `POST /api/admin/log-activity` (signup):
- Emails **all admins** (`profiles.is_admin = true`) an internal alert via Resend (`buildAdminEmail`), linking to `/admin/subscribers`.
- Also flips the existing **welcome email** from fire-and-forget → awaited, so it and the admin alert reliably complete on Vercel.

## Notes
- Comp email rides the `subscription_confirmed` preference, so a user who unsubscribed from that won't get the email — but still gets the in-app notification. Reasonable; fl/no schema churn.
- "Email me" = every admin account. Today that's you; if you add admins they'd be alerted too.

## Test plan
- [ ] Grant a comp to a test user → they get a bell notification + an email.
- [ ] Sign up a fresh account → admin inbox gets a "New signup" email; the new user still gets their welcome email.

Verified: `tsc` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)