### PR TITLE
Studio A2 Phase 2: workspace write-roles edit/delete releases (069)

### DIFF
--- a/supabase/migrations/069_workspace_release_write.sql
+++ b/supabase/migrations/069_workspace_release_write.sql
@@ -1,0 +1,51 @@
+-- 069_workspace_release_write.sql
+-- Studio A2 Phase 2: let workspace write-roles edit releases, and owner/admin delete them.
+--
+-- Phase 1 (067) gave workspace members READ + (for write roles) write *visibility*
+-- via accessible_release_ids('collaborator'). But three policies still keyed on
+-- releases.user_id and blocked non-owner team members from actually mutating:
+--   * releases_update.WITH CHECK = (user_id = auth.uid()) — a non-owner edit keeps
+--     the owner's user_id on the row, so the check FAILED. Effectively owner-only
+--     edits despite the USING clause. (This was a latent bug even pre-teams.)
+--   * releases_delete = owner-only.
+--   * brief_shares_delete (portal shares) = owner-only, while insert/update already
+--     allow collaborators.
+--
+-- Role model (per A2 design): owner/admin/engineer = write; viewer = read;
+-- delete = owner/admin only.
+
+-- ── Helper: workspaces where the current user is owner or admin ──────────────
+-- (write + manage). Mirrors user_workspace_ids()/owned_workspace_ids(): SECURITY
+-- DEFINER + locked search_path, EXECUTE kept for authenticated, revoked for anon.
+CREATE OR REPLACE FUNCTION public.admin_workspace_ids()
+ RETURNS SETOF uuid
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'pg_catalog', 'public'
+AS $function$
+  SELECT workspace_id FROM workspace_members
+  WHERE user_id = (select auth.uid())
+    AND accepted_at IS NOT NULL
+    AND role IN ('owner', 'admin')
+$function$;
+REVOKE EXECUTE ON FUNCTION public.admin_workspace_ids() FROM anon;
+
+-- ── releases_update: fix the WITH CHECK so write-role members can edit ───────
+-- Mirror USING — the updated row must remain in the editor's write-accessible
+-- set (so they also can't move a release into a workspace they can't write).
+ALTER POLICY releases_update ON public.releases
+  WITH CHECK (id IN (SELECT accessible_release_ids('collaborator')));
+
+-- ── releases_delete: owner OR a workspace owner/admin ────────────────────────
+ALTER POLICY releases_delete ON public.releases
+  USING (
+    user_id = (select auth.uid())
+    OR workspace_id IN (SELECT admin_workspace_ids())
+  );
+
+-- ── brief_shares_delete: allow collaborators (align with insert/update) ──────
+ALTER POLICY brief_shares_delete ON public.brief_shares
+  USING (release_id IN (SELECT accessible_release_ids('collaborator')));
+
+-- ── Hygiene: the 068 trigger fn is trigger-only, never an RPC ────────────────
+REVOKE EXECUTE ON FUNCTION public.sync_workspace_plan_from_subscription() FROM anon, authenticated;

