### PR TITLE
Admin: grant + switch comp accounts between Pro and Studio

### DIFF
--- a/src/app/api/admin/comp-account/route.ts
+++ b/src/app/api/admin/comp-account/route.ts
@@ -16,17 +16,21 @@ import {
 import { buildCompGrantedEmail } from "@/lib/email-templates/transactional";
 
 /**
- * Notify a user that they've been granted a complimentary Pro account:
+ * Notify a user that they've been granted a complimentary account:
  * an in-app notification + a confirmation email. Never throws — a
  * notification failure must not fail the grant itself.
  */
-async function notifyCompGranted(userId: string) {
+async function notifyCompGranted(userId: string, plan: "pro" | "studio") {
+  const planLabel = plan === "studio" ? "Studio" : "Pro";
   try {
     await createNotification({
       userId,
       type: "payment_update",
-      title: "Complimentary Pro unlocked",
-      body: "An admin upgraded your account to Pro — unlimited releases and all Pro features are now active.",
+      title: `Complimentary ${planLabel} unlocked`,
+      body:
+        plan === "studio"
+          ? "An admin upgraded your account to Studio — unlimited releases, team workspace, and full white-label features are now active."
+          : "An admin upgraded your account to Pro — unlimited releases and all Pro features are now active.",
     });
 
     const email = await getUserEmail(userId);
@@ -43,7 +47,7 @@ async function notifyCompGranted(userId: string) {
       ? buildUnsubscribeUrl(prefs.unsubscribe_token, "subscription_confirmed")
       : undefined;
 
-    const { subject, html } = buildCompGrantedEmail({ displayName, unsubscribeUrl });
+    const { subject, html } = buildCompGrantedEmail({ displayName, unsubscribeUrl, plan });
     await sendTransactionalEmail({
       userId,
       to: email,
@@ -58,11 +62,14 @@ async function notifyCompGranted(userId: string) {
 
 /**
  * POST /api/admin/comp-account
- * Grant or revoke a comp (admin-granted) Pro subscription.
+ * Grant or revoke a comp (admin-granted) subscription. The grant action
+ * doubles as a tier switch: re-granting with a different plan upserts the
+ * existing comp row in place (the workspace plan follows via DB trigger).
  *
  * Body: {
  *   userId: string;
  *   action: "grant" | "revoke";
+ *   plan?: "pro" | "studio";   // grant only, defaults to "pro"
  *   reason?: string;
  *   duration?: "indefinite" | "30d" | "90d" | "6m" | "1y";
  * }
@@ -85,11 +92,12 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json();
-    const { userId, action, reason, duration } = body as {
+    const { userId, action, reason, duration, plan } = body as {
       userId: string;
       action: "grant" | "revoke";
       reason?: string;
       duration?: "indefinite" | "30d" | "90d" | "6m" | "1y";
+      plan?: "pro" | "studio";
     };
 
     if (!userId || !action || !["grant", "revoke"].includes(action)) {
@@ -98,6 +106,10 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       );
     }
+
+    // Comp tier — anything other than "studio" falls back to "pro" so older
+    // callers (e.g. bulk-comp) that omit `plan` keep granting Pro.
+    const compPlan: "pro" | "studio" = plan === "studio" ? "studio" : "pro";
 
     const serviceClient = createSupabaseServiceClient();
 
@@ -123,7 +135,7 @@ export async function POST(req: NextRequest) {
       const { error } = await serviceClient.from("subscriptions").upsert(
         {
           user_id: userId,
-          plan: "pro",
+          plan: compPlan,
           status: "active",
           granted_by_admin: true,
           cancel_at_period_end: false,
@@ -141,6 +153,7 @@ export async function POST(req: NextRequest) {
 
       logActivity(userId, "comp_account_granted", {
         granted_by: user.id,
+        plan: compPlan,
         reason: reason || undefined,
         duration: duration || "indefinite",
         expires_at: expiresAt || undefined,
@@ -148,7 +161,7 @@ export async function POST(req: NextRequest) {
 
       // Notify the user (in-app + email). Awaited so the email send isn't
       // killed when the handler returns; non-fatal on failure.
-      await notifyCompGranted(userId);
+      await notifyCompGranted(userId, compPlan);
     } else {
       // Revoke: set plan back to free
       const { error } = await serviceClient
@@ -172,7 +185,7 @@ export async function POST(req: NextRequest) {
       }, { ip: getClientIp(req), userAgent: req.headers.get("user-agent") ?? undefined });
     }
 
-    logAdminAction(user.id, `comp_${action}`, { target_user: userId, reason, duration }, { ip: getClientIp(req), userAgent: req.headers.get("user-agent") ?? undefined });
+    logAdminAction(user.id, `comp_${action}`, { target_user: userId, reason, duration, plan: action === "grant" ? compPlan : undefined }, { ip: getClientIp(req), userAgent: req.headers.get("user-agent") ?? undefined });
 
     return NextResponse.json({ success: true, action });
   } catch (err) {

--- a/src/components/admin/SubscriptionPlanControl.tsx
+++ b/src/components/admin/SubscriptionPlanControl.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Gift, X, Clock, AlertTriangle } from "lucide-react";
-import { isAtLeastPro } from "@/lib/entitlements";
+import { Gift, X, Clock, AlertTriangle, ArrowLeftRight } from "lucide-react";
+import { isAtLeastPro, normalizePlan, type Plan } from "@/lib/entitlements";
 
 /**
  * Plan controls for the admin user-detail page.
@@ -11,12 +11,12 @@ import { isAtLeastPro } from "@/lib/entitlements";
  * The buttons surface different actions depending on what kind of
  * subscription the user has:
  *
- *   - Free / no row → "Grant Comp Pro" (calls existing
- *     /api/admin/comp-account, action=grant).
+ *   - Free / no row → "Grant Comp Pro" + "Grant Comp Studio" (both call
+ *     /api/admin/comp-account, action=grant, with the chosen plan).
  *
- *   - Admin-granted comp → "Remove Comp" (calls
- *     /api/admin/cancel-subscription — handler short-circuits to a
- *     DB-only flip when granted_by_admin = true).
+ *   - Admin-granted comp → "Switch to Pro/Studio" (re-grants the other
+ *     tier in place) + "Remove Comp" (calls /api/admin/cancel-subscription
+ *     — handler short-circuits to a DB-only flip when granted_by_admin = true).
  *
  *   - Paid Pro (real Stripe sub, active, NOT scheduled to cancel) →
  *     "Cancel Now" + "Cancel at Period End".
@@ -54,9 +54,14 @@ export function SubscriptionPlanControl({ userId, subscription }: Props) {
     isActivePro && !!subscription?.stripe_subscription_id && !isComp;
   const willCancelAtPeriodEnd =
     isPaidPro && subscription?.cancel_at_period_end === true;
+  const currentPlan = normalizePlan(subscription?.plan);
 
-  async function grantComp() {
-    if (!confirm("Grant this user a comp Pro subscription (indefinite)?")) return;
+  async function grantComp(plan: Plan, opts?: { switching?: boolean }) {
+    const planLabel = plan === "studio" ? "Studio" : "Pro";
+    const message = opts?.switching
+      ? `Switch this comp account to ${planLabel}? Their workspace plan updates immediately.`
+      : `Grant this user a comp ${planLabel} subscription (indefinite)?`;
+    if (!confirm(message)) return;
     setState("loading");
     setErrorMsg(null);
     try {
@@ -66,8 +71,11 @@ export function SubscriptionPlanControl({ userId, subscription }: Props) {
         body: JSON.stringify({
           userId,
           action: "grant",
+          plan,
           duration: "indefinite",
-          reason: "Admin testing / support",
+          reason: opts?.switching
+            ? `Admin switched comp to ${planLabel}`
+            : "Admin testing / support",
         }),
       });
       if (!res.ok) {
@@ -115,19 +123,29 @@ export function SubscriptionPlanControl({ userId, subscription }: Props) {
     }
   }
 
-  // Free user — offer to grant comp.
+  // Free user — offer to grant a comp at either tier.
   if (!isActivePro) {
     return (
       <>
         <button
           type="button"
-          onClick={grantComp}
+          onClick={() => grantComp("pro")}
           disabled={state === "loading"}
           className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded border border-amber-500/30 text-amber-400 hover:bg-amber-500/10 transition-colors disabled:opacity-50"
           title="Grant a comp (admin-granted) Pro subscription"
         >
           <Gift size={12} />
           {state === "loading" ? "Granting…" : "Grant Comp Pro"}
+        </button>
+        <button
+          type="button"
+          onClick={() => grantComp("studio")}
+          disabled={state === "loading"}
+          className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded border border-violet-500/30 text-violet-400 hover:bg-violet-500/10 transition-colors disabled:opacity-50"
+          title="Grant a comp (admin-granted) Studio subscription"
+        >
+          <Gift size={12} />
+          {state === "loading" ? "Granting…" : "Grant Comp Studio"}
         </button>
         {errorMsg && (
           <span className="text-xs text-red-400 inline-flex items-center gap-1">
@@ -139,7 +157,43 @@ export function SubscriptionPlanControl({ userId, subscription }: Props) {
     );
   }
 
-  // Active Pro — offer cancel paths.
+  // Admin-granted comp — offer a tier switch + removal.
+  if (isComp) {
+    const otherPlan: Plan = currentPlan === "studio" ? "pro" : "studio";
+    const otherLabel = otherPlan === "studio" ? "Studio" : "Pro";
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => grantComp(otherPlan, { switching: true })}
+          disabled={state === "loading"}
+          className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded border border-sky-500/30 text-sky-400 hover:bg-sky-500/10 transition-colors disabled:opacity-50"
+          title={`Switch this comp account to ${otherLabel}`}
+        >
+          <ArrowLeftRight size={12} />
+          {state === "loading" ? "Working…" : `Switch to ${otherLabel}`}
+        </button>
+        <button
+          type="button"
+          onClick={() => cancel("immediate")}
+          disabled={state === "loading"}
+          className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded border border-red-500/30 text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50"
+          title="Remove comp — user immediately goes back to Free"
+        >
+          <X size={12} />
+          Remove Comp
+        </button>
+        {errorMsg && (
+          <span className="text-xs text-red-400 inline-flex items-center gap-1">
+            <AlertTriangle size={12} />
+            {errorMsg}
+          </span>
+        )}
+      </>
+    );
+  }
+
+  // Paid Pro/Studio (real Stripe sub) — offer cancel paths.
   return (
     <>
       <button
@@ -147,14 +201,10 @@ export function SubscriptionPlanControl({ userId, subscription }: Props) {
         onClick={() => cancel("immediate")}
         disabled={state === "loading"}
         className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded border border-red-500/30 text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50"
-        title={
-          isComp
-            ? "Remove comp Pro — user immediately goes back to Free"
-            : "Cancel this Stripe subscription immediately"
-        }
+        title="Cancel this Stripe subscription immediately"
       >
         <X size={12} />
-        {isComp ? "Remove Comp" : "Cancel Now"}
+        Cancel Now
       </button>
 
       {isPaidPro && !willCancelAtPeriodEnd && (

--- a/src/lib/email-templates/transactional.ts
+++ b/src/lib/email-templates/transactional.ts
@@ -355,21 +355,36 @@ export function buildSubscriptionCancelledEmail({
 export function buildCompGrantedEmail({
   displayName,
   unsubscribeUrl,
+  plan = "pro",
 }: {
   displayName: string;
   unsubscribeUrl?: string;
+  plan?: "pro" | "studio";
 }) {
+  const planLabel = plan === "studio" ? "Studio" : "Pro";
+  const features =
+    plan === "studio"
+      ? [
+          "Unlimited releases and tracks",
+          "Team workspace with unlimited seats",
+          "Full white-label portal — your logo, colors, and custom domain",
+          "Branded client emails from your own domain",
+          "Priority support",
+        ]
+      : [
+          "Unlimited releases and tracks",
+          "Web-based client delivery portal",
+          "Release templates &amp; payment tracking",
+          "Priority support",
+        ];
   return {
-    subject: "You've been upgraded to Mix Architect Pro",
+    subject: `You've been upgraded to Mix Architect ${planLabel}`,
     html: wrap(
       `
-      ${heading("Complimentary Pro unlocked")}
-      ${paragraph(`Hi ${escapeHtml(displayName)}, we've upgraded your account to Mix Architect Pro — on us. Here's what's now unlocked:`)}
+      ${heading(`Complimentary ${planLabel} unlocked`)}
+      ${paragraph(`Hi ${escapeHtml(displayName)}, we've upgraded your account to Mix Architect ${planLabel} — on us. Here's what's now unlocked:`)}
       <ul style="margin:8px 0 16px;padding-left:20px;font-size:14px;color:#666;line-height:1.8">
-        <li>Unlimited releases and tracks</li>
-        <li>Web-based client delivery portal</li>
-        <li>Release templates &amp; payment tracking</li>
-        <li>Priority support</li>
+        ${features.map((f) => `<li>${f}</li>`).join("\n        ")}
       </ul>
       ${cta("Open Mix Architect", "https://mixarchitect.com/app")}
     `,


### PR DESCRIPTION
## What

The comp (admin-granted) subscription system was **Pro-only end to end** — no way to grant a Studio comp or move an existing comp between tiers. This adds both, on the admin user-detail page (Admin → Subscribers → user).

## Changes

- **`/api/admin/comp-account`** — accepts an optional `plan` (`"pro" | "studio"`, defaults to `"pro"` so the bulk-comp path is unaffected). The grant upsert sets `plan` accordingly; the existing `sync_workspace_plan_from_subscription` DB trigger cascades the workspace plan automatically (Studio comps instantly get team seats, white-label, custom domain, branded email).
- **`SubscriptionPlanControl`** — Free users now see **Grant Comp Pro** + **Grant Comp Studio**; existing comps see **Switch to Pro/Studio** (re-grants the other tier in place) + **Remove Comp**.
- **Comp-granted notification + email** — now tier-aware; Studio grants list the Studio features instead of the Pro list.

## Verification

- `tsc` clean (only pre-existing stale `.next` validator errors from the removed Aikido route)
- `eslint` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)