### PR TITLE
Studio A2 Phase 1: workspace-membership release access (additive)

### DIFF
--- a/supabase/migrations/067_workspace_release_access.sql
+++ b/supabase/migrations/067_workspace_release_access.sql
@@ -1,0 +1,44 @@
+-- 067_workspace_release_access.sql
+-- Studio A2 — Phase 1: workspace-membership release access (ADDITIVE).
+--
+-- Adds a third access path to accessible_release_ids(): a member of a release's
+-- workspace can access that release, with read/write gated by their workspace
+-- role. This is the keystone of Studio teams — almost every release-scoped RLS
+-- policy funnels through this one function, so this single change cascades to
+-- releases, tracks, all track_*, portal_*, brief_shares, distribution, etc.
+--
+-- ADDITIVE / NO-OP for current data: every user is a workspace-of-one today, so
+-- the new branch returns only releases the user already owns. It grants no new
+-- access until a second member joins a workspace (A3 invites). Verified by the
+-- read-only proof in the PR (zero new (user, release) access pairs on prod).
+--
+-- Role gate: viewer = read-only (returned for p_min_role = 'client' only);
+-- owner/admin/engineer = read + write (returned for 'client' and 'collaborator').
+-- The existing owner + per-release release_members paths are unchanged.
+--
+-- SECURITY DEFINER + locked search_path are preserved: the function reads
+-- releases/workspace_members as the definer, bypassing RLS, so it cannot recurse
+-- into the very policies that call it.
+
+CREATE OR REPLACE FUNCTION public.accessible_release_ids(p_min_role text DEFAULT 'client'::text)
+ RETURNS SETOF uuid
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'pg_catalog', 'public'
+AS $function$
+  -- 1. Releases you own.
+  SELECT id FROM releases WHERE user_id = (select auth.uid())
+  UNION ALL
+  -- 2. Releases shared with you per-release (release_members).
+  SELECT release_id FROM release_members
+  WHERE user_id = (select auth.uid())
+    AND accepted_at IS NOT NULL
+    AND (p_min_role = 'client' OR role = 'collaborator')
+  UNION ALL
+  -- 3. Releases in workspaces you belong to (Studio teams).
+  SELECT r.id FROM releases r
+  JOIN workspace_members wm ON wm.workspace_id = r.workspace_id
+  WHERE wm.user_id = (select auth.uid())
+    AND wm.accepted_at IS NOT NULL
+    AND (p_min_role = 'client' OR wm.role IN ('owner', 'admin', 'engineer'))
+$function$;

--- a/supabase/tests/067_workspace_release_access_test.sql
+++ b/supabase/tests/067_workspace_release_access_test.sql
@@ -31,10 +31,10 @@ BEGIN
 
   -- Fixture: one Studio workspace, three members, one release in it.
   INSERT INTO workspaces (id, owner_user_id, name, plan) VALUES (ws, u_owner, 'TEST WS', 'studio');
-  INSERT INTO workspace_members (workspace_id, user_id, role, accepted_at) VALUES
-    (ws, u_owner,    'owner',    now()),
-    (ws, u_viewer,   'viewer',   now()),
-    (ws, u_engineer, 'engineer', now());
+  INSERT INTO workspace_members (workspace_id, user_id, invited_email, role, accepted_at) VALUES
+    (ws, u_owner,    'owner@test.local',    'owner',    now()),
+    (ws, u_viewer,   'viewer@test.local',   'viewer',   now()),
+    (ws, u_engineer, 'engineer@test.local', 'engineer', now());
   INSERT INTO releases (id, user_id, workspace_id, title) VALUES (rel, u_owner, ws, 'TEST REL');
 
   -- Impersonation: accessible_release_ids() is SECURITY DEFINER and reads auth.uid(),