--- a/supabase/tests/069_workspace_release_write_test.sql
+++ b/supabase/tests/069_workspace_release_write_test.sql
@@ -1,0 +1,55 @@
+-- 069_workspace_release_write_test.sql
+-- A2 Phase 2: workspace write-roles can edit releases; viewers can't; owner/admin delete.
+-- SAFE: runs in one transaction and ROLLS BACK. Requires 067 + 069 applied.
+-- Switches to the `authenticated` role so RLS is actually enforced.
+-- Run: psql "$DATABASE_URL" -f supabase/tests/069_workspace_release_write_test.sql
+
+BEGIN;
+
+DO $$
+DECLARE
+  u_owner uuid; u_engineer uuid; u_viewer uuid; u_admin uuid;
+  ws uuid := gen_random_uuid(); rel uuid := gen_random_uuid();
+  n int;
+BEGIN
+  SELECT id INTO u_owner    FROM auth.users ORDER BY created_at LIMIT 1;
+  SELECT id INTO u_engineer FROM auth.users WHERE id <> u_owner ORDER BY created_at LIMIT 1;
+  SELECT id INTO u_viewer   FROM auth.users WHERE id NOT IN (u_owner, u_engineer) ORDER BY created_at LIMIT 1;
+  SELECT id INTO u_admin    FROM auth.users WHERE id NOT IN (u_owner, u_engineer, u_viewer) ORDER BY created_at LIMIT 1;
+  IF u_admin IS NULL THEN RAISE EXCEPTION 'Need at least 4 users in auth.users'; END IF;
+
+  INSERT INTO workspaces (id, owner_user_id, name, plan) VALUES (ws, u_owner, 'TEST WS', 'studio');
+  INSERT INTO workspace_members (workspace_id, user_id, invited_email, role, accepted_at) VALUES
+    (ws, u_owner,    'o@t.local', 'owner',    now()),
+    (ws, u_engineer, 'e@t.local', 'engineer', now()),
+    (ws, u_viewer,   'v@t.local', 'viewer',   now()),
+    (ws, u_admin,    'a@t.local', 'admin',    now());
+  INSERT INTO releases (id, user_id, workspace_id, title) VALUES (rel, u_owner, ws, 'TEST REL');
+
+  SET LOCAL ROLE authenticated;  -- enforce RLS as a signed-in user
+
+  -- write-role member can edit (the WITH CHECK fix)
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', u_engineer)::text, true);
+  UPDATE releases SET title = 'edited' WHERE id = rel; GET DIAGNOSTICS n = ROW_COUNT;
+  ASSERT n = 1, 'engineer (write role) should UPDATE the workspace release';
+
+  -- viewer cannot edit
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', u_viewer)::text, true);
+  UPDATE releases SET title = 'nope' WHERE id = rel; GET DIAGNOSTICS n = ROW_COUNT;
+  ASSERT n = 0, 'viewer should NOT UPDATE (read-only)';
+
+  -- engineer cannot delete (owner/admin only)
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', u_engineer)::text, true);
+  DELETE FROM releases WHERE id = rel; GET DIAGNOSTICS n = ROW_COUNT;
+  ASSERT n = 0, 'engineer should NOT DELETE (owner/admin only)';
+
+  -- admin can delete
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', u_admin)::text, true);
+  DELETE FROM releases WHERE id = rel; GET DIAGNOSTICS n = ROW_COUNT;
+  ASSERT n = 1, 'admin should DELETE the workspace release';
+
+  RESET ROLE;
+  RAISE NOTICE 'PASS — write-role edit, viewer read-only, engineer cannot delete, admin can.';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## What
Phase 1 (067) let team members *see* releases; Phase 2 lets the right roles *mutate* them. Three policies still keyed on `releases.user_id`:

- **`releases_update.WITH CHECK`** was `(user_id = auth.uid())` — blocked any non-owner edit even though `USING` allowed collaborators (a latent bug even pre-teams). Now mirrors `USING` (`accessible_release_ids('collaborator')`).
- **`releases_delete`** owner-only → owner **or** workspace owner/admin.
- **`brief_shares_delete`** owner-only → collaborators (aligns with insert/update).

Adds `admin_workspace_ids()` (SECURITY DEFINER; `anon` EXECUTE revoked, matching the 065 pattern) and revokes the 068 trigger fn from anon/authenticated.

| role | edit | delete |
|---|---|---|
| owner / admin | ✅ | ✅ |
| engineer | ✅ | ❌ |
| viewer | ❌ | ❌ |

## Verified live (applied to prod, under real RLS)
`eng_update=1 viewer_update=0 eng_delete=0 admin_delete=1` — exactly expected. Rollback-safe test: `supabase/tests/069_workspace_release_write_test.sql`.

## Next
Phase 3 (shared roster: saved_contacts / quotes / templates), then A3 (invite/member UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)