### PR TITLE
Studio A4: branded email sender (per-workspace domain)

### DIFF
--- a/src/actions/quotes.ts
+++ b/src/actions/quotes.ts
@@ -9,6 +9,7 @@ import {
   buildUnsubscribeUrl,
 } from "@/lib/email/service";
 import { buildQuoteReceivedEmail } from "@/lib/email-templates/quote-emails";
+import { getWorkspaceSenderFrom } from "@/lib/email/workspace-sender";
 import { syncPaymentStatus } from "@/lib/payment-sync";
 import { fireTrigger } from "@/lib/workflow-engine";
 import type { Quote, QuoteLineItem, PaymentSchedule } from "@/types/payments";
@@ -520,7 +521,7 @@ export async function sendQuote(
     const resend = new Resend(resendKey);
     try {
       await resend.emails.send({
-        from: "Mix Architect <team@mixarchitect.com>",
+        from: await getWorkspaceSenderFrom(quote.workspace_id),
         to: quote.client_email,
         subject: email.subject,
         html: email.html,

--- a/src/app/api/workspace/email-domain/route.ts
+++ b/src/app/api/workspace/email-domain/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
+import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
+import { getEntitlements } from "@/lib/entitlements";
+
+const resend = new Resend(process.env.RESEND_API_KEY || "re_placeholder");
+const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+
+/**
+ * POST /api/workspace/email-domain
+ *  { action: "add", domain }  → register the domain in Resend, store DNS records
+ *  { action: "verify" }        → ask Resend to verify, refresh status
+ * Studio-gated + owner-only. The customer adds the returned DNS records to their
+ * domain, then verifies.
+ */
+export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
+  const ip = getClientIp(req);
+  const { success } = rateLimit(`ws-email-domain:${ip}`, 10, 60_000);
+  if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const action = String(body.action ?? "add");
+
+  const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: ws } = await supabase
+    .from("workspaces")
+    .select("id, plan")
+    .eq("owner_user_id", user.id)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (!ws) return NextResponse.json({ error: "No workspace found." }, { status: 404 });
+  if (!getEntitlements(ws.plan).brandedEmail) {
+    return NextResponse.json(
+      { error: "Branded email is a Studio feature. Upgrade to use your own domain." },
+      { status: 403 },
+    );
+  }
+
+  const service = createSupabaseServiceClient();
+
+  if (action === "add") {
+    const domain = String(body.domain ?? "").trim().toLowerCase();
+    if (!DOMAIN_RE.test(domain)) {
+      return NextResponse.json({ error: "Enter a valid domain, e.g. yourstudio.com." }, { status: 400 });
+    }
+    try {
+      const created = await resend.domains.create({ name: domain });
+      const d = created.data;
+      if (!d) throw new Error(created.error?.message || "Resend rejected the domain.");
+      await service.from("workspace_email_domains").upsert(
+        {
+          workspace_id: ws.id,
+          domain,
+          resend_domain_id: d.id,
+          status: d.status ?? "pending",
+          dns_records: d.records ?? null,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "workspace_id" },
+      );
+      return NextResponse.json({ domain, status: d.status ?? "pending", records: d.records ?? [] });
+    } catch (err) {
+      console.error("[workspace/email-domain] add failed:", err);
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : "Failed to add domain." },
+        { status: 500 },
+      );
+    }
+  }
+
+  if (action === "verify") {
+    const { data: row } = await service
+      .from("workspace_email_domains")
+      .select("resend_domain_id")
+      .eq("workspace_id", ws.id)
+      .maybeSingle();
+    if (!row?.resend_domain_id) {
+      return NextResponse.json({ error: "Add a domain first." }, { status: 404 });
+    }
+    try {
+      await resend.domains.verify(row.resend_domain_id);
+      const got = await resend.domains.get(row.resend_domain_id);
+      const status = got.data?.status ?? "pending";
+      await service
+        .from("workspace_email_domains")
+        .update({ status, updated_at: new Date().toISOString() })
+        .eq("workspace_id", ws.id);
+      return NextResponse.json({ status });
+    } catch (err) {
+      console.error("[workspace/email-domain] verify failed:", err);
+      return NextResponse.json({ error: "Verification check failed. Try again shortly." }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json({ error: "Unknown action." }, { status: 400 });
+}

--- a/src/app/api/workspace/invite/route.ts
+++ b/src/app/api/workspace/invite/route.ts
@@ -5,6 +5,7 @@ import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { requireSameOrigin } from "@/lib/origin-check";
 import { getEntitlements } from "@/lib/entitlements";
+import { getWorkspaceSenderFrom } from "@/lib/email/workspace-sender";
 
 const resend = new Resend(process.env.RESEND_API_KEY || "re_placeholder");
 
@@ -163,7 +164,7 @@ export async function POST(request: NextRequest) {
   // and the invitee will be claimed on sign-in regardless).
   try {
     await resend.emails.send({
-      from: "Mix Architect <team@mixarchitect.com>",
+      from: await getWorkspaceSenderFrom(ws.id),
       to: email,
       subject: `You've been added to ${ws.name || "a team"} on Mix Architect`,
       html: buildWorkspaceInviteHtml({

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -20,6 +20,7 @@ import { useSubscription } from "@/lib/subscription-context";
 import { hasProAccess, isStudio } from "@/lib/entitlements";
 import { PortalBrandingCard } from "@/components/settings/portal-branding-card";
 import { WorkspaceMembersCard } from "@/components/settings/workspace-members-card";
+import { WorkspaceEmailDomainCard } from "@/components/settings/workspace-email-domain-card";
 import { useUnsavedChanges } from "@/hooks/use-unsaved-changes";
 import { useFeatureVisibility } from "@/lib/features/feature-visibility-context";
 import {
@@ -310,6 +311,9 @@ export default function SettingsPage() {
 
         {/* Team members (Studio) */}
         <WorkspaceMembersCard />
+
+        {/* Branded email (Studio) */}
+        <WorkspaceEmailDomainCard />
 
         {/* Region & Currency */}
         <Panel>

--- a/src/components/settings/workspace-email-domain-card.tsx
+++ b/src/components/settings/workspace-email-domain-card.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { Lock, Loader2, Check, Mail } from "lucide-react";
+import { createSupabaseBrowserClient } from "@/lib/supabaseBrowserClient";
+import { useSubscription } from "@/lib/subscription-context";
+import { getEntitlements } from "@/lib/entitlements";
+
+type DnsRecord = { type?: string; name?: string; value?: string; record?: string };
+type DomainRow = { domain: string; status: string; dns_records: DnsRecord[] | null };
+
+/**
+ * Studio branded email: verify your own domain (Resend) so client emails send
+ * from noreply@yourstudio.com. Gated on the `brandedEmail` entitlement.
+ */
+export function WorkspaceEmailDomainCard() {
+  const sub = useSubscription();
+  const gated = !getEntitlements(sub.plan).brandedEmail;
+
+  const [loading, setLoading] = useState(true);
+  const [row, setRow] = useState<DomainRow | null>(null);
+  const [domainInput, setDomainInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    const supabase = createSupabaseBrowserClient();
+    const { data } = await supabase
+      .from("workspace_email_domains")
+      .select("domain, status, dns_records")
+      .maybeSingle();
+    setRow((data as DomainRow | null) ?? null);
+  }, []);
+
+  useEffect(() => {
+    if (gated) {
+      setLoading(false);
+      return;
+    }
+    (async () => {
+      try {
+        await load();
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [gated, load]);
+
+  async function call(payload: object) {
+    setError("");
+    setBusy(true);
+    try {
+      const res = await fetch("/api/workspace/email-domain", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Request failed.");
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /* ── Gated ──────────────────────────────────────────────────────── */
+  if (gated) {
+    return (
+      <div className="rounded-xl border border-border p-6" style={{ background: "var(--panel)" }}>
+        <div className="flex items-center gap-2">
+          <Lock size={16} className="text-muted" />
+          <h2 className="text-sm font-semibold text-text">Branded email</h2>
+        </div>
+        <p className="mt-2 text-sm text-muted">
+          Send client emails from your own domain (noreply@yourstudio.com). Available on Studio.
+        </p>
+        <Link
+          href="/app/settings?upgrade=studio"
+          className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors"
+          style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+        >
+          Upgrade to Studio
+        </Link>
+      </div>
+    );
+  }
+
+  const verified = row?.status === "verified";
+
+  /* ── Active (Studio) ────────────────────────────────────────────── */
+  return (
+    <div className="rounded-xl border border-border p-6 space-y-5" style={{ background: "var(--panel)" }}>
+      <div>
+        <h2 className="text-sm font-semibold text-text">Branded email</h2>
+        <p className="mt-1 text-sm text-muted">
+          Verify a domain so client emails send from your studio instead of Mix Architect.
+        </p>
+      </div>
+
+      {error && <p className="text-xs text-red-500">{error}</p>}
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-muted">
+          <Loader2 size={14} className="animate-spin" /> Loading…
+        </div>
+      ) : !row ? (
+        /* No domain yet — add one */
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            call({ action: "add", domain: domainInput.trim() });
+          }}
+          className="flex flex-col gap-2 sm:flex-row sm:items-center"
+        >
+          <input
+            type="text"
+            required
+            value={domainInput}
+            onChange={(e) => setDomainInput(e.target.value)}
+            placeholder="yourstudio.com"
+            className="input text-sm flex-1"
+          />
+          <button
+            type="submit"
+            disabled={busy}
+            className="inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium rounded-md transition-colors disabled:opacity-40"
+            style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+          >
+            {busy ? <Loader2 size={12} className="animate-spin" /> : <Mail size={12} />}
+            Add domain
+          </button>
+        </form>
+      ) : (
+        <>
+          {/* Status */}
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-text font-medium">{row.domain}</span>
+            {verified ? (
+              <span className="inline-flex items-center gap-1 text-xs text-emerald-500">
+                <Check size={12} /> Verified
+              </span>
+            ) : (
+              <span className="text-xs font-medium uppercase tracking-wide text-amber-500">Pending</span>
+            )}
+          </div>
+
+          {verified ? (
+            <p className="text-xs text-muted">
+              Client emails now send from <strong className="text-text">noreply@{row.domain}</strong>.
+            </p>
+          ) : (
+            <>
+              {/* DNS records to add */}
+              {row.dns_records && row.dns_records.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-xs text-muted">
+                    Add these DNS records at your domain registrar, then verify:
+                  </p>
+                  <div className="overflow-x-auto rounded-md border border-border" style={{ background: "var(--panel-2)" }}>
+                    <table className="w-full text-[11px]">
+                      <thead className="text-faint">
+                        <tr>
+                          <th className="text-left px-3 py-1.5 font-medium">Type</th>
+                          <th className="text-left px-3 py-1.5 font-medium">Name</th>
+                          <th className="text-left px-3 py-1.5 font-medium">Value</th>
+                        </tr>
+                      </thead>
+                      <tbody className="font-mono text-text">
+                        {row.dns_records.map((r, i) => (
+                          <tr key={i} className="border-t border-border">
+                            <td className="px-3 py-1.5 align-top">{r.type ?? r.record}</td>
+                            <td className="px-3 py-1.5 align-top break-all">{r.name}</td>
+                            <td className="px-3 py-1.5 align-top break-all">{r.value}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => call({ action: "verify" })}
+                disabled={busy}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors disabled:opacity-40"
+                style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+              >
+                {busy ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
+                Verify domain
+              </button>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/email/workspace-sender.ts
+++ b/src/lib/email/workspace-sender.ts
@@ -1,0 +1,34 @@
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+
+export const DEFAULT_FROM = "Mix Architect <team@mixarchitect.com>";
+
+/**
+ * The `from` header for a workspace's outbound email. If the workspace has a
+ * verified custom domain (Studio, A4), returns "<Workspace> <noreply@domain>";
+ * otherwise the Mix Architect default. Server-only — reads via the service
+ * client (bypasses RLS), so callers must already be authorized.
+ */
+export async function getWorkspaceSenderFrom(
+  workspaceId: string | null | undefined,
+): Promise<string> {
+  if (!workspaceId) return DEFAULT_FROM;
+
+  const service = createSupabaseServiceClient();
+  const { data } = await service
+    .from("workspace_email_domains")
+    .select("domain, status, sender_local")
+    .eq("workspace_id", workspaceId)
+    .maybeSingle();
+
+  if (!data || data.status !== "verified" || !data.domain) return DEFAULT_FROM;
+
+  const { data: ws } = await service
+    .from("workspaces")
+    .select("name")
+    .eq("id", workspaceId)
+    .maybeSingle();
+
+  const name = (ws?.name ?? "").trim() || "Mix Architect";
+  const local = (data.sender_local || "noreply").replace(/[^a-z0-9._-]/gi, "") || "noreply";
+  return `${name} <${local}@${data.domain}>`;
+}

--- a/supabase/migrations/072_workspace_email_domains.sql
+++ b/supabase/migrations/072_workspace_email_domains.sql
@@ -1,0 +1,25 @@
+-- 072_workspace_email_domains.sql
+-- Studio A4: per-workspace branded email sender.
+-- A Studio workspace can verify its own domain (via Resend) so client-facing
+-- emails send from e.g. noreply@theirstudio.com instead of team@mixarchitect.com.
+-- One domain per workspace. Owner-only; the email-sending code reads the verified
+-- sender via the service client (bypassing RLS).
+
+CREATE TABLE IF NOT EXISTS public.workspace_email_domains (
+  workspace_id     uuid PRIMARY KEY REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  domain           text NOT NULL,
+  resend_domain_id text,
+  status           text NOT NULL DEFAULT 'pending',   -- pending | verified | failed
+  dns_records      jsonb,                              -- records the customer must add
+  sender_local     text NOT NULL DEFAULT 'noreply',    -- local-part: noreply@<domain>
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.workspace_email_domains ENABLE ROW LEVEL SECURITY;
+
+-- Owner of the workspace manages its email domain.
+CREATE POLICY workspace_email_domains_owner ON public.workspace_email_domains
+  FOR ALL
+  USING (workspace_id IN (SELECT owned_workspace_ids()))
+  WITH CHECK (workspace_id IN (SELECT owned_workspace_ids()));


### PR DESCRIPTION
## What
Studio workspaces can verify their own domain (via Resend) so **client emails send from their studio** (e.g. `noreply@yourstudio.com`) instead of `team@mixarchitect.com`.

- **Migration 072** — `workspace_email_domains` (owner-only RLS).
- **`/api/workspace/email-domain`** — Studio-gated, owner-only: `add` (Resend `domains.create` → returns DNS records) and `verify` (`domains.verify` + refresh status).
- **`WorkspaceEmailDomainCard`** in Settings — enter domain → shows the DNS records to add → Verify → status. Gated on `brandedEmail`.
- **`getWorkspaceSenderFrom()`** helper → verified branded sender or the default; wired into the **client quote email** (`actions/quotes.ts`) and the **team invite**.

## Safety
Additive — falls back to the default sender until a domain is verified, so existing emails are unchanged, and the feature is behind the Studio gate.

## ⚠️ Verification note
Code is tsc/lint-clean and the migration is applied, but **full end-to-end can't be verified without a real customer domain** (add DNS records → Resend verifies). The setup/verify flow follows Resend's standard domains API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)