### PR TITLE
Admin MRR: exclude comps, include Studio

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -29,6 +29,7 @@ import {
 export const dynamic = "force-dynamic";
 
 const PRO_PRICE = 14; // $14/month
+const STUDIO_PRICE = 39; // $39/month
 
 const currencyFmt = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -210,8 +211,21 @@ export default async function AdminDashboard({ searchParams }: Props) {
   const newSignups = signupsRes.count ?? 0;
   const events = activityRes.count ?? 0;
 
-  // MRR (always current)
-  const mrr = activePro * PRO_PRICE;
+  // MRR (always current). Count only PAYING subscribers — exclude
+  // admin-granted comps (no revenue) and test accounts — and price each
+  // tier. (The Pro headcount above still includes comps; they're also
+  // listed on the comp-accounts page.)
+  let payingQ = supabase
+    .from("subscriptions")
+    .select("plan")
+    .eq("status", "active")
+    .eq("granted_by_admin", false)
+    .in("plan", ["pro", "studio"]);
+  if (testIds.length > 0) payingQ = payingQ.not("user_id", "in", `(${testIds.join(",")})`);
+  const { data: payingRows } = await payingQ;
+  const payingPro = (payingRows ?? []).filter((r) => r.plan === "pro").length;
+  const payingStudio = (payingRows ?? []).filter((r) => r.plan === "studio").length;
+  const mrr = payingPro * PRO_PRICE + payingStudio * STUDIO_PRICE;
 
   // Churn rate for selected period
   const periodStartSubs = activePro + cancellations;


### PR DESCRIPTION
## Summary
Fixes the reported bug: granting a comp Pro account added \$14 to dashboard **MRR** even though comps generate no revenue.

MRR was `activePro * \$14`, and `activePro` counts *all* active Pro subs including `granted_by_admin = true` comps. It also never counted Studio subscriptions.

**Now:** MRR counts only paying subscribers (`status = active`, `granted_by_admin = false`, excluding test accounts), priced per tier — `payingPro * \$14 + payingStudio * \$39`.

## Scope
Surgical — MRR only. The "Pro subscribers" headcount + conversion-rate stats still include comps (comps are listed separately on the comp-accounts page). Say the word and I'll make those paid-only too for consistency.

## Test plan
- [ ] A comp Pro account no longer contributes to MRR.
- [ ] A real paying Pro contributes \$14; a paying Studio contributes \$39.

Verified: `tsc` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)