### PR TITLE
Harden workspace logo route: nodejs runtime, try/catch, lazy DOMPurify

### DIFF
--- a/src/app/api/workspace/logo/route.ts
+++ b/src/app/api/workspace/logo/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import DOMPurify from "isomorphic-dompurify";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { requireSameOrigin } from "@/lib/origin-check";
 import { getEntitlements } from "@/lib/entitlements";
+
+// Needs the Node runtime: Buffer + the lazily-loaded SVG sanitizer (jsdom).
+export const runtime = "nodejs";
 
 const MAX_BYTES = 5 * 1024 * 1024;
 const EXT: Record<string, string> = {
@@ -16,10 +18,11 @@ const EXT: Record<string, string> = {
 
 /**
  * POST /api/workspace/logo  (multipart: file)
- * Uploads a portal-branding logo. SVGs are SANITIZED here (DOMPurify, SVG
- * profile, no <script>/<foreignObject>) before being written to the PUBLIC
- * workspace-logos bucket — otherwise a malicious SVG opened at its public URL
- * would execute scripts. Studio/Pro only; owner-only. Returns the storage path.
+ * Uploads a portal-branding logo for every supported type and writes the
+ * path onto the branding row — all server-side with the service client, so it
+ * doesn't depend on the browser storage session. SVGs are SANITIZED here
+ * (DOMPurify, SVG profile, no <script>/<foreignObject>) before being written
+ * to the PUBLIC bucket. Studio/Pro only; owner-only. Returns the storage path.
  */
 export async function POST(req: NextRequest) {
   const originErr = requireSameOrigin(req);
@@ -29,73 +32,83 @@ export async function POST(req: NextRequest) {
   const { success } = rateLimit(`ws-logo:${ip}`, 20, 60_000);
   if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
 
-  const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  const { data: ws } = await supabase
-    .from("workspaces")
-    .select("id, plan")
-    .eq("owner_user_id", user.id)
-    .order("created_at", { ascending: true })
-    .limit(1)
-    .maybeSingle();
-  if (!ws) return NextResponse.json({ error: "No workspace found." }, { status: 404 });
-  if (getEntitlements(ws.plan).branding === "none") {
-    return NextResponse.json({ error: "Portal branding is a paid feature." }, { status: 403 });
-  }
-
-  let form: FormData;
   try {
-    form = await req.formData();
-  } catch {
-    return NextResponse.json({ error: "Invalid upload." }, { status: 400 });
-  }
-  const file = form.get("file");
-  if (!(file instanceof File)) return NextResponse.json({ error: "No file provided." }, { status: 400 });
-  if (file.size > MAX_BYTES) return NextResponse.json({ error: "Logo must be under 5MB." }, { status: 400 });
-  const ext = EXT[file.type];
-  if (!ext) return NextResponse.json({ error: "Use a PNG, JPG, WebP, or SVG image." }, { status: 400 });
+    const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  let body: Buffer;
-  if (file.type === "image/svg+xml") {
-    const raw = await file.text();
-    const clean = DOMPurify.sanitize(raw, {
-      USE_PROFILES: { svg: true, svgFilters: true },
-      FORBID_TAGS: ["script", "foreignObject"],
-    });
-    if (!clean || !clean.includes("<svg")) {
-      return NextResponse.json({ error: "That SVG couldn't be processed safely." }, { status: 400 });
+    const { data: ws } = await supabase
+      .from("workspaces")
+      .select("id, plan")
+      .eq("owner_user_id", user.id)
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    if (!ws) return NextResponse.json({ error: "No workspace found." }, { status: 404 });
+    if (getEntitlements(ws.plan).branding === "none") {
+      return NextResponse.json({ error: "Portal branding is a paid feature." }, { status: 403 });
     }
-    body = Buffer.from(clean, "utf8");
-  } else {
-    body = Buffer.from(await file.arrayBuffer());
-  }
 
-  const path = `${user.id}/logo.${ext}`;
-  const service = createSupabaseServiceClient();
-  const { error: upErr } = await service.storage
-    .from("workspace-logos")
-    .upload(path, body, { contentType: file.type, upsert: true });
-  if (upErr) {
-    console.error("[workspace/logo] upload failed:", upErr);
-    return NextResponse.json({ error: "Upload failed." }, { status: 500 });
-  }
+    let form: FormData;
+    try {
+      form = await req.formData();
+    } catch {
+      return NextResponse.json({ error: "Invalid upload." }, { status: 400 });
+    }
+    const file = form.get("file");
+    if (!(file instanceof File)) return NextResponse.json({ error: "No file provided." }, { status: 400 });
+    if (file.size > MAX_BYTES) return NextResponse.json({ error: "Logo must be under 5MB." }, { status: 400 });
+    const ext = EXT[file.type];
+    if (!ext) return NextResponse.json({ error: "Use a PNG, JPG, WebP, or SVG image." }, { status: 400 });
 
-  // Persist the path on the branding row server-side too, so the whole
-  // operation doesn't depend on a second browser-side write. Only logo_path
-  // is touched on conflict — a previously saved accent_color is preserved.
-  const { error: brandErr } = await service.from("workspace_branding").upsert(
-    { workspace_id: ws.id, logo_path: path, updated_at: new Date().toISOString() },
-    { onConflict: "workspace_id" },
-  );
-  if (brandErr) {
-    console.error("[workspace/logo] branding upsert failed:", brandErr);
-    return NextResponse.json(
-      { error: "Uploaded the file but couldn't save branding." },
-      { status: 500 },
+    let body: Buffer;
+    if (file.type === "image/svg+xml") {
+      // Load the sanitizer lazily so a raster upload never depends on it.
+      const { default: DOMPurify } = await import("isomorphic-dompurify");
+      const raw = await file.text();
+      const clean = DOMPurify.sanitize(raw, {
+        USE_PROFILES: { svg: true, svgFilters: true },
+        FORBID_TAGS: ["script", "foreignObject"],
+      });
+      if (!clean || !clean.includes("<svg")) {
+        return NextResponse.json({ error: "That SVG couldn't be processed safely." }, { status: 400 });
+      }
+      body = Buffer.from(clean, "utf8");
+    } else {
+      body = Buffer.from(await file.arrayBuffer());
+    }
+
+    const path = `${user.id}/logo.${ext}`;
+    const service = createSupabaseServiceClient();
+    const { error: upErr } = await service.storage
+      .from("workspace-logos")
+      .upload(path, body, { contentType: file.type, upsert: true });
+    if (upErr) {
+      console.error("[workspace/logo] storage upload failed:", upErr);
+      return NextResponse.json({ error: `Upload failed: ${upErr.message}` }, { status: 500 });
+    }
+
+    // Persist the path on the branding row server-side too, so the whole
+    // operation doesn't depend on a second browser-side write. Only logo_path
+    // is touched on conflict — a previously saved accent_color is preserved.
+    const { error: brandErr } = await service.from("workspace_branding").upsert(
+      { workspace_id: ws.id, logo_path: path, updated_at: new Date().toISOString() },
+      { onConflict: "workspace_id" },
     );
-  }
+    if (brandErr) {
+      console.error("[workspace/logo] branding upsert failed:", brandErr);
+      return NextResponse.json(
+        { error: `Uploaded the file but couldn't save branding: ${brandErr.message}` },
+        { status: 500 },
+      );
+    }
 
-  return NextResponse.json({ path });
+    return NextResponse.json({ path });
+  } catch (err) {
+    console.error("[workspace/logo] unhandled error:", err);
+    const msg = err instanceof Error ? err.message : "Unexpected error";
+    return NextResponse.json({ error: `Server error: ${msg}` }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Problem

After routing all logo uploads through `/api/workspace/logo`, a PNG upload returned an opaque **500**. Storage logs show the route threw **before** the service-client storage upload (no server-side `node` POST to the bucket), and the route had never succeeded (zero objects in `workspace-logos`). The Vercel logs API is 403 for the current token, so the exact server error wasn't directly readable.

## Fix (robust + self-diagnosing)

- **`export const runtime = "nodejs"`** — guarantees `Buffer` and the jsdom-backed SVG sanitizer are available, ruling out an edge-runtime module-load failure.
- **Top-level try/catch** returning the real error message — a future failure surfaces a useful reason instead of an opaque 500.
- **Lazy `isomorphic-dompurify`** (dynamic `import()` inside the SVG branch only) — raster uploads no longer load the jsdom-backed dependency at all.
- Storage/branding errors now include their underlying message in the response.

Raster uploads (PNG/JPG/WebP) now take a path that touches none of the risky pieces; if anything still fails, the response will say exactly what.

## Verification

`tsc` clean (only pre-existing stale `.next` Aikido validator errors), `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)