### PR TITLE
Studio A1: hide Powered-by banner for Studio (full white-label)

### DIFF
--- a/src/app/portal/[shareToken]/page.tsx
+++ b/src/app/portal/[shareToken]/page.tsx
@@ -1,6 +1,6 @@
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { signAudioVersions } from "@/lib/storage-urls";
-import { isAtLeastPro } from "@/lib/entitlements";
+import { isAtLeastPro, getEntitlements } from "@/lib/entitlements";
 import { notFound } from "next/navigation";
 import { PortalClient } from "./portal-client";
 import type { Metadata } from "next";
@@ -194,6 +194,7 @@ export default async function PortalPage({ params }: Props) {
 
   let portalAccent: string | null = null;
   let portalLogoUrl: string | null = null;
+  let removePoweredBy = false;
   if (release.workspace_id) {
     const [{ data: ws }, { data: branding }] = await Promise.all([
       supabase.from("workspaces").select("plan").eq("id", release.workspace_id).maybeSingle(),
@@ -213,6 +214,9 @@ export default async function PortalPage({ params }: Props) {
           .getPublicUrl(branding.logo_path).data.publicUrl;
       }
     }
+    // Studio is fully white-labeled — drop the "Powered by" banner.
+    // (Resolved from entitlements, independent of whether branding is set.)
+    if (ws) removePoweredBy = getEntitlements(ws.plan).removePoweredBy;
   }
 
   /* ── 5. Build visibility + approval maps ──────────────────────── */
@@ -377,6 +381,7 @@ export default async function PortalPage({ params }: Props) {
       hasStripeConnected={hasStripeConnected}
       accentColor={portalAccent}
       logoUrl={portalLogoUrl}
+      removePoweredBy={removePoweredBy}
     />
   );
 }

--- a/src/app/portal/[shareToken]/portal-client.tsx
+++ b/src/app/portal/[shareToken]/portal-client.tsx
@@ -37,6 +37,8 @@ type PortalClientProps = {
   accentColor?: string | null;
   /** Workspace logo URL (Pro/Studio branding), or null. */
   logoUrl?: string | null;
+  /** Studio workspaces hide the "Powered by Mix Architect" banner. */
+  removePoweredBy?: boolean;
 };
 
 export function PortalClient({
@@ -50,6 +52,7 @@ export function PortalClient({
   hasStripeConnected = false,
   accentColor = null,
   logoUrl = null,
+  removePoweredBy = false,
 }: PortalClientProps) {
   const [tracks, setTracks] = useState(initialTracks);
 
@@ -190,6 +193,7 @@ export function PortalClient({
           tracks={tracks}
           engineerName={release.engineer_name}
           paymentGated={paymentGated}
+          removePoweredBy={removePoweredBy}
         />
       </div>
 

--- a/src/components/portal/portal-footer.tsx
+++ b/src/components/portal/portal-footer.tsx
@@ -10,6 +10,8 @@ type PortalFooterProps = {
   tracks: PortalTrack[];
   engineerName: string | null;
   paymentGated: boolean;
+  /** Studio workspaces are fully white-labeled — hide the Powered-by banner. */
+  removePoweredBy: boolean;
 };
 
 function formatCurrency(amount: number, currency: string) {
@@ -27,6 +29,7 @@ export function PortalFooter({
   tracks,
   engineerName,
   paymentGated,
+  removePoweredBy,
 }: PortalFooterProps) {
   const hasPaymentData =
     showPayment &&
@@ -192,8 +195,11 @@ export function PortalFooter({
         </div>
       )}
 
-      {/* Powered by footer with attribution tracking */}
-      <PoweredByBanner engineerId={release.engineer_id} />
+      {/* Powered by footer with attribution tracking. Hidden for Studio
+          workspaces (full white-label). */}
+      {!removePoweredBy && (
+        <PoweredByBanner engineerId={release.engineer_id} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What
Studio is advertised as "full white-label," but the `removePoweredBy` entitlement was **defined and never consumed** — every client portal rendered "Powered by Mix Architect," Studio included.

## Change
- The portal page resolves `removePoweredBy` from the workspace's plan via `getEntitlements(ws.plan)` — the same spot Session 5 resolves branding (`isAtLeastPro(ws.plan)`).
- Threads the flag through `PortalClient` → `PortalFooter`, which now hides `<PoweredByBanner>` for Studio. Free/Pro unchanged.

## Context
This is **A1** of the "finish Studio" plan (the deferred Session 7). Next: A2 (team access / RLS cutover — design first), A3 (invites/roles UI), A4 (branded email), A5 (custom domain).

## Test plan
- [x] tsc clean; no new lint
- [ ] Studio workspace portal → no "Powered by" banner
- [ ] Free/Pro workspace portal → banner still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)