### PR TITLE
Studio A3: team invites & member-management UI

### DIFF
--- a/src/app/api/workspace/invite/route.ts
+++ b/src/app/api/workspace/invite/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
+import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
+import { getEntitlements } from "@/lib/entitlements";
+
+const resend = new Resend(process.env.RESEND_API_KEY || "re_placeholder");
+
+const ALLOWED_ROLES = ["admin", "engineer", "viewer"] as const;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function buildWorkspaceInviteHtml({
+  inviterEmail,
+  workspaceName,
+  role,
+  appUrl,
+}: {
+  inviterEmail: string;
+  workspaceName: string;
+  role: string;
+  appUrl: string;
+}) {
+  const safeInviter = escapeHtml(inviterEmail);
+  const safeWorkspace = escapeHtml(workspaceName);
+  const roleLabel = role.charAt(0).toUpperCase() + role.slice(1);
+  const signInUrl = `${appUrl}/auth/sign-in`;
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /></head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:40px 0;">
+    <tr><td align="center">
+      <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;">
+        <tr><td style="padding:32px 32px 24px;">
+          <div style="font-size:11px;text-transform:uppercase;letter-spacing:1px;color:#a1a1aa;margin-bottom:16px;">Mix Architect</div>
+          <h1 style="margin:0 0 16px;font-size:20px;color:#18181b;">You&rsquo;ve been added to a team</h1>
+          <p style="margin:0 0 12px;font-size:14px;line-height:1.6;color:#3f3f46;">
+            <strong>${safeInviter}</strong> has invited you to join <strong>${safeWorkspace}</strong> on Mix Architect as a <strong>${roleLabel}</strong>.
+          </p>
+          <p style="margin:0 0 24px;font-size:14px;line-height:1.6;color:#71717a;">
+            Sign in or create an account with this email address to access the team&rsquo;s releases.
+          </p>
+          <a href="${signInUrl}" style="display:inline-block;padding:10px 24px;background:#18181b;color:#ffffff;font-size:14px;font-weight:500;text-decoration:none;border-radius:6px;">
+            Open Mix Architect
+          </a>
+        </td></tr>
+        <tr><td style="padding:16px 32px;border-top:1px solid #e4e4e7;">
+          <p style="margin:0;font-size:11px;color:#a1a1aa;">
+            You received this email because ${safeInviter} invited you on
+            <a href="${appUrl}" style="color:#a1a1aa;">mixarchitect.com</a>.
+          </p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}
+
+/**
+ * POST /api/workspace/invite
+ * Invite a member to the caller's Studio workspace by email.
+ * Body: { email: string, role: "admin" | "engineer" | "viewer" }
+ *
+ * Studio is gated here (at invite time), not in RLS — per the A2 design,
+ * RLS stays plan-agnostic so a billing blip can't revoke team access.
+ */
+export async function POST(request: NextRequest) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
+  const ip = getClientIp(request);
+  const { success } = rateLimit(`ws-invite:${ip}`, 20, 60_000);
+  if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const email = String(body.email ?? "").trim().toLowerCase();
+  const role = String(body.role ?? "");
+
+  if (!EMAIL_RE.test(email)) {
+    return NextResponse.json({ error: "Enter a valid email address." }, { status: 400 });
+  }
+  if (!ALLOWED_ROLES.includes(role as (typeof ALLOWED_ROLES)[number])) {
+    return NextResponse.json({ error: "Invalid role." }, { status: 400 });
+  }
+
+  const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Resolve the caller's workspace (they must be the owner to invite).
+  const { data: ws } = await supabase
+    .from("workspaces")
+    .select("id, name, plan")
+    .eq("owner_user_id", user.id)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (!ws) {
+    return NextResponse.json({ error: "No workspace found." }, { status: 404 });
+  }
+
+  // Studio gate (at invite time).
+  if (!getEntitlements(ws.plan).teamWorkspace) {
+    return NextResponse.json(
+      { error: "Team members are a Studio feature. Upgrade to invite teammates." },
+      { status: 403 },
+    );
+  }
+
+  if (email === (user.email ?? "").toLowerCase()) {
+    return NextResponse.json({ error: "You're already the owner of this workspace." }, { status: 400 });
+  }
+
+  const service = createSupabaseServiceClient();
+
+  // Already invited / a member?
+  const { data: existing } = await service
+    .from("workspace_members")
+    .select("id")
+    .eq("workspace_id", ws.id)
+    .eq("invited_email", email)
+    .maybeSingle();
+  if (existing) {
+    return NextResponse.json({ error: "That email is already a member or invited." }, { status: 409 });
+  }
+
+  // Create the pending membership (user_id NULL until they sign in and
+  // claim_pending_invites() runs).
+  const { error: insertErr } = await service.from("workspace_members").insert({
+    workspace_id: ws.id,
+    invited_email: email,
+    role,
+    user_id: null,
+  });
+  if (insertErr) {
+    console.error("[workspace/invite] insert failed:", insertErr);
+    return NextResponse.json({ error: "Failed to create the invite." }, { status: 500 });
+  }
+
+  // Send the invite email (best-effort — the membership is already created,
+  // and the invitee will be claimed on sign-in regardless).
+  try {
+    await resend.emails.send({
+      from: "Mix Architect <team@mixarchitect.com>",
+      to: email,
+      subject: `You've been added to ${ws.name || "a team"} on Mix Architect`,
+      html: buildWorkspaceInviteHtml({
+        inviterEmail: user.email ?? "A teammate",
+        workspaceName: ws.name || "a team",
+        role,
+        appUrl: new URL(request.url).origin,
+      }),
+    });
+  } catch (err) {
+    console.error("[workspace/invite] email send failed (member still created):", err);
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -19,6 +19,7 @@ import { AutoSaveIndicator } from "@/components/ui/auto-save-indicator";
 import { useSubscription } from "@/lib/subscription-context";
 import { hasProAccess, isStudio } from "@/lib/entitlements";
 import { PortalBrandingCard } from "@/components/settings/portal-branding-card";
+import { WorkspaceMembersCard } from "@/components/settings/workspace-members-card";
 import { useUnsavedChanges } from "@/hooks/use-unsaved-changes";
 import { useFeatureVisibility } from "@/lib/features/feature-visibility-context";
 import {
@@ -306,6 +307,9 @@ export default function SettingsPage() {
 
         {/* Portal branding (Pro/Studio) */}
         <PortalBrandingCard />
+
+        {/* Team members (Studio) */}
+        <WorkspaceMembersCard />
 
         {/* Region & Currency */}
         <Panel>

--- a/src/components/settings/workspace-members-card.tsx
+++ b/src/components/settings/workspace-members-card.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { Users, Lock, Loader2, Trash2, UserPlus } from "lucide-react";
+import { createSupabaseBrowserClient } from "@/lib/supabaseBrowserClient";
+import { useSubscription } from "@/lib/subscription-context";
+import { getEntitlements } from "@/lib/entitlements";
+
+type Member = {
+  id: string;
+  invited_email: string;
+  role: string;
+  accepted_at: string | null;
+  user_id: string | null;
+};
+
+const ASSIGNABLE_ROLES = ["admin", "engineer", "viewer"] as const;
+
+/**
+ * Studio team management: invite members to the workspace, set roles, remove.
+ * Gated on the `teamWorkspace` entitlement — Free/Pro see an upgrade prompt.
+ * Reads/mutates workspace_members directly under owner-only RLS; invites go
+ * through /api/workspace/invite (Studio gate + email).
+ */
+export function WorkspaceMembersCard() {
+  const sub = useSubscription();
+  const gated = !getEntitlements(sub.plan).teamWorkspace;
+
+  const [loading, setLoading] = useState(true);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<(typeof ASSIGNABLE_ROLES)[number]>("engineer");
+  const [inviting, setInviting] = useState(false);
+  const [error, setError] = useState("");
+
+  const loadMembers = useCallback(async () => {
+    const supabase = createSupabaseBrowserClient();
+    const { data } = await supabase
+      .from("workspace_members")
+      .select("id, invited_email, role, accepted_at, user_id")
+      .order("invited_at", { ascending: true });
+    setMembers((data as Member[] | null) ?? []);
+  }, []);
+
+  useEffect(() => {
+    if (gated) {
+      setLoading(false);
+      return;
+    }
+    (async () => {
+      try {
+        await loadMembers();
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [gated, loadMembers]);
+
+  async function handleInvite(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setInviting(true);
+    try {
+      const res = await fetch("/api/workspace/invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: inviteEmail.trim(), role: inviteRole }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to invite.");
+      setInviteEmail("");
+      await loadMembers();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to invite.");
+    } finally {
+      setInviting(false);
+    }
+  }
+
+  async function handleRoleChange(id: string, role: string) {
+    setError("");
+    const supabase = createSupabaseBrowserClient();
+    const { error: err } = await supabase.from("workspace_members").update({ role }).eq("id", id);
+    if (err) {
+      setError(err.message);
+      return;
+    }
+    await loadMembers();
+  }
+
+  async function handleRemove(id: string) {
+    setError("");
+    const supabase = createSupabaseBrowserClient();
+    const { error: err } = await supabase.from("workspace_members").delete().eq("id", id);
+    if (err) {
+      setError(err.message);
+      return;
+    }
+    setMembers((prev) => prev.filter((m) => m.id !== id));
+  }
+
+  /* ── Gated (Free / Pro) ─────────────────────────────────────────── */
+  if (gated) {
+    return (
+      <div className="rounded-xl border border-border p-6" style={{ background: "var(--panel)" }}>
+        <div className="flex items-center gap-2">
+          <Lock size={16} className="text-muted" />
+          <h2 className="text-sm font-semibold text-text">Team members</h2>
+        </div>
+        <p className="mt-2 text-sm text-muted">
+          Invite your team to collaborate on releases with shared access and roles. Available on Studio.
+        </p>
+        <Link
+          href="/app/settings?upgrade=studio"
+          className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors"
+          style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+        >
+          Upgrade to Studio
+        </Link>
+      </div>
+    );
+  }
+
+  /* ── Active (Studio) ────────────────────────────────────────────── */
+  return (
+    <div className="rounded-xl border border-border p-6 space-y-5" style={{ background: "var(--panel)" }}>
+      <div>
+        <h2 className="text-sm font-semibold text-text">Team members</h2>
+        <p className="mt-1 text-sm text-muted">
+          Invite teammates to your workspace. They get access to all releases, gated by role.
+        </p>
+      </div>
+
+      {error && <p className="text-xs text-red-500">{error}</p>}
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-muted">
+          <Loader2 size={14} className="animate-spin" /> Loading…
+        </div>
+      ) : (
+        <>
+          {/* Member list */}
+          <div className="space-y-1.5">
+            {members.map((m) => {
+              const isOwner = m.role === "owner";
+              const pending = !m.accepted_at;
+              return (
+                <div
+                  key={m.id}
+                  className="flex items-center gap-3 rounded-md border border-border px-3 py-2"
+                  style={{ background: "var(--panel-2)" }}
+                >
+                  <Users size={14} className="text-muted shrink-0" />
+                  <span className="text-sm text-text truncate flex-1">{m.invited_email}</span>
+                  {pending && (
+                    <span className="text-[10px] font-medium uppercase tracking-wide text-amber-500">Pending</span>
+                  )}
+                  {isOwner ? (
+                    <span className="text-xs text-muted capitalize px-2">Owner</span>
+                  ) : (
+                    <>
+                      <select
+                        value={m.role}
+                        onChange={(e) => handleRoleChange(m.id, e.target.value)}
+                        className="rounded-md border border-border bg-panel px-2 py-1 text-xs text-text focus:outline-none"
+                      >
+                        {ASSIGNABLE_ROLES.map((r) => (
+                          <option key={r} value={r}>
+                            {r.charAt(0).toUpperCase() + r.slice(1)}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(m.id)}
+                        className="text-muted hover:text-red-500 transition-colors shrink-0"
+                        aria-label={`Remove ${m.invited_email}`}
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Invite form */}
+          <form onSubmit={handleInvite} className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <input
+              type="email"
+              required
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              placeholder="teammate@email.com"
+              className="input text-sm flex-1"
+            />
+            <select
+              value={inviteRole}
+              onChange={(e) => setInviteRole(e.target.value as (typeof ASSIGNABLE_ROLES)[number])}
+              className="rounded-md border border-border bg-panel px-2 py-2 text-sm text-text focus:outline-none"
+            >
+              {ASSIGNABLE_ROLES.map((r) => (
+                <option key={r} value={r}>
+                  {r.charAt(0).toUpperCase() + r.slice(1)}
+                </option>
+              ))}
+            </select>
+            <button
+              type="submit"
+              disabled={inviting}
+              className="inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium rounded-md transition-colors disabled:opacity-40"
+              style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+            >
+              {inviting ? <Loader2 size={12} className="animate-spin" /> : <UserPlus size={12} />}
+              Invite
+            </button>
+          </form>
+          <p className="text-[10px] text-faint">
+            Admin/Engineer can edit releases; Viewer is read-only. Only owner &amp; admin can delete.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/070_claim_workspace_invites.sql
+++ b/supabase/migrations/070_claim_workspace_invites.sql
@@ -1,0 +1,32 @@
+-- 070_claim_workspace_invites.sql
+-- Studio A3: extend claim_pending_invites() to also accept workspace invites.
+--
+-- A workspace invite is a workspace_members row with invited_email set and
+-- user_id NULL (pending). When the invited person signs in, the app calls
+-- claim_pending_invites() (src/app/app/layout.tsx) — so adding the workspace
+-- branch here means invites auto-accept on next load, no extra wiring.
+-- The existing release_members claim is preserved unchanged.
+
+CREATE OR REPLACE FUNCTION public.claim_pending_invites()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'pg_catalog', 'public'
+AS $function$
+DECLARE
+  v_email text;
+BEGIN
+  SELECT email INTO v_email FROM auth.users WHERE id = (select auth.uid());
+  IF v_email IS NULL THEN RETURN; END IF;
+
+  -- Per-release collaborator invites (existing behavior).
+  UPDATE release_members
+  SET user_id = (select auth.uid()), accepted_at = now()
+  WHERE invited_email = v_email AND user_id IS NULL;
+
+  -- Workspace (team) invites.
+  UPDATE workspace_members
+  SET user_id = (select auth.uid()), accepted_at = now()
+  WHERE invited_email = v_email AND user_id IS NULL;
+END;
+$function$;


### PR DESCRIPTION
## What
The user-visible piece that turns the Phase 1/2 plumbing into a real teams feature.

- **Migration 070** — `claim_pending_invites()` now also accepts **workspace** invites (it already handled per-release ones). It's RPC-called on every app load, so an invited member is auto-claimed on sign-in. *Verified live:* pending invite → claimed on impersonated sign-in.
- **`POST /api/workspace/invite`** — Studio-gated + owner-only; inserts the pending `workspace_members` row (user_id NULL) and emails the invitee via Resend.
- **`WorkspaceMembersCard`** (Settings) — member list, invite by email + role, change role, remove. Gated on the `teamWorkspace` entitlement; Free/Pro get an upgrade prompt. Reads/mutates under owner-only RLS (mirrors `PortalBrandingCard`).

| role | edit releases | delete | manage members |
|---|---|---|---|
| owner | ✅ | ✅ | ✅ |
| admin / engineer | ✅ | admin only | — (owner only, MVP) |
| viewer | ❌ | ❌ | — |

## Verified
- `tsc` + `eslint` clean on new files.
- Claim flow tested live (rollback-safe). Access matrix from 067/069 already verified.

## Notes / follow-ups
- Member *management* is owner-only for now (RLS); admin-managed members can come later.
- Studio is gated at invite time (route), not in RLS — per the A2 design.
- Phase 3 (shared roster: saved_contacts/quotes/templates) still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)