--- a/supabase/tests/067_workspace_release_access_test.sql
+++ b/supabase/tests/067_workspace_release_access_test.sql
@@ -1,0 +1,65 @@
+-- 067_workspace_release_access_test.sql
+-- Cross-workspace denial + role matrix for accessible_release_ids() (Studio A2, Phase 1).
+--
+-- SAFE: the whole thing runs in one transaction and ROLLS BACK — no data persists.
+-- It uses existing auth.users as actors (no auth.users inserts → no signup-trigger noise).
+-- Requires migration 067 to be applied first.
+--
+-- Run:  psql "$DATABASE_URL" -f supabase/tests/067_workspace_release_access_test.sql
+--   or paste into the Supabase SQL editor (ideally on a dev branch).
+-- A failing ASSERT aborts with the message; success prints the PASS notice.
+
+BEGIN;
+
+DO $$
+DECLARE
+  u_owner    uuid;
+  u_viewer   uuid;
+  u_engineer uuid;
+  u_outsider uuid;
+  ws  uuid := gen_random_uuid();
+  rel uuid := gen_random_uuid();
+BEGIN
+  -- Four distinct real users as actors.
+  SELECT id INTO u_owner    FROM auth.users ORDER BY created_at LIMIT 1;
+  SELECT id INTO u_viewer   FROM auth.users WHERE id <> u_owner ORDER BY created_at LIMIT 1;
+  SELECT id INTO u_engineer FROM auth.users WHERE id NOT IN (u_owner, u_viewer) ORDER BY created_at LIMIT 1;
+  SELECT id INTO u_outsider FROM auth.users WHERE id NOT IN (u_owner, u_viewer, u_engineer) ORDER BY created_at LIMIT 1;
+  IF u_outsider IS NULL THEN
+    RAISE EXCEPTION 'Need at least 4 users in auth.users to run this test';
+  END IF;
+
+  -- Fixture: one Studio workspace, three members, one release in it.
+  INSERT INTO workspaces (id, owner_user_id, name, plan) VALUES (ws, u_owner, 'TEST WS', 'studio');
+  INSERT INTO workspace_members (workspace_id, user_id, role, accepted_at) VALUES
+    (ws, u_owner,    'owner',    now()),
+    (ws, u_viewer,   'viewer',   now()),
+    (ws, u_engineer, 'engineer', now());
+  INSERT INTO releases (id, user_id, workspace_id, title) VALUES (rel, u_owner, ws, 'TEST REL');
+
+  -- Impersonation: accessible_release_ids() is SECURITY DEFINER and reads auth.uid(),
+  -- which resolves from request.jwt.claims->>'sub'. set_config(..., true) is txn-local.
+
+  -- viewer → read-only
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', u_viewer)::text, true);
+  ASSERT      rel IN (SELECT accessible_release_ids('client')),       'viewer should READ the workspace release';
+  ASSERT NOT (rel IN (SELECT accessible_release_ids('collaborator'))),'viewer should NOT WRITE (read-only)';
+
+  -- engineer → read + write
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', u_engineer)::text, true);
+  ASSERT rel IN (SELECT accessible_release_ids('client')),       'engineer should READ';
+  ASSERT rel IN (SELECT accessible_release_ids('collaborator')), 'engineer should WRITE';
+
+  -- outsider → no membership → isolation
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', u_outsider)::text, true);
+  ASSERT NOT (rel IN (SELECT accessible_release_ids('client'))), 'outsider must NOT see another workspace''s release';
+
+  -- unaccepted invite → no access
+  UPDATE workspace_members SET accepted_at = NULL WHERE workspace_id = ws AND user_id = u_viewer;
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', u_viewer)::text, true);
+  ASSERT NOT (rel IN (SELECT accessible_release_ids('client'))), 'unaccepted member must NOT have access';
+
+  RAISE NOTICE 'PASS — read/write by role, cross-workspace isolation, unaccepted-invite denial.';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## What
Keystone of Studio teams. Rewrites `accessible_release_ids()` to grant access to **every release in a workspace you belong to**, read/write gated by your workspace role. ~60 release-scoped RLS policies funnel through this one function, so it cascades everywhere — no per-policy edits.

| workspace role | capability |
|---|---|
| owner / admin / engineer | read + write |
| viewer | read only |

## Why it's safe to ship now (additive / no-op)
Every user is a workspace-of-one today, so the new branch returns only releases they already own. **Proven against prod:**
```
workspaces: 6 · members: 6 · multi_member_workspaces: 0 · new_access_pairs: 0
```
Zero new (user, release) access. It stays inert until A3 adds a second member.

## Verification
`supabase/tests/067_workspace_release_access_test.sql` — a **rollback-safe** matrix (no data persists): viewer reads / can't write, engineer reads+writes, outsider denied (isolation), unaccepted invite denied. Run after applying 067.

## Not in this PR
- Phase 2: relax `releases_update` WITH CHECK + delete/member-management for workspace write-roles.
- Phase 3: workspace-scope `saved_contacts` / `quotes` / `release_templates` (shared roster).
- A3: invite/accept + member-management UI (what makes teams user-visible).

Design: `.claude/plans/studio-a2-team-rls-cutover.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)