### PR TITLE
Move cover-art + artist-photo uploads server-side (fix anon-key storage RLS)

### DIFF
--- a/src/app/api/artist-photo/route.ts
+++ b/src/app/api/artist-photo/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
+
+// Needs the Node runtime for Buffer (the binary upload body).
+export const runtime = "nodejs";
+
+const MAX_BYTES = 5 * 1024 * 1024;
+const EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+};
+
+const slug = (name: string) => name.toLowerCase().trim().replace(/[^a-z0-9]/g, "-");
+const key = (name: string) => name.toLowerCase().trim();
+
+/**
+ * Artist-photo writes, server-side — same reasoning as the cover-art route:
+ * browser-direct storage uploads can fall back to the anon key and fail RLS.
+ * Auth via cookies; the storage write uses the service client (bypasses storage
+ * RLS); the artist_photos write uses the RLS-bound server client. user_id is
+ * always derived from the session, never the request body.
+ *
+ * POST   (multipart: file, artistName)  → upload + upsert artist_photos
+ * PATCH  (json: { artistName, url })     → set photo_url (paste URL)
+ * DELETE (json: { artistName })          → remove the photo row
+ */
+export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+  const { success } = rateLimit(`artist-photo:${getClientIp(req)}`, 30, 60_000);
+  if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
+  try {
+    const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    let form: FormData;
+    try {
+      form = await req.formData();
+    } catch {
+      return NextResponse.json({ error: "Invalid upload." }, { status: 400 });
+    }
+    const file = form.get("file");
+    const artistName = form.get("artistName");
+    if (typeof artistName !== "string" || !artistName.trim()) {
+      return NextResponse.json({ error: "Missing artist name." }, { status: 400 });
+    }
+    if (!(file instanceof File)) return NextResponse.json({ error: "No file provided." }, { status: 400 });
+    if (file.size > MAX_BYTES) return NextResponse.json({ error: "Image must be under 5MB." }, { status: 400 });
+    const ext = EXT[file.type];
+    if (!ext) return NextResponse.json({ error: "Use a PNG, JPG, WebP, or GIF image." }, { status: 400 });
+
+    const service = createSupabaseServiceClient();
+    const path = `${user.id}/artist-${slug(artistName)}.${ext}`;
+    const body = Buffer.from(await file.arrayBuffer());
+    const { error: upErr } = await service.storage
+      .from("cover-art")
+      .upload(path, body, { contentType: file.type, upsert: true });
+    if (upErr) {
+      console.error("[artist-photo] upload failed:", upErr);
+      return NextResponse.json({ error: `Upload failed: ${upErr.message}` }, { status: 500 });
+    }
+
+    const url = `${service.storage.from("cover-art").getPublicUrl(path).data.publicUrl}?t=${Date.now()}`;
+    const { error: dbErr } = await supabase.from("artist_photos").upsert(
+      { user_id: user.id, artist_name_key: key(artistName), photo_url: url },
+      { onConflict: "user_id,artist_name_key" },
+    );
+    if (dbErr) {
+      console.error("[artist-photo] db upsert failed:", dbErr);
+      return NextResponse.json({ error: `Saved image but couldn't save photo: ${dbErr.message}` }, { status: 500 });
+    }
+
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error("[artist-photo] error:", err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Server error" }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
+  try {
+    const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const body = await req.json().catch(() => ({}));
+    const artistName = typeof body.artistName === "string" ? body.artistName : "";
+    const url = typeof body.url === "string" ? body.url.trim() : "";
+    if (!artistName.trim() || !url) {
+      return NextResponse.json({ error: "Missing artist name or URL." }, { status: 400 });
+    }
+    const { error: dbErr } = await supabase.from("artist_photos").upsert(
+      { user_id: user.id, artist_name_key: key(artistName), photo_url: url },
+      { onConflict: "user_id,artist_name_key" },
+    );
+    if (dbErr) return NextResponse.json({ error: dbErr.message }, { status: 500 });
+
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error("[artist-photo] PATCH error:", err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
+  try {
+    const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const body = await req.json().catch(() => ({}));
+    const artistName = typeof body.artistName === "string" ? body.artistName : "";
+    if (!artistName.trim()) return NextResponse.json({ error: "Missing artist name." }, { status: 400 });
+
+    const { error: dbErr } = await supabase
+      .from("artist_photos")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("artist_name_key", key(artistName));
+    if (dbErr) return NextResponse.json({ error: dbErr.message }, { status: 500 });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[artist-photo] DELETE error:", err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/releases/[releaseId]/cover-art/route.ts
+++ b/src/app/api/releases/[releaseId]/cover-art/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
+
+// Needs the Node runtime for Buffer (the binary upload body).
+export const runtime = "nodejs";
+
+const MAX_BYTES = 5 * 1024 * 1024;
+const EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+};
+
+/**
+ * Release cover-art writes, server-side.
+ *
+ * Browser-direct storage uploads can go out with the anon key when the browser
+ * session lapses (it falls back to the publishable key), which fails storage
+ * RLS. So all cover-art mutations run here: cookie auth + an explicit ownership
+ * check, the storage write via the service client (bypasses storage RLS), and
+ * the DB write via the RLS-bound server client.
+ *
+ * POST  (multipart: file)        → upload + set releases.cover_art_url
+ * PATCH (json: { url?: string })  → set/clear cover_art_url (paste URL / remove)
+ */
+async function requireOwnedRelease(req: NextRequest, releaseId: string) {
+  const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+
+  const { data: rel } = await supabase
+    .from("releases")
+    .select("id")
+    .eq("id", releaseId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (!rel) return { error: NextResponse.json({ error: "Release not found." }, { status: 404 }) };
+
+  return { supabase, user };
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ releaseId: string }> },
+) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+  const { success } = rateLimit(`cover-art:${getClientIp(req)}`, 30, 60_000);
+  if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
+  try {
+    const { releaseId } = await params;
+    const auth = await requireOwnedRelease(req, releaseId);
+    if (auth.error) return auth.error;
+    const { supabase, user } = auth;
+
+    let form: FormData;
+    try {
+      form = await req.formData();
+    } catch {
+      return NextResponse.json({ error: "Invalid upload." }, { status: 400 });
+    }
+    const file = form.get("file");
+    if (!(file instanceof File)) return NextResponse.json({ error: "No file provided." }, { status: 400 });
+    if (file.size > MAX_BYTES) return NextResponse.json({ error: "Image must be under 5MB." }, { status: 400 });
+    const ext = EXT[file.type];
+    if (!ext) return NextResponse.json({ error: "Use a PNG, JPG, WebP, or GIF image." }, { status: 400 });
+
+    const service = createSupabaseServiceClient();
+    const path = `${user.id}/${releaseId}.${ext}`;
+    const body = Buffer.from(await file.arrayBuffer());
+    const { error: upErr } = await service.storage
+      .from("cover-art")
+      .upload(path, body, { contentType: file.type, upsert: true });
+    if (upErr) {
+      console.error("[releases/cover-art] upload failed:", upErr);
+      return NextResponse.json({ error: `Upload failed: ${upErr.message}` }, { status: 500 });
+    }
+
+    const url = `${service.storage.from("cover-art").getPublicUrl(path).data.publicUrl}?t=${Date.now()}`;
+    const { error: updErr } = await supabase
+      .from("releases")
+      .update({ cover_art_url: url })
+      .eq("id", releaseId);
+    if (updErr) {
+      console.error("[releases/cover-art] db update failed:", updErr);
+      return NextResponse.json({ error: `Saved image but couldn't update release: ${updErr.message}` }, { status: 500 });
+    }
+
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error("[releases/cover-art] error:", err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Server error" }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ releaseId: string }> },
+) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
+  try {
+    const { releaseId } = await params;
+    const auth = await requireOwnedRelease(req, releaseId);
+    if (auth.error) return auth.error;
+    const { supabase } = auth;
+
+    const body = await req.json().catch(() => ({}));
+    const raw = typeof body.url === "string" ? body.url.trim() : "";
+    const url = raw || null;
+    const { error: updErr } = await supabase
+      .from("releases")
+      .update({ cover_art_url: url })
+      .eq("id", releaseId);
+    if (updErr) return NextResponse.json({ error: updErr.message }, { status: 500 });
+
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error("[releases/cover-art] PATCH error:", err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/app/releases/[releaseId]/settings/settings-form.tsx
+++ b/src/app/app/releases/[releaseId]/settings/settings-form.tsx
@@ -312,22 +312,15 @@ export function SettingsForm({ releaseId, role, initialMembers, hasQuotes = fals
     }
     setUploading(true);
     try {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) throw new Error("Not authenticated");
-      const rawExt = file.type.split("/")[1];
-      const ext = (rawExt === "jpeg" ? "jpg" : rawExt ?? "").replace(/[^a-zA-Z0-9]/g, "") || "bin";
-      const path = `${user.id}/${releaseId}.${ext}`;
-      const { error: uploadErr } = await supabase.storage
-        .from("cover-art")
-        .upload(path, file, { upsert: true });
-      if (uploadErr) throw uploadErr;
-      const { data: urlData } = supabase.storage
-        .from("cover-art")
-        .getPublicUrl(path);
-      const url = urlData.publicUrl + `?t=${Date.now()}`;
-      setCoverArtUrl(url);
+      // Server-side upload: avoids the browser storage client falling back to
+      // the anon key when the session lapses (which fails storage RLS).
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch(`/api/releases/${releaseId}/cover-art`, { method: "POST", body: fd });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Upload failed");
+      setCoverArtUrl(data.url);
       setCoverArtMode("preview");
-      await supabase.from("releases").update({ cover_art_url: url }).eq("id", releaseId);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Upload failed");
     } finally {
@@ -338,7 +331,11 @@ export function SettingsForm({ releaseId, role, initialMembers, hasQuotes = fals
   async function handleRemoveCover() {
     setCoverArtUrl("");
     setCoverArtMode("none");
-    await supabase.from("releases").update({ cover_art_url: null }).eq("id", releaseId);
+    await fetch(`/api/releases/${releaseId}/cover-art`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: null }),
+    });
   }
 
   async function handleInvite() {

--- a/src/app/app/releases/[releaseId]/sidebar-editors.tsx
+++ b/src/app/app/releases/[releaseId]/sidebar-editors.tsx
@@ -491,23 +491,15 @@ export function CoverArtEditor({ releaseId, initialUrl, role }: CoverArtEditorPr
     }
     setUploading(true);
     setError("");
-    const supabase = createSupabaseBrowserClient();
     try {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) throw new Error("Not authenticated");
-      const rawExt = file.type.split("/")[1];
-      const ext = (rawExt === "jpeg" ? "jpg" : rawExt ?? "").replace(/[^a-zA-Z0-9]/g, "") || "bin";
-      const path = `${user.id}/${releaseId}.${ext}`;
-      const { error: uploadErr } = await supabase.storage
-        .from("cover-art")
-        .upload(path, file, { upsert: true });
-      if (uploadErr) throw uploadErr;
-      const { data: urlData } = supabase.storage
-        .from("cover-art")
-        .getPublicUrl(path);
-      const newUrl = urlData.publicUrl + `?t=${Date.now()}`;
-      setUrl(newUrl);
-      await supabase.from("releases").update({ cover_art_url: newUrl }).eq("id", releaseId);
+      // Server-side upload: avoids the browser storage client falling back to
+      // the anon key when the session lapses (which fails storage RLS).
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch(`/api/releases/${releaseId}/cover-art`, { method: "POST", body: fd });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || t("uploadFailed"));
+      setUrl(data.url);
       setEditing(false);
       router.refresh();
     } catch (err) {
@@ -520,9 +512,14 @@ export function CoverArtEditor({ releaseId, initialUrl, role }: CoverArtEditorPr
   async function handleUrlSave() {
     if (!urlInput.trim()) return;
     setError("");
-    const supabase = createSupabaseBrowserClient();
     try {
-      await supabase.from("releases").update({ cover_art_url: urlInput.trim() }).eq("id", releaseId);
+      const res = await fetch(`/api/releases/${releaseId}/cover-art`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: urlInput.trim() }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || t("urlSaveFailed"));
       setUrl(urlInput.trim());
       setUrlInput("");
       setEditing(false);
@@ -534,9 +531,16 @@ export function CoverArtEditor({ releaseId, initialUrl, role }: CoverArtEditorPr
 
   async function handleRemove() {
     setError("");
-    const supabase = createSupabaseBrowserClient();
     try {
-      await supabase.from("releases").update({ cover_art_url: null }).eq("id", releaseId);
+      const res = await fetch(`/api/releases/${releaseId}/cover-art`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: null }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || t("removeFailed"));
+      }
       setUrl("");
       setEditing(false);
       router.refresh();

--- a/src/components/ui/artist-photo-uploader.tsx
+++ b/src/components/ui/artist-photo-uploader.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Pencil, Upload, X, Check, ImageIcon } from "lucide-react";
-import { createSupabaseBrowserClient } from "@/lib/supabaseBrowserClient";
 import { ArtistPhoto } from "./artist-photo";
 
 type Props = {
@@ -31,10 +30,6 @@ export function ArtistPhotoUploader({
   const displayUrl = url ?? fallbackCoverUrl;
   const px = SIZES[size];
 
-  function sanitizeName(name: string) {
-    return name.toLowerCase().trim().replace(/[^a-z0-9]/g, "-");
-  }
-
   async function handleUpload(file: File) {
     const MAX_SIZE = 5 * 1024 * 1024;
     if (file.size > MAX_SIZE) {
@@ -48,31 +43,16 @@ export function ArtistPhotoUploader({
     }
     setUploading(true);
     setError("");
-    const supabase = createSupabaseBrowserClient();
     try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) throw new Error("Not authenticated");
-      const rawExt = file.type.split("/")[1];
-      const ext = (rawExt === "jpeg" ? "jpg" : rawExt ?? "").replace(/[^a-zA-Z0-9]/g, "") || "bin";
-      const path = `${user.id}/artist-${sanitizeName(artistName)}.${ext}`;
-      const { error: uploadErr } = await supabase.storage
-        .from("cover-art")
-        .upload(path, file, { upsert: true });
-      if (uploadErr) throw uploadErr;
-      const { data: urlData } = supabase.storage.from("cover-art").getPublicUrl(path);
-      const newUrl = urlData.publicUrl + `?t=${Date.now()}`;
-      // Upsert artist_photos row
-      await supabase.from("artist_photos").upsert(
-        {
-          user_id: user.id,
-          artist_name_key: artistName.toLowerCase().trim(),
-          photo_url: newUrl,
-        },
-        { onConflict: "user_id,artist_name_key" },
-      );
-      setUrl(newUrl);
+      // Server-side upload: avoids the browser storage client falling back to
+      // the anon key when the session lapses (which fails storage RLS).
+      const fd = new FormData();
+      fd.append("file", file);
+      fd.append("artistName", artistName);
+      const res = await fetch("/api/artist-photo", { method: "POST", body: fd });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Upload failed");
+      setUrl(data.url);
       setEditing(false);
       router.refresh();
     } catch (err) {
@@ -85,47 +65,40 @@ export function ArtistPhotoUploader({
   async function handleUrlSave() {
     if (!urlInput.trim()) return;
     setError("");
-    const supabase = createSupabaseBrowserClient();
     try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) throw new Error("Not authenticated");
-      await supabase.from("artist_photos").upsert(
-        {
-          user_id: user.id,
-          artist_name_key: artistName.toLowerCase().trim(),
-          photo_url: urlInput.trim(),
-        },
-        { onConflict: "user_id,artist_name_key" },
-      );
+      const res = await fetch("/api/artist-photo", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ artistName, url: urlInput.trim() }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Failed to save URL");
       setUrl(urlInput.trim());
       setUrlInput("");
       setEditing(false);
       router.refresh();
-    } catch {
-      setError("Failed to save URL");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save URL");
     }
   }
 
   async function handleRemove() {
     setError("");
-    const supabase = createSupabaseBrowserClient();
     try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) throw new Error("Not authenticated");
-      await supabase
-        .from("artist_photos")
-        .delete()
-        .eq("user_id", user.id)
-        .eq("artist_name_key", artistName.toLowerCase().trim());
+      const res = await fetch("/api/artist-photo", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ artistName }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to remove photo");
+      }
       setUrl(null);
       setEditing(false);
       router.refresh();
-    } catch {
-      setError("Failed to remove photo");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove photo");
     }
   }
 


### PR DESCRIPTION
## Root cause (investigated in source)

Browser-direct `supabase.storage.from(...).upload()` was failing with `400 new row violates row-level security policy`. Reading `supabase-js@2.86` + `@supabase/ssr@0.8`:

- Storage and REST share the **same** authenticated fetch (`fetchWithAuth`) and the **same** token resolver (`SupabaseClient._getAccessToken` → `getSession()?.access_token ?? supabaseKey`).
- So there is **no storage-specific token drop**. When the browser session lapses, `getSession()` is empty and the client falls back to the **publishable anon key** → storage sees `anon` → `auth.uid()` is null → RLS fails.
- It looked storage-specific only because almost all app data is **server-rendered** (separate, working cookie auth), so a flaky *browser* session is invisible until a browser-initiated write like an upload.

Same root cause already fixed for portal logos ([#64](https://github.com/mixarchitect/mix-architect/pull/64)/[#65](https://github.com/mixarchitect/mix-architect/pull/65)).

## Fix — one pattern, all uploaders

Both the upload **and** its coupled DB write move server-side (they fail together when the session is anon), so the whole operation no longer depends on the browser session:

- **`POST/PATCH /api/releases/[releaseId]/cover-art`** — cookie auth + ownership check; storage write via service client; `releases.cover_art_url` via the RLS-bound server client. Covers upload, paste-URL, and remove.
- **`POST/PATCH/DELETE /api/artist-photo`** — same shape; `artist_photos` keyed by the session user (never request input). Covers upload, paste-URL, and remove.
- `sidebar-editors.tsx`, `settings/settings-form.tsx`, and `artist-photo-uploader.tsx` now call these endpoints instead of the browser storage/db client.

Service-client usage is confined to the storage write, behind explicit auth + ownership, mirroring the existing logo route.

## Verification

- `tsc` clean (only pre-existing stale `.next` Aikido validator errors).
- `eslint`: no new problems (the autoFocus/img/unused warnings are pre-existing in untouched code; `main` builds with them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)