### PR TITLE
Fix portal logo upload: route all uploads through the server endpoint

### DIFF
--- a/src/app/api/workspace/logo/route.ts
+++ b/src/app/api/workspace/logo/route.ts
@@ -82,5 +82,20 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Upload failed." }, { status: 500 });
   }
 
+  // Persist the path on the branding row server-side too, so the whole
+  // operation doesn't depend on a second browser-side write. Only logo_path
+  // is touched on conflict — a previously saved accent_color is preserved.
+  const { error: brandErr } = await service.from("workspace_branding").upsert(
+    { workspace_id: ws.id, logo_path: path, updated_at: new Date().toISOString() },
+    { onConflict: "workspace_id" },
+  );
+  if (brandErr) {
+    console.error("[workspace/logo] branding upsert failed:", brandErr);
+    return NextResponse.json(
+      { error: "Uploaded the file but couldn't save branding." },
+      { status: 500 },
+    );
+  }
+
   return NextResponse.json({ path });
 }

--- a/src/components/settings/portal-branding-card.tsx
+++ b/src/components/settings/portal-branding-card.tsx
@@ -25,7 +25,6 @@ export function PortalBrandingCard() {
 
   const [loading, setLoading] = useState(true);
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
-  const [userId, setUserId] = useState<string | null>(null);
   const [logoPath, setLogoPath] = useState<string | null>(null);
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
   const [accent, setAccent] = useState<string>(DEFAULT_ACCENT);
@@ -53,7 +52,6 @@ export function PortalBrandingCard() {
           data: { user },
         } = await supabase.auth.getUser();
         if (!user) return;
-        setUserId(user.id);
 
         const { data: ws } = await supabase
           .from("workspaces")
@@ -110,30 +108,18 @@ export function PortalBrandingCard() {
       setError("Use a PNG, JPG, WebP, or SVG image.");
       return;
     }
-    if (!userId) return;
     setUploading(true);
     try {
-      let path: string;
-      if (file.type === "image/svg+xml") {
-        // SVGs are sanitized server-side before storing — the logo bucket is
-        // public, so a raw SVG with scripts would be an XSS vector.
-        const fd = new FormData();
-        fd.append("file", file);
-        const res = await fetch("/api/workspace/logo", { method: "POST", body: fd });
-        const data = await res.json();
-        if (!res.ok) throw new Error(data.error || "Upload failed.");
-        path = data.path;
-      } else {
-        const supabase = createSupabaseBrowserClient();
-        const rawExt = file.type.split("/")[1];
-        const ext = (rawExt === "jpeg" ? "jpg" : rawExt ?? "").replace(/[^a-z0-9]/gi, "") || "png";
-        path = `${userId}/logo.${ext}`;
-        const { error: uploadErr } = await supabase.storage
-          .from(LOGO_BUCKET)
-          .upload(path, file, { upsert: true });
-        if (uploadErr) throw uploadErr;
-      }
-      await upsertBranding({ logo_path: path });
+      // All uploads go through the server route. It authenticates via cookies,
+      // sanitizes SVGs, and writes both the file and the branding row with the
+      // service client — so it never depends on the browser storage session,
+      // which doesn't reliably attach the auth token (uploads would 400 on RLS).
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/api/workspace/logo", { method: "POST", body: fd });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Upload failed.");
+      const path: string = data.path;
       setLogoPath(path);
       setLogoUrl(publicUrl(path));
     } catch (err) {


### PR DESCRIPTION
## Problem

Portal-branding logo uploads always failed with `400 new row violates row-level security policy`, and **nothing ever uploaded** (`total_logos = 0` in the bucket).

## Root cause

Confirmed via storage logs + DB impersonation:
- The `workspace-logos` bucket, its RLS policies, the user's workspace/ownership, and the `workspace_branding` policies are all **correct** — an impersonated `authenticated` insert succeeds.
- The **browser-direct storage upload** (`supabase.storage.from(...).upload()`) was reaching storage **without the auth token** in prod (postgrest reads and `getUser()` work fine; only the storage client failed to attach the session), so it hit storage RLS as `anon` → 400.

## Fix

The server route `/api/workspace/logo` already accepted every file type and uploaded via the service client (bypassing RLS) — only the client was sending raster files through the broken browser path.

- `handleUpload` now posts **all** types (png/jpg/webp/svg) to the server route and updates local state from the returned path. Removed the browser-direct `storage.upload()` and the now-unused `userId` state.
- The server route now also upserts `workspace_branding.logo_path` (service client, `onConflict: workspace_id`, touches only `logo_path` so a saved `accent_color` is preserved). The whole logo operation is server-side and no longer depends on a second browser write.

Accent-color save / logo removal keep using the browser postgrest client (reads/writes there work).

## Verification

- `tsc` clean (only pre-existing stale `.next` Aikido validator errors), `eslint` clean.
- Server route uses the service role for both the storage write and the branding upsert — both proven to succeed against this DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)