### PR TITLE
Studio: route remaining client-facing emails through the workspace branded sender

### DIFF
--- a/src/app/api/portal/notify/route.ts
+++ b/src/app/api/portal/notify/route.ts
@@ -7,6 +7,7 @@ import {
   buildTrackDeliveredEmail,
 } from "@/lib/email-templates/portal-notification";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { getWorkspaceSenderFrom } from "@/lib/email/workspace-sender";
 
 // Lazy-init Resend to avoid build failures when RESEND_API_KEY is missing
 function getResend() {
@@ -64,7 +65,7 @@ export async function POST(req: NextRequest) {
     // Fetch share + release + track
     const { data: share } = await supabase
       .from("brief_shares")
-      .select("*, releases!inner(title, user_id)")
+      .select("*, releases!inner(title, user_id, workspace_id)")
       .eq("share_token", share_token)
       .maybeSingle();
 
@@ -82,9 +83,10 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Track not found" }, { status: 404 });
     }
 
-    const releaseTitle = (share as Record<string, unknown>).releases
-      ? ((share as Record<string, unknown>).releases as { title: string }).title
-      : "Release";
+    const releaseRel = (share as Record<string, unknown>).releases as
+      | { title: string; user_id: string; workspace_id: string | null }
+      | undefined;
+    const releaseTitle = releaseRel?.title ?? "Release";
     const trackTitle = track.title;
     const portalUrl = `${process.env.NEXT_PUBLIC_APP_URL || "https://app.mixarchitect.com"}/portal/${share_token}`;
 
@@ -102,7 +104,7 @@ export async function POST(req: NextRequest) {
       }
 
       // Get engineer email
-      const ownerId = ((share as Record<string, unknown>).releases as { user_id: string }).user_id;
+      const ownerId = releaseRel?.user_id ?? "";
       const { data: ownerData } = await supabase.auth.admin.getUserById(ownerId);
       recipientEmail = ownerData?.user?.email ?? null;
 
@@ -142,7 +144,7 @@ export async function POST(req: NextRequest) {
     }
 
     await resend.emails.send({
-      from: "Mix Architect <team@mixarchitect.com>",
+      from: await getWorkspaceSenderFrom(releaseRel?.workspace_id ?? null),
       to: recipientEmail,
       subject: emailContent.subject,
       html: emailContent.html,

--- a/src/app/api/send-invite/route.ts
+++ b/src/app/api/send-invite/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { getWorkspaceSenderFrom } from "@/lib/email/workspace-sender";
 
 const resend = new Resend(process.env.RESEND_API_KEY || "re_placeholder");
 
@@ -97,7 +98,7 @@ export async function POST(request: NextRequest) {
   // Verify caller owns the release
   const { data: release } = await supabase
     .from("releases")
-    .select("id")
+    .select("id, workspace_id")
     .eq("id", releaseId)
     .eq("user_id", user.id)
     .maybeSingle();
@@ -111,7 +112,7 @@ export async function POST(request: NextRequest) {
 
   try {
     await resend.emails.send({
-      from: "Mix Architect <team@mixarchitect.com>",
+      from: await getWorkspaceSenderFrom(release.workspace_id),
       to: email,
       subject: `You've been invited to collaborate on "${releaseTitle}"`,
       html: buildInviteHtml({ inviterEmail, releaseTitle, role, appUrl }),

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -1,5 +1,6 @@
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { sendQuote } from "@/actions/quotes";
+import { getWorkspaceSenderFrom } from "@/lib/email/workspace-sender";
 import type { TriggerEvent, ActionType } from "@/types/payments";
 
 export type TriggerContext = {
@@ -154,7 +155,7 @@ async function handleSendEmailThankYou(context: TriggerContext): Promise<ActionR
   // Get release info and client email
   const { data: release } = await supabase
     .from("releases")
-    .select("title, client_email, client_name")
+    .select("title, client_email, client_name, workspace_id")
     .eq("id", context.releaseId)
     .maybeSingle();
 
@@ -174,7 +175,7 @@ async function handleSendEmailThankYou(context: TriggerContext): Promise<ActionR
   const { Resend } = require("resend") as typeof import("resend");
   const resend = new Resend(process.env.RESEND_API_KEY);
   await resend.emails.send({
-    from: "Mix Architect <team@mixarchitect.com>",
+    from: await getWorkspaceSenderFrom(release?.workspace_id ?? null),
     to: release.client_email,
     subject,
     html,
@@ -194,7 +195,7 @@ async function handleSendEmailTestimonialRequest(
 
   const { data: release } = await supabase
     .from("releases")
-    .select("title, client_email, client_name")
+    .select("title, client_email, client_name, workspace_id")
     .eq("id", context.releaseId)
     .maybeSingle();
 
@@ -214,7 +215,7 @@ async function handleSendEmailTestimonialRequest(
   const { Resend } = require("resend") as typeof import("resend");
   const resend = new Resend(process.env.RESEND_API_KEY);
   await resend.emails.send({
-    from: "Mix Architect <team@mixarchitect.com>",
+    from: await getWorkspaceSenderFrom(release?.workspace_id ?? null),
     to: release.client_email,
     subject,
     html,
@@ -248,7 +249,7 @@ async function handleSendPaymentReminder(context: TriggerContext): Promise<Actio
 
   const { data: release } = await supabase
     .from("releases")
-    .select("title")
+    .select("title, workspace_id")
     .eq("id", context.releaseId)
     .maybeSingle();
 
@@ -265,7 +266,7 @@ async function handleSendPaymentReminder(context: TriggerContext): Promise<Actio
   const { Resend } = require("resend") as typeof import("resend");
   const resend = new Resend(process.env.RESEND_API_KEY);
   await resend.emails.send({
-    from: "Mix Architect <team@mixarchitect.com>",
+    from: await getWorkspaceSenderFrom(release?.workspace_id ?? null),
     to: quote.client_email,
     subject,
     html,


### PR DESCRIPTION
Finishes the Studio branded-email feature (A4). Previously only the client **quote** email and the **team invite** used a workspace's verified sending domain; every other client-facing email still went out as `team@mixarchitect.com`. This routes the rest through `getWorkspaceSenderFrom(workspaceId)`.

## Send sites switched (all client-facing)
| Site | Emails |
|---|---|
| `api/portal/notify` | new-version, delivered, approved, changes-requested |
| `api/send-invite` | client & collaborator release invites |
| `lib/workflow-engine` | thank-you, testimonial request, payment reminder |

Each resolves the sender from `releases.workspace_id`.

## The `team@mixarchitect.com` fallback — kept, and it's automatic
`getWorkspaceSenderFrom()` **already returns the Mix Architect default** whenever the workspace is `null`, has no email domain, or the domain isn't `verified`:
```ts
if (!workspaceId) return DEFAULT_FROM;
if (!data || data.status !== "verified" || !data.domain) return DEFAULT_FROM;
```
So it's a **built-in protective fallback** — Free/Pro and unverified-domain Studio workspaces are unaffected, and no per-call guarding is needed. Wiring it in only changes behavior for a Studio workspace that has actually verified a domain.

## Intentionally left as Mix Architect (platform mail, not studio→client)
- `api/admin/*` (bulk email, notifications, signup alert to the founder)
- `lib/email/service.ts` transactional dispatcher — it's `userId`-scoped with per-recipient preferences/unsubscribe, i.e. platform→user account mail (welcome, subscription, payment received)

## Verification
- `tsc --noEmit` clean on all 3 files (`releases.workspace_id` is a typed column)
- No **new** eslint issues — the only flags in these files are pre-existing `require("resend")` lazy-inits I didn't touch; `send-invite` is fully lint-clean
- Grep-confirmed: 0 remaining `team@mixarchitect.com` in the 3 files; 7 total `getWorkspaceSenderFrom` call sites

## Known follow-up (out of scope)
The `send-invite` HTML body still hardcodes Mix Architect chrome (label, button, footer). Switching the **from** is the high-impact deliverability/brand signal; full **body** white-labeling (logo/name/footer per workspace) across these templates is a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)