### PR TITLE
Studio A5: custom portal domain (Vercel Domains API)

### DIFF
--- a/src/app/api/workspace/custom-domain/route.ts
+++ b/src/app/api/workspace/custom-domain/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
+import { getEntitlements } from "@/lib/entitlements";
+
+// The production Vercel project that serves mixarchitect.com. Token must be set
+// in env; project/team default to the known prod values.
+const VERCEL_TOKEN = process.env.VERCEL_API_TOKEN;
+const VERCEL_PROJECT = process.env.VERCEL_PROJECT_ID || "prj_2xMVpZmbBOVoJ0id4g89cgXFQQkg";
+const VERCEL_TEAM = process.env.VERCEL_TEAM_ID || "team_2Sd8tWqMXcE6tq4LER1v7sl5";
+const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+
+async function vercel(path: string, init?: RequestInit) {
+  const sep = path.includes("?") ? "&" : "?";
+  const res = await fetch(`https://api.vercel.com${path}${sep}teamId=${VERCEL_TEAM}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${VERCEL_TOKEN}`,
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+  const data = await res.json().catch(() => ({}));
+  return { ok: res.ok, status: res.status, data } as {
+    ok: boolean;
+    status: number;
+    data: { verified?: boolean; verification?: unknown[]; error?: { message?: string } };
+  };
+}
+
+/**
+ * POST /api/workspace/custom-domain
+ *  { action: "add", domain } → register the domain on the Vercel project
+ *  { action: "verify" }       → refresh verification status
+ *  { action: "remove" }       → unregister + clear
+ * Studio-gated, owner-only. Portals then serve at <domain>/portal/<shareToken>.
+ */
+export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
+  const ip = getClientIp(req);
+  const { success } = rateLimit(`ws-custom-domain:${ip}`, 10, 60_000);
+  if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
+  if (!VERCEL_TOKEN) {
+    return NextResponse.json({ error: "Custom domains aren't configured yet." }, { status: 503 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const action = String(body.action ?? "add");
+
+  const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data: ws } = await supabase
+    .from("workspaces")
+    .select("id, plan")
+    .eq("owner_user_id", user.id)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (!ws) return NextResponse.json({ error: "No workspace found." }, { status: 404 });
+  if (!getEntitlements(ws.plan).customDomain) {
+    return NextResponse.json(
+      { error: "Custom domains are a Studio feature." },
+      { status: 403 },
+    );
+  }
+
+  const service = createSupabaseServiceClient();
+
+  if (action === "add") {
+    const domain = String(body.domain ?? "")
+      .trim()
+      .toLowerCase()
+      .replace(/^https?:\/\//, "")
+      .replace(/\/.*$/, "");
+    if (!DOMAIN_RE.test(domain)) {
+      return NextResponse.json({ error: "Enter a valid domain, e.g. portal.yourstudio.com." }, { status: 400 });
+    }
+    const add = await vercel(`/v10/projects/${VERCEL_PROJECT}/domains`, {
+      method: "POST",
+      body: JSON.stringify({ name: domain }),
+    });
+    if (!add.ok) {
+      return NextResponse.json(
+        { error: add.data?.error?.message || "Vercel rejected the domain." },
+        { status: add.status === 409 ? 409 : 400 },
+      );
+    }
+    const status = add.data?.verified ? "verified" : "pending";
+    await service.from("workspace_custom_domains").upsert(
+      {
+        workspace_id: ws.id,
+        domain,
+        status,
+        verification: add.data?.verification ?? null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "workspace_id" },
+    );
+    return NextResponse.json({ domain, status, verification: add.data?.verification ?? [] });
+  }
+
+  if (action === "verify") {
+    const { data: row } = await service
+      .from("workspace_custom_domains")
+      .select("domain")
+      .eq("workspace_id", ws.id)
+      .maybeSingle();
+    if (!row?.domain) return NextResponse.json({ error: "Add a domain first." }, { status: 404 });
+    const got = await vercel(`/v9/projects/${VERCEL_PROJECT}/domains/${row.domain}`);
+    if (!got.ok) return NextResponse.json({ error: "Could not check status. Try again shortly." }, { status: 500 });
+    const status = got.data?.verified ? "verified" : "pending";
+    await service
+      .from("workspace_custom_domains")
+      .update({ status, verification: got.data?.verification ?? null, updated_at: new Date().toISOString() })
+      .eq("workspace_id", ws.id);
+    return NextResponse.json({ status, verification: got.data?.verification ?? [] });
+  }
+
+  if (action === "remove") {
+    const { data: row } = await service
+      .from("workspace_custom_domains")
+      .select("domain")
+      .eq("workspace_id", ws.id)
+      .maybeSingle();
+    if (row?.domain) {
+      await vercel(`/v9/projects/${VERCEL_PROJECT}/domains/${row.domain}`, { method: "DELETE" });
+      await service.from("workspace_custom_domains").delete().eq("workspace_id", ws.id);
+    }
+    return NextResponse.json({ ok: true });
+  }
+
+  return NextResponse.json({ error: "Unknown action." }, { status: 400 });
+}

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -21,6 +21,7 @@ import { hasProAccess, isStudio } from "@/lib/entitlements";
 import { PortalBrandingCard } from "@/components/settings/portal-branding-card";
 import { WorkspaceMembersCard } from "@/components/settings/workspace-members-card";
 import { WorkspaceEmailDomainCard } from "@/components/settings/workspace-email-domain-card";
+import { WorkspaceCustomDomainCard } from "@/components/settings/workspace-custom-domain-card";
 import { useUnsavedChanges } from "@/hooks/use-unsaved-changes";
 import { useFeatureVisibility } from "@/lib/features/feature-visibility-context";
 import {
@@ -314,6 +315,9 @@ export default function SettingsPage() {
 
         {/* Branded email (Studio) */}
         <WorkspaceEmailDomainCard />
+
+        {/* Custom portal domain (Studio) */}
+        <WorkspaceCustomDomainCard />
 
         {/* Region & Currency */}
         <Panel>

--- a/src/components/settings/workspace-custom-domain-card.tsx
+++ b/src/components/settings/workspace-custom-domain-card.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { Lock, Loader2, Check, Globe, Trash2 } from "lucide-react";
+import { createSupabaseBrowserClient } from "@/lib/supabaseBrowserClient";
+import { useSubscription } from "@/lib/subscription-context";
+import { getEntitlements } from "@/lib/entitlements";
+
+type VerificationRec = { type?: string; domain?: string; value?: string };
+type DomainRow = { domain: string; status: string; verification: VerificationRec[] | null };
+
+/**
+ * Studio custom portal domain: serve client portals at the studio's own domain
+ * (e.g. portal.theirstudio.com/portal/<token>). Gated on `customDomain`.
+ */
+export function WorkspaceCustomDomainCard() {
+  const sub = useSubscription();
+  const gated = !getEntitlements(sub.plan).customDomain;
+
+  const [loading, setLoading] = useState(true);
+  const [row, setRow] = useState<DomainRow | null>(null);
+  const [domainInput, setDomainInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    const supabase = createSupabaseBrowserClient();
+    const { data } = await supabase
+      .from("workspace_custom_domains")
+      .select("domain, status, verification")
+      .maybeSingle();
+    setRow((data as DomainRow | null) ?? null);
+  }, []);
+
+  useEffect(() => {
+    if (gated) {
+      setLoading(false);
+      return;
+    }
+    (async () => {
+      try {
+        await load();
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [gated, load]);
+
+  async function call(payload: object) {
+    setError("");
+    setBusy(true);
+    try {
+      const res = await fetch("/api/workspace/custom-domain", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Request failed.");
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (gated) {
+    return (
+      <div className="rounded-xl border border-border p-6" style={{ background: "var(--panel)" }}>
+        <div className="flex items-center gap-2">
+          <Lock size={16} className="text-muted" />
+          <h2 className="text-sm font-semibold text-text">Custom portal domain</h2>
+        </div>
+        <p className="mt-2 text-sm text-muted">
+          Serve client portals on your own domain (portal.yourstudio.com). Available on Studio.
+        </p>
+        <Link
+          href="/app/settings?upgrade=studio"
+          className="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors"
+          style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+        >
+          Upgrade to Studio
+        </Link>
+      </div>
+    );
+  }
+
+  const verified = row?.status === "verified";
+
+  return (
+    <div className="rounded-xl border border-border p-6 space-y-5" style={{ background: "var(--panel)" }}>
+      <div>
+        <h2 className="text-sm font-semibold text-text">Custom portal domain</h2>
+        <p className="mt-1 text-sm text-muted">
+          Serve client portals on your own domain instead of mixarchitect.com.
+        </p>
+      </div>
+
+      {error && <p className="text-xs text-red-500">{error}</p>}
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-muted">
+          <Loader2 size={14} className="animate-spin" /> Loading…
+        </div>
+      ) : !row ? (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            call({ action: "add", domain: domainInput.trim() });
+          }}
+          className="flex flex-col gap-2 sm:flex-row sm:items-center"
+        >
+          <input
+            type="text"
+            required
+            value={domainInput}
+            onChange={(e) => setDomainInput(e.target.value)}
+            placeholder="portal.yourstudio.com"
+            className="input text-sm flex-1"
+          />
+          <button
+            type="submit"
+            disabled={busy}
+            className="inline-flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium rounded-md transition-colors disabled:opacity-40"
+            style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+          >
+            {busy ? <Loader2 size={12} className="animate-spin" /> : <Globe size={12} />}
+            Add domain
+          </button>
+        </form>
+      ) : (
+        <>
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-text font-medium">{row.domain}</span>
+            {verified ? (
+              <span className="inline-flex items-center gap-1 text-xs text-emerald-500">
+                <Check size={12} /> Verified
+              </span>
+            ) : (
+              <span className="text-xs font-medium uppercase tracking-wide text-amber-500">Pending DNS</span>
+            )}
+            <button
+              type="button"
+              onClick={() => call({ action: "remove" })}
+              disabled={busy}
+              className="ml-auto text-muted hover:text-red-500 transition-colors"
+              aria-label="Remove domain"
+            >
+              <Trash2 size={14} />
+            </button>
+          </div>
+
+          {verified ? (
+            <p className="text-xs text-muted">
+              Portals are live at{" "}
+              <strong className="text-text">https://{row.domain}/portal/&lt;link&gt;</strong>.
+            </p>
+          ) : (
+            <>
+              <div className="space-y-2">
+                <p className="text-xs text-muted">Point your domain at Vercel, then verify:</p>
+                <div className="rounded-md border border-border p-3 font-mono text-[11px] text-text space-y-1" style={{ background: "var(--panel-2)" }}>
+                  <div>Subdomain → CNAME → <span className="text-signal">cname.vercel-dns.com</span></div>
+                  <div>Apex domain → A → <span className="text-signal">76.76.21.21</span></div>
+                </div>
+                {row.verification && row.verification.length > 0 && (
+                  <div className="rounded-md border border-border p-3 font-mono text-[11px] text-text space-y-1" style={{ background: "var(--panel-2)" }}>
+                    <div className="text-faint mb-1">Plus this verification record:</div>
+                    {row.verification.map((v, i) => (
+                      <div key={i} className="break-all">
+                        {v.type} {v.domain} → {v.value}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => call({ action: "verify" })}
+                disabled={busy}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-colors disabled:opacity-40"
+                style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+              >
+                {busy ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
+                Verify domain
+              </button>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/073_workspace_custom_domains.sql
+++ b/supabase/migrations/073_workspace_custom_domains.sql
@@ -1,0 +1,23 @@
+-- 073_workspace_custom_domains.sql
+-- Studio A5: per-workspace custom portal domain.
+-- A Studio workspace registers a domain (e.g. portal.theirstudio.com); the app
+-- adds it to the Vercel project via the Vercel Domains API and stores the
+-- mapping. Client portals are then served at the custom domain
+-- (theirdomain.com/portal/<shareToken>). Owner-only; the verification/status
+-- comes from Vercel.
+
+CREATE TABLE IF NOT EXISTS public.workspace_custom_domains (
+  workspace_id uuid PRIMARY KEY REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  domain       text NOT NULL UNIQUE,
+  status       text NOT NULL DEFAULT 'pending',  -- pending | verified
+  verification jsonb,                             -- Vercel verification / DNS records
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.workspace_custom_domains ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY workspace_custom_domains_owner ON public.workspace_custom_domains
+  FOR ALL
+  USING (workspace_id IN (SELECT owned_workspace_ids()))
+  WITH CHECK (workspace_id IN (SELECT owned_workspace_ids()));


### PR DESCRIPTION
## What
The last advertised Studio feature. A workspace registers its own domain (e.g. `portal.theirstudio.com`); client portals then serve at `theirdomain.com/portal/<shareToken>`.

- **Migration 073** — `workspace_custom_domains` (owner-only RLS).
- **`/api/workspace/custom-domain`** — Studio-gated, owner-only: `add` / `verify` / `remove` via the **Vercel Domains API** on the prod project; stores status + verification records.
- **`WorkspaceCustomDomainCard`** in Settings — add domain → DNS instructions (CNAME `cname.vercel-dns.com` / apex A `76.76.21.21`) → verify → status.

## Design (low-risk)
**No middleware change.** The registered domain serves the same Next app, so `/portal/<token>` resolves on it once DNS points at Vercel — no host-rewrite surgery on the critical request path.

## Verified
- Vercel Domains API confirmed live (add → get → delete a throwaway, 200/200/200, cleaned up).
- tsc + eslint clean; migration applied.

## ⚠️ Activation requirements
- **`VERCEL_API_TOKEN` must be set in Vercel env** (the token provided). `VERCEL_PROJECT_ID`/`VERCEL_TEAM_ID` default to the prod values.
- Per-domain: the customer points DNS (CNAME) at Vercel, then verifies — inherently their step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)