### PR TITLE
Studio: members-card scoping fix + Phase 3 shared roster

### DIFF
--- a/src/components/settings/workspace-members-card.tsx
+++ b/src/components/settings/workspace-members-card.tsx
@@ -28,17 +28,21 @@ export function WorkspaceMembersCard() {
   const gated = !getEntitlements(sub.plan).teamWorkspace;
 
   const [loading, setLoading] = useState(true);
+  const [workspaceId, setWorkspaceId] = useState<string | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState<(typeof ASSIGNABLE_ROLES)[number]>("engineer");
   const [inviting, setInviting] = useState(false);
   const [error, setError] = useState("");
 
-  const loadMembers = useCallback(async () => {
+  // Scoped to the workspace the user OWNS — not every workspace they belong to
+  // (a guest in another studio shouldn't see/manage that team here).
+  const loadMembers = useCallback(async (wsId: string) => {
     const supabase = createSupabaseBrowserClient();
     const { data } = await supabase
       .from("workspace_members")
       .select("id, invited_email, role, accepted_at, user_id")
+      .eq("workspace_id", wsId)
       .order("invited_at", { ascending: true });
     setMembers((data as Member[] | null) ?? []);
   }, []);
@@ -50,7 +54,21 @@ export function WorkspaceMembersCard() {
     }
     (async () => {
       try {
-        await loadMembers();
+        const supabase = createSupabaseBrowserClient();
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) return;
+        const { data: ws } = await supabase
+          .from("workspaces")
+          .select("id")
+          .eq("owner_user_id", user.id)
+          .order("created_at", { ascending: true })
+          .limit(1)
+          .maybeSingle();
+        if (!ws) return;
+        setWorkspaceId(ws.id);
+        await loadMembers(ws.id);
       } finally {
         setLoading(false);
       }
@@ -70,7 +88,7 @@ export function WorkspaceMembersCard() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Failed to invite.");
       setInviteEmail("");
-      await loadMembers();
+      if (workspaceId) await loadMembers(workspaceId);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to invite.");
     } finally {
@@ -86,7 +104,7 @@ export function WorkspaceMembersCard() {
       setError(err.message);
       return;
     }
-    await loadMembers();
+    if (workspaceId) await loadMembers(workspaceId);
   }
 
   async function handleRemove(id: string) {

--- a/supabase/migrations/071_studio_shared_roster.sql
+++ b/supabase/migrations/071_studio_shared_roster.sql
@@ -1,0 +1,71 @@
+-- 071_studio_shared_roster.sql
+-- Studio A2 Phase 3: workspace-shared roster.
+-- saved_contacts, quotes (+ line items), and release_templates become visible
+-- and editable to all members of the owning workspace, not just the creator.
+-- (Design decision: shared roster = all team members; release content keeps the
+-- finer read/write/delete role gating from 067/069.)
+
+-- release_templates didn't get a workspace_id in Session 1 — add + index it.
+ALTER TABLE public.release_templates
+  ADD COLUMN IF NOT EXISTS workspace_id uuid REFERENCES public.workspaces(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_release_templates_workspace_id
+  ON public.release_templates(workspace_id);
+
+-- Backfill workspace_id to each owner's personal workspace (idempotent).
+UPDATE public.saved_contacts t SET workspace_id = w.id
+  FROM public.workspaces w WHERE w.owner_user_id = t.user_id AND t.workspace_id IS NULL;
+UPDATE public.quotes t SET workspace_id = w.id
+  FROM public.workspaces w WHERE w.owner_user_id = t.user_id AND t.workspace_id IS NULL;
+UPDATE public.release_templates t SET workspace_id = w.id
+  FROM public.workspaces w WHERE w.owner_user_id = t.user_id AND t.workspace_id IS NULL;
+
+-- Stamp new rows with the creator's owned workspace so they're shared too.
+CREATE OR REPLACE FUNCTION public.stamp_owner_workspace_id()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'pg_catalog', 'public'
+AS $function$
+BEGIN
+  IF NEW.workspace_id IS NULL AND NEW.user_id IS NOT NULL THEN
+    SELECT id INTO NEW.workspace_id FROM workspaces
+    WHERE owner_user_id = NEW.user_id ORDER BY created_at LIMIT 1;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+REVOKE EXECUTE ON FUNCTION public.stamp_owner_workspace_id() FROM anon, authenticated;
+
+DROP TRIGGER IF EXISTS trg_stamp_workspace_saved_contacts ON public.saved_contacts;
+CREATE TRIGGER trg_stamp_workspace_saved_contacts
+  BEFORE INSERT ON public.saved_contacts
+  FOR EACH ROW EXECUTE FUNCTION public.stamp_owner_workspace_id();
+
+DROP TRIGGER IF EXISTS trg_stamp_workspace_quotes ON public.quotes;
+CREATE TRIGGER trg_stamp_workspace_quotes
+  BEFORE INSERT ON public.quotes
+  FOR EACH ROW EXECUTE FUNCTION public.stamp_owner_workspace_id();
+
+DROP TRIGGER IF EXISTS trg_stamp_workspace_release_templates ON public.release_templates;
+CREATE TRIGGER trg_stamp_workspace_release_templates
+  BEFORE INSERT ON public.release_templates
+  FOR EACH ROW EXECUTE FUNCTION public.stamp_owner_workspace_id();
+
+-- Scope policies: creator OR any member of the row's workspace.
+ALTER POLICY saved_contacts_owner ON public.saved_contacts
+  USING (user_id = (select auth.uid()) OR workspace_id IN (SELECT user_workspace_ids()))
+  WITH CHECK (user_id = (select auth.uid()) OR workspace_id IN (SELECT user_workspace_ids()));
+
+ALTER POLICY "Users can manage their own quotes" ON public.quotes
+  USING (user_id = (select auth.uid()) OR workspace_id IN (SELECT user_workspace_ids()))
+  WITH CHECK (user_id = (select auth.uid()) OR workspace_id IN (SELECT user_workspace_ids()));
+
+ALTER POLICY "Users can manage line items on their own quotes" ON public.quote_line_items
+  USING (quote_id IN (SELECT id FROM quotes
+    WHERE user_id = (select auth.uid()) OR workspace_id IN (SELECT user_workspace_ids())))
+  WITH CHECK (quote_id IN (SELECT id FROM quotes
+    WHERE user_id = (select auth.uid()) OR workspace_id IN (SELECT user_workspace_ids())));
+
+ALTER POLICY release_templates_owner ON public.release_templates
+  USING (user_id = (select auth.uid()) OR workspace_id IN (SELECT user_workspace_ids()))
+  WITH CHECK (user_id = (select auth.uid()) OR workspace_id IN (SELECT user_workspace_ids()));

--- a/supabase/tests/071_studio_shared_roster_test.sql
+++ b/supabase/tests/071_studio_shared_roster_test.sql
@@ -1,0 +1,45 @@
+-- 071_studio_shared_roster_test.sql
+-- Phase 3: workspace members share the roster (saved_contacts). Rollback-safe.
+-- Requires 071 applied. Run: psql "$DATABASE_URL" -f supabase/tests/071_studio_shared_roster_test.sql
+
+BEGIN;
+
+DO $$
+DECLARE
+  u_owner uuid; u_member uuid; u_outsider uuid;
+  ws uuid := gen_random_uuid();
+  contact uuid := gen_random_uuid();
+  stamp_contact uuid := gen_random_uuid();
+  n int; stamped uuid;
+BEGIN
+  SELECT id INTO u_owner    FROM auth.users ORDER BY created_at LIMIT 1;
+  SELECT id INTO u_member   FROM auth.users WHERE id <> u_owner ORDER BY created_at LIMIT 1;
+  SELECT id INTO u_outsider FROM auth.users WHERE id NOT IN (u_owner, u_member) ORDER BY created_at LIMIT 1;
+  IF u_outsider IS NULL THEN RAISE EXCEPTION 'Need at least 3 users'; END IF;
+
+  INSERT INTO workspaces (id, owner_user_id, name, plan) VALUES (ws, u_owner, 'TEST WS', 'studio');
+  INSERT INTO workspace_members (workspace_id, user_id, invited_email, role, accepted_at) VALUES
+    (ws, u_owner,  'o@t.local', 'owner',    now()),
+    (ws, u_member, 'm@t.local', 'engineer', now());
+
+  -- shared contact in the workspace + a NULL-workspace contact for the stamp trigger
+  INSERT INTO saved_contacts (id, user_id, person_name, workspace_id) VALUES (contact, u_owner, 'Shared Client', ws);
+  INSERT INTO saved_contacts (id, user_id, person_name) VALUES (stamp_contact, u_owner, 'Auto Stamp');
+  SELECT workspace_id INTO stamped FROM saved_contacts WHERE id = stamp_contact;
+  ASSERT stamped IS NOT NULL, 'stamp trigger should set workspace_id on a new contact';
+
+  SET LOCAL ROLE authenticated;  -- enforce RLS
+
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', u_member)::text, true);
+  SELECT count(*) INTO n FROM saved_contacts WHERE id = contact;
+  ASSERT n = 1, 'workspace member should see the shared contact';
+
+  PERFORM set_config('request.jwt.claims', json_build_object('sub', u_outsider)::text, true);
+  SELECT count(*) INTO n FROM saved_contacts WHERE id = contact;
+  ASSERT n = 0, 'outsider should NOT see the shared contact';
+
+  RESET ROLE;
+  RAISE NOTICE 'PASS — member shares roster, outsider isolated, stamp trigger works.';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## 1. Members-card scoping fix
`WorkspaceMembersCard` listed members via RLS without filtering to the *owned* workspace, so a user who's also a guest in another studio would see a mixed list. Now it resolves the owned workspace and filters to it.

## 2. A2 Phase 3 — shared roster (migration 071)
`saved_contacts`, `quotes` (+ `quote_line_items`), and `release_templates` are now shared across the owning workspace, not just the creator:
- Added `workspace_id` to `release_templates` (the others already had it) + backfilled all three to each owner's workspace.
- A `BEFORE INSERT` trigger stamps new rows with the creator's workspace so future items are shared too.
- The four roster policies grant access to `user_id = auth.uid() OR workspace_id IN user_workspace_ids()`.

(Shared roster = all team members; release *content* keeps the finer read/write/delete role gating from 067/069.)

## Verified live (rollback-safe)
`member_sees=1 outsider_sees=0 stamp_set=t` — member shares the roster, outsider isolated, stamp trigger works. Test: `supabase/tests/071_studio_shared_roster_test.sql`.

## Remaining for full Studio
A4 (branded email sender), A5 (custom portal domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)