### PR TITLE
Studio: white-label client email bodies (logo, accent, footer)

### DIFF
--- a/src/actions/quotes.ts
+++ b/src/actions/quotes.ts
@@ -9,7 +9,7 @@ import {
   buildUnsubscribeUrl,
 } from "@/lib/email/service";
 import { buildQuoteReceivedEmail } from "@/lib/email-templates/quote-emails";
-import { getWorkspaceSenderFrom } from "@/lib/email/workspace-sender";
+import { getWorkspaceSenderFrom, getWorkspaceEmailBrand } from "@/lib/email/workspace-sender";
 import { syncPaymentStatus } from "@/lib/payment-sync";
 import { fireTrigger } from "@/lib/workflow-engine";
 import type { Quote, QuoteLineItem, PaymentSchedule } from "@/types/payments";
@@ -503,16 +503,20 @@ export async function sendQuote(
     ? buildUnsubscribeUrl(prefs.unsubscribe_token, "payment_received")
     : undefined;
 
-  const email = buildQuoteReceivedEmail({
-    engineerName: displayName,
-    quoteNumber: quote.quote_number,
-    total: quote.total,
-    currency: quote.currency,
-    releaseTitle,
-    portalUrl,
-    unsubscribeUrl,
-    documentType: quote.document_type ?? "quote",
-  });
+  const brand = await getWorkspaceEmailBrand(quote.workspace_id);
+  const email = buildQuoteReceivedEmail(
+    {
+      engineerName: displayName,
+      quoteNumber: quote.quote_number,
+      total: quote.total,
+      currency: quote.currency,
+      releaseTitle,
+      portalUrl,
+      unsubscribeUrl,
+      documentType: quote.document_type ?? "quote",
+    },
+    brand,
+  );
 
   // Send directly via Resend (client email, not engineer's preference system)
   const resendKey = process.env.RESEND_API_KEY;

--- a/src/app/api/portal/notify/route.ts
+++ b/src/app/api/portal/notify/route.ts
@@ -7,7 +7,7 @@ import {
   buildTrackDeliveredEmail,
 } from "@/lib/email-templates/portal-notification";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
-import { getWorkspaceSenderFrom } from "@/lib/email/workspace-sender";
+import { getWorkspaceSenderFrom, getWorkspaceEmailBrand } from "@/lib/email/workspace-sender";
 
 // Lazy-init Resend to avoid build failures when RESEND_API_KEY is missing
 function getResend() {
@@ -93,6 +93,7 @@ export async function POST(req: NextRequest) {
     // Determine recipient and check notification preferences
     let recipientEmail: string | null = null;
     let emailContent: { subject: string; html: string } | null = null;
+    const brand = await getWorkspaceEmailBrand(releaseRel?.workspace_id ?? null);
 
     if (event === "approved" || event === "changes_requested") {
       // Notify engineer (release owner)
@@ -109,20 +110,26 @@ export async function POST(req: NextRequest) {
       recipientEmail = ownerData?.user?.email ?? null;
 
       if (event === "approved") {
-        emailContent = buildTrackApprovedEmail({
-          releaseTitle,
-          trackTitle,
-          actorName: actor_name || "Client",
-          portalUrl,
-        });
+        emailContent = buildTrackApprovedEmail(
+          {
+            releaseTitle,
+            trackTitle,
+            actorName: actor_name || "Client",
+            portalUrl,
+          },
+          brand,
+        );
       } else {
-        emailContent = buildChangesRequestedEmail({
-          releaseTitle,
-          trackTitle,
-          actorName: actor_name || "Client",
-          note: note || "",
-          portalUrl,
-        });
+        emailContent = buildChangesRequestedEmail(
+          {
+            releaseTitle,
+            trackTitle,
+            actorName: actor_name || "Client",
+            note: note || "",
+            portalUrl,
+          },
+          brand,
+        );
       }
     } else if (event === "new_version" || event === "delivered") {
       // Notify client
@@ -133,9 +140,9 @@ export async function POST(req: NextRequest) {
       recipientEmail = share.client_notification_email;
 
       if (event === "new_version") {
-        emailContent = buildNewVersionEmail({ releaseTitle, trackTitle, portalUrl });
+        emailContent = buildNewVersionEmail({ releaseTitle, trackTitle, portalUrl }, brand);
       } else {
-        emailContent = buildTrackDeliveredEmail({ releaseTitle, trackTitle, portalUrl });
+        emailContent = buildTrackDeliveredEmail({ releaseTitle, trackTitle, portalUrl }, brand);
       }
     }
 

--- a/src/app/api/send-invite/route.ts
+++ b/src/app/api/send-invite/route.ts
@@ -2,66 +2,45 @@ import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
-import { getWorkspaceSenderFrom } from "@/lib/email/workspace-sender";
+import { getWorkspaceSenderFrom, getWorkspaceEmailBrand } from "@/lib/email/workspace-sender";
+import {
+  brandedWrap,
+  brandedCta,
+  escapeHtml,
+  heading,
+  paragraph,
+  DEFAULT_BRAND,
+  type EmailBrand,
+} from "@/lib/email-templates/branded-layout";
 
 const resend = new Resend(process.env.RESEND_API_KEY || "re_placeholder");
 
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-function buildInviteHtml({
-  inviterEmail,
-  releaseTitle,
-  role,
-  appUrl,
-}: {
-  inviterEmail: string;
-  releaseTitle: string;
-  role: string;
-  appUrl: string;
-}) {
-  const safeInviter = escapeHtml(inviterEmail);
-  const safeTitle = escapeHtml(releaseTitle);
+function buildInviteHtml(
+  {
+    inviterEmail,
+    releaseTitle,
+    role,
+    appUrl,
+  }: {
+    inviterEmail: string;
+    releaseTitle: string;
+    role: string;
+    appUrl: string;
+  },
+  brand: EmailBrand = DEFAULT_BRAND,
+) {
   const roleLabel = role === "collaborator" ? "Collaborator" : "Client";
   const signInUrl = `${appUrl}/auth/sign-in`;
 
-  return `<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8" /></head>
-<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:40px 0;">
-    <tr><td align="center">
-      <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;">
-        <tr><td style="padding:32px 32px 24px;">
-          <div style="font-size:11px;text-transform:uppercase;letter-spacing:1px;color:#a1a1aa;margin-bottom:16px;">Mix Architect</div>
-          <h1 style="margin:0 0 16px;font-size:20px;color:#18181b;">You&rsquo;ve been invited to collaborate</h1>
-          <p style="margin:0 0 12px;font-size:14px;line-height:1.6;color:#3f3f46;">
-            <strong>${safeInviter}</strong> has invited you as a <strong>${roleLabel}</strong> on the release <strong>&ldquo;${safeTitle}&rdquo;</strong>.
-          </p>
-          <p style="margin:0 0 24px;font-size:14px;line-height:1.6;color:#71717a;">
-            Sign in or create an account to view the project and start collaborating.
-          </p>
-          <a href="${signInUrl}" style="display:inline-block;padding:10px 24px;background:#18181b;color:#ffffff;font-size:14px;font-weight:500;text-decoration:none;border-radius:6px;">
-            Open Mix Architect
-          </a>
-        </td></tr>
-        <tr><td style="padding:16px 32px;border-top:1px solid #e4e4e7;">
-          <p style="margin:0;font-size:11px;color:#a1a1aa;">
-            You received this email because ${safeInviter} invited you on
-            <a href="${appUrl}" style="color:#a1a1aa;">mixarchitect.com</a>.
-          </p>
-        </td></tr>
-      </table>
-    </td></tr>
-  </table>
-</body>
-</html>`;
+  return brandedWrap(
+    `
+      ${heading("You've been invited to collaborate")}
+      ${paragraph(`<strong>${escapeHtml(inviterEmail)}</strong> has invited you as a <strong>${roleLabel}</strong> on the release <strong>&ldquo;${escapeHtml(releaseTitle)}&rdquo;</strong>.`)}
+      ${paragraph("Sign in or create an account to view the project and start collaborating.")}
+      ${brandedCta("Accept invitation", signInUrl, brand)}
+    `,
+    brand,
+  );
 }
 
 export async function POST(request: NextRequest) {
@@ -109,13 +88,14 @@ export async function POST(request: NextRequest) {
 
   // Send email
   const appUrl = new URL(request.url).origin;
+  const brand = await getWorkspaceEmailBrand(release.workspace_id);
 
   try {
     await resend.emails.send({
       from: await getWorkspaceSenderFrom(release.workspace_id),
       to: email,
       subject: `You've been invited to collaborate on "${releaseTitle}"`,
-      html: buildInviteHtml({ inviterEmail, releaseTitle, role, appUrl }),
+      html: buildInviteHtml({ inviterEmail, releaseTitle, role, appUrl }, brand),
     });
 
     return NextResponse.json({ success: true });

--- a/src/lib/email-templates/branded-layout.ts
+++ b/src/lib/email-templates/branded-layout.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared HTML email layout. Renders the outer shell, header, and footer with an
+ * optional per-workspace brand (Studio white-label). Falls back to Mix Architect
+ * chrome via DEFAULT_BRAND so non-branded callers render exactly as before.
+ *
+ * The brand is resolved server-side by getWorkspaceEmailBrand() in
+ * src/lib/email/workspace-sender.ts — only Studio workspaces (removePoweredBy)
+ * get a non-default brand.
+ */
+
+export type EmailBrand = {
+  /** Studio name, or "Mix Architect" for the default. */
+  name: string;
+  /** Public URL of the studio logo (light variant), or null to render the name. */
+  logoUrl: string | null;
+  /** Accent hex (#RRGGBB) for the header text and neutral CTAs. */
+  accent: string;
+  /** When true, the footer credits Mix Architect; when false, it credits `name`. */
+  showPoweredBy: boolean;
+};
+
+export const DEFAULT_BRAND: EmailBrand = {
+  name: "Mix Architect",
+  logoUrl: null,
+  accent: "#0D9488",
+  showPoweredBy: true,
+};
+
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Wrap body `content` in the branded shell. `footerExtra` appends inside the
+ * footer block (e.g. an unsubscribe link).
+ */
+export function brandedWrap(
+  content: string,
+  brand: EmailBrand = DEFAULT_BRAND,
+  footerExtra = "",
+): string {
+  const header = brand.logoUrl
+    ? `<img src="${escapeHtml(brand.logoUrl)}" alt="${escapeHtml(brand.name)}" style="max-height:40px;max-width:220px;margin-bottom:24px;display:block">`
+    : `<div style="font-size:14px;font-weight:600;color:${brand.accent};margin-bottom:24px;text-transform:uppercase;letter-spacing:0.04em">${escapeHtml(brand.name)}</div>`;
+
+  const attribution = brand.showPoweredBy
+    ? `Sent by <a href="https://mixarchitect.com" style="color:${brand.accent};text-decoration:none">Mix Architect</a>`
+    : `Sent by ${escapeHtml(brand.name)}`;
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f5f5f5">
+<table width="100%" cellpadding="0" cellspacing="0" style="padding:40px 20px">
+<tr><td align="center">
+<table width="560" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:8px;overflow:hidden;border:1px solid #e5e5e5">
+<tr><td style="padding:32px 40px">
+  ${header}
+  ${content}
+  <div style="margin-top:32px;padding-top:16px;border-top:1px solid #eee;font-size:11px;color:#999">
+    ${attribution}
+    ${footerExtra}
+  </div>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
+/** A solid button in the brand accent (white label text). */
+export function brandedCta(
+  label: string,
+  url: string,
+  brand: EmailBrand = DEFAULT_BRAND,
+): string {
+  return `<a href="${escapeHtml(url)}" style="display:inline-block;margin-top:8px;padding:10px 24px;background:${brand.accent};color:#fff;font-size:14px;font-weight:600;text-decoration:none;border-radius:6px">${escapeHtml(label)}</a>`;
+}
+
+export function heading(text: string): string {
+  return `<h2 style="margin:0 0 12px;font-size:18px;color:#1a1a1a">${escapeHtml(text)}</h2>`;
+}
+
+export function paragraph(text: string): string {
+  return `<p style="margin:0 0 8px;font-size:14px;color:#666;line-height:1.6">${text}</p>`;
+}

--- a/src/lib/email-templates/portal-notification.ts
+++ b/src/lib/email-templates/portal-notification.ts
@@ -1,37 +1,16 @@
 /**
  * Email templates for portal notification events.
- * Follows the same HTML structure pattern as send-invite.
+ * Header/footer/neutral CTAs are branded per workspace (Studio white-label);
+ * approved/delivered keep their semantic status colors.
  */
 
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-function wrap(content: string): string {
-  return `<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
-<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f5f5f5">
-<table width="100%" cellpadding="0" cellspacing="0" style="padding:40px 20px">
-<tr><td align="center">
-<table width="560" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:8px;overflow:hidden;border:1px solid #e5e5e5">
-<tr><td style="padding:32px 40px">
-  <div style="font-size:14px;font-weight:600;color:#0D9488;margin-bottom:24px">MIX ARCHITECT</div>
-  ${content}
-  <div style="margin-top:32px;padding-top:16px;border-top:1px solid #eee;font-size:11px;color:#999">
-    Sent by <a href="https://mixarchitect.com" style="color:#0D9488;text-decoration:none">Mix Architect</a>
-  </div>
-</td></tr>
-</table>
-</td></tr>
-</table>
-</body>
-</html>`;
-}
+import {
+  brandedWrap,
+  brandedCta,
+  escapeHtml,
+  DEFAULT_BRAND,
+  type EmailBrand,
+} from "./branded-layout";
 
 type NewVersionParams = {
   releaseTitle: string;
@@ -39,19 +18,23 @@ type NewVersionParams = {
   portalUrl: string;
 };
 
-export function buildNewVersionEmail({ releaseTitle, trackTitle, portalUrl }: NewVersionParams) {
+export function buildNewVersionEmail(
+  { releaseTitle, trackTitle, portalUrl }: NewVersionParams,
+  brand: EmailBrand = DEFAULT_BRAND,
+) {
   return {
     subject: `New version ready for review — ${escapeHtml(trackTitle)}`,
-    html: wrap(`
+    html: brandedWrap(
+      `
       <h2 style="margin:0 0 8px;font-size:18px;color:#1a1a1a">New version ready for review</h2>
       <p style="margin:0 0 16px;font-size:14px;color:#666">
         A new version of <strong>${escapeHtml(trackTitle)}</strong> on
         <strong>${escapeHtml(releaseTitle)}</strong> is ready for your review.
       </p>
-      <a href="${escapeHtml(portalUrl)}" style="display:inline-block;padding:10px 24px;background:#0D9488;color:#1a1a1a;font-size:14px;font-weight:600;text-decoration:none;border-radius:6px">
-        Review on Portal
-      </a>
-    `),
+      ${brandedCta("Review on Portal", portalUrl, brand)}
+    `,
+      brand,
+    ),
   };
 }
 
@@ -62,10 +45,14 @@ type ApprovalParams = {
   portalUrl: string;
 };
 
-export function buildTrackApprovedEmail({ releaseTitle, trackTitle, actorName, portalUrl }: ApprovalParams) {
+export function buildTrackApprovedEmail(
+  { releaseTitle, trackTitle, actorName, portalUrl }: ApprovalParams,
+  brand: EmailBrand = DEFAULT_BRAND,
+) {
   return {
     subject: `Track approved — ${escapeHtml(trackTitle)}`,
-    html: wrap(`
+    html: brandedWrap(
+      `
       <h2 style="margin:0 0 8px;font-size:18px;color:#1a1a1a">Track approved</h2>
       <p style="margin:0 0 16px;font-size:14px;color:#666">
         <strong>${escapeHtml(actorName)}</strong> approved
@@ -75,7 +62,9 @@ export function buildTrackApprovedEmail({ releaseTitle, trackTitle, actorName, p
       <a href="${escapeHtml(portalUrl)}" style="display:inline-block;padding:10px 24px;background:#22C55E;color:#fff;font-size:14px;font-weight:600;text-decoration:none;border-radius:6px">
         View Portal
       </a>
-    `),
+    `,
+      brand,
+    ),
   };
 }
 
@@ -87,23 +76,27 @@ type ChangesParams = {
   portalUrl: string;
 };
 
-export function buildChangesRequestedEmail({ releaseTitle, trackTitle, actorName, note, portalUrl }: ChangesParams) {
+export function buildChangesRequestedEmail(
+  { releaseTitle, trackTitle, actorName, note, portalUrl }: ChangesParams,
+  brand: EmailBrand = DEFAULT_BRAND,
+) {
   return {
     subject: `Changes requested — ${escapeHtml(trackTitle)}`,
-    html: wrap(`
+    html: brandedWrap(
+      `
       <h2 style="margin:0 0 8px;font-size:18px;color:#1a1a1a">Changes requested</h2>
       <p style="margin:0 0 8px;font-size:14px;color:#666">
         <strong>${escapeHtml(actorName)}</strong> requested changes on
         <strong>${escapeHtml(trackTitle)}</strong> on
         <strong>${escapeHtml(releaseTitle)}</strong>:
       </p>
-      <div style="margin:0 0 16px;padding:12px 16px;background:#f9f5f0;border-left:3px solid #0D9488;border-radius:4px;font-size:14px;color:#333;line-height:1.5">
+      <div style="margin:0 0 16px;padding:12px 16px;background:#f9f5f0;border-left:3px solid ${brand.accent};border-radius:4px;font-size:14px;color:#333;line-height:1.5">
         ${escapeHtml(note)}
       </div>
-      <a href="${escapeHtml(portalUrl)}" style="display:inline-block;padding:10px 24px;background:#0D9488;color:#1a1a1a;font-size:14px;font-weight:600;text-decoration:none;border-radius:6px">
-        View Portal
-      </a>
-    `),
+      ${brandedCta("View Portal", portalUrl, brand)}
+    `,
+      brand,
+    ),
   };
 }
 
@@ -113,10 +106,14 @@ type DeliveredParams = {
   portalUrl: string;
 };
 
-export function buildTrackDeliveredEmail({ releaseTitle, trackTitle, portalUrl }: DeliveredParams) {
+export function buildTrackDeliveredEmail(
+  { releaseTitle, trackTitle, portalUrl }: DeliveredParams,
+  brand: EmailBrand = DEFAULT_BRAND,
+) {
   return {
     subject: `Track delivered — ${escapeHtml(trackTitle)}`,
-    html: wrap(`
+    html: brandedWrap(
+      `
       <h2 style="margin:0 0 8px;font-size:18px;color:#1a1a1a">Track delivered</h2>
       <p style="margin:0 0 16px;font-size:14px;color:#666">
         <strong>${escapeHtml(trackTitle)}</strong> on
@@ -125,6 +122,8 @@ export function buildTrackDeliveredEmail({ releaseTitle, trackTitle, portalUrl }
       <a href="${escapeHtml(portalUrl)}" style="display:inline-block;padding:10px 24px;background:#3B82F6;color:#fff;font-size:14px;font-weight:600;text-decoration:none;border-radius:6px">
         View Portal
       </a>
-    `),
+    `,
+      brand,
+    ),
   };
 }

--- a/src/lib/email-templates/quote-emails.ts
+++ b/src/lib/email-templates/quote-emails.ts
@@ -1,76 +1,48 @@
 /**
  * Email templates for quote notifications.
- * Follows the same inline HTML pattern as transactional.ts.
+ * Branded per workspace (Studio white-label) via the shared layout.
  */
 
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
+import {
+  brandedWrap,
+  brandedCta,
+  escapeHtml,
+  heading,
+  paragraph,
+  DEFAULT_BRAND,
+  type EmailBrand,
+} from "./branded-layout";
 
-function wrap(content: string, unsubscribeUrl?: string): string {
-  const unsubscribeHtml = unsubscribeUrl
+function unsubscribeFooter(unsubscribeUrl?: string): string {
+  return unsubscribeUrl
     ? `<div style="margin-top:12px;font-size:11px"><a href="${escapeHtml(unsubscribeUrl)}" style="color:#999;text-decoration:underline">Unsubscribe from these emails</a></div>`
     : "";
-
-  return `<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
-<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f5f5f5">
-<table width="100%" cellpadding="0" cellspacing="0" style="padding:40px 20px">
-<tr><td align="center">
-<table width="560" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:8px;overflow:hidden;border:1px solid #e5e5e5">
-<tr><td style="padding:32px 40px">
-  <div style="font-size:14px;font-weight:600;color:#0D9488;margin-bottom:24px">MIX ARCHITECT</div>
-  ${content}
-  <div style="margin-top:32px;padding-top:16px;border-top:1px solid #eee;font-size:11px;color:#999">
-    Sent by <a href="https://mixarchitect.com" style="color:#0D9488;text-decoration:none">Mix Architect</a>
-    ${unsubscribeHtml}
-  </div>
-</td></tr>
-</table>
-</td></tr>
-</table>
-</body>
-</html>`;
-}
-
-function cta(label: string, url: string): string {
-  return `<a href="${escapeHtml(url)}" style="display:inline-block;margin-top:8px;padding:10px 24px;background:#0D9488;color:#fff;font-size:14px;font-weight:600;text-decoration:none;border-radius:6px">${escapeHtml(label)}</a>`;
-}
-
-function paragraph(text: string): string {
-  return `<p style="margin:0 0 8px;font-size:14px;color:#666;line-height:1.6">${text}</p>`;
-}
-
-function heading(text: string): string {
-  return `<h2 style="margin:0 0 12px;font-size:18px;color:#1a1a1a">${escapeHtml(text)}</h2>`;
 }
 
 // ─── Quote Received ──────────────────────────────────────────────
 
-export function buildQuoteReceivedEmail({
-  engineerName,
-  quoteNumber,
-  total,
-  currency,
-  releaseTitle,
-  portalUrl,
-  unsubscribeUrl,
-  documentType = "quote",
-}: {
-  engineerName: string;
-  quoteNumber: string;
-  total: number;
-  currency: string;
-  releaseTitle?: string;
-  portalUrl: string;
-  unsubscribeUrl?: string;
-  documentType?: "quote" | "invoice";
-}) {
+export function buildQuoteReceivedEmail(
+  {
+    engineerName,
+    quoteNumber,
+    total,
+    currency,
+    releaseTitle,
+    portalUrl,
+    unsubscribeUrl,
+    documentType = "quote",
+  }: {
+    engineerName: string;
+    quoteNumber: string;
+    total: number;
+    currency: string;
+    releaseTitle?: string;
+    portalUrl: string;
+    unsubscribeUrl?: string;
+    documentType?: "quote" | "invoice";
+  },
+  brand: EmailBrand = DEFAULT_BRAND,
+) {
   const formattedTotal = new Intl.NumberFormat("en-US", {
     style: "currency",
     currency,
@@ -85,7 +57,7 @@ export function buildQuoteReceivedEmail({
 
   return {
     subject: `${docLabel} ${quoteNumber} from ${engineerName}`,
-    html: wrap(
+    html: brandedWrap(
       `
       ${heading(`${docLabel} ${escapeHtml(quoteNumber)}`)}
       ${paragraph(`${escapeHtml(engineerName)} has sent you ${docLabelLower}${projectLine}.`)}
@@ -94,32 +66,35 @@ export function buildQuoteReceivedEmail({
         <div style="font-size:12px;color:#999;margin-top:4px">${escapeHtml(currency)}</div>
       </div>
       ${paragraph(`View the full ${docLabel.toLowerCase()} details and pay online:`)}
-      ${cta(`View ${docLabel}`, portalUrl)}
+      ${brandedCta(`View ${docLabel}`, portalUrl, brand)}
     `,
-      unsubscribeUrl,
+      brand,
+      unsubscribeFooter(unsubscribeUrl),
     ),
   };
 }
 
 // ─── Payment Confirmation ────────────────────────────────────────
 
-export function buildPaymentConfirmationEmail({
-  clientName,
-  engineerName,
-  quoteNumber,
-  total,
-  currency,
-  releaseTitle,
-  unsubscribeUrl,
-}: {
-  clientName: string;
-  engineerName: string;
-  quoteNumber: string;
-  total: number;
-  currency: string;
-  releaseTitle?: string;
-  unsubscribeUrl?: string;
-}) {
+export function buildPaymentConfirmationEmail(
+  {
+    clientName,
+    quoteNumber,
+    total,
+    currency,
+    releaseTitle,
+    unsubscribeUrl,
+  }: {
+    clientName: string;
+    engineerName: string;
+    quoteNumber: string;
+    total: number;
+    currency: string;
+    releaseTitle?: string;
+    unsubscribeUrl?: string;
+  },
+  brand: EmailBrand = DEFAULT_BRAND,
+) {
   const formattedTotal = new Intl.NumberFormat("en-US", {
     style: "currency",
     currency,
@@ -131,7 +106,7 @@ export function buildPaymentConfirmationEmail({
 
   return {
     subject: `Payment received — ${quoteNumber}`,
-    html: wrap(
+    html: brandedWrap(
       `
       ${heading("Payment Received")}
       ${paragraph(`${escapeHtml(clientName)} has paid ${formattedTotal}${projectLine}.`)}
@@ -141,7 +116,8 @@ export function buildPaymentConfirmationEmail({
       </div>
       ${paragraph("The payment has been processed and will appear in your Stripe dashboard.")}
     `,
-      unsubscribeUrl,
+      brand,
+      unsubscribeFooter(unsubscribeUrl),
     ),
   };
 }

--- a/src/lib/email-templates/workflow-emails.ts
+++ b/src/lib/email-templates/workflow-emails.ts
@@ -1,112 +1,94 @@
 /**
- * Email templates for workflow-triggered emails.
- * Follows the same inline HTML pattern as transactional.ts.
+ * Email templates for workflow-triggered emails (client-facing).
+ * Branded per workspace (Studio white-label) via the shared layout.
  */
 
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-function wrap(content: string): string {
-  return `<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
-<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f5f5f5">
-<table width="100%" cellpadding="0" cellspacing="0" style="padding:40px 20px">
-<tr><td align="center">
-<table width="560" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:8px;overflow:hidden;border:1px solid #e5e5e5">
-<tr><td style="padding:32px 40px">
-  <div style="font-size:14px;font-weight:600;color:#0D9488;margin-bottom:24px">MIX ARCHITECT</div>
-  ${content}
-  <div style="margin-top:32px;padding-top:16px;border-top:1px solid #eee;font-size:11px;color:#999">
-    Sent by <a href="https://mixarchitect.com" style="color:#0D9488;text-decoration:none">Mix Architect</a>
-  </div>
-</td></tr>
-</table>
-</td></tr>
-</table>
-</body>
-</html>`;
-}
-
-function cta(label: string, url: string): string {
-  return `<a href="${escapeHtml(url)}" style="display:inline-block;margin-top:8px;padding:10px 24px;background:#0D9488;color:#fff;font-size:14px;font-weight:600;text-decoration:none;border-radius:6px">${escapeHtml(label)}</a>`;
-}
-
-function paragraph(text: string): string {
-  return `<p style="margin:0 0 8px;font-size:14px;color:#666;line-height:1.6">${text}</p>`;
-}
-
-function heading(text: string): string {
-  return `<h2 style="margin:0 0 12px;font-size:18px;color:#1a1a1a">${escapeHtml(text)}</h2>`;
-}
+import {
+  brandedWrap,
+  brandedCta,
+  escapeHtml,
+  heading,
+  paragraph,
+  DEFAULT_BRAND,
+  type EmailBrand,
+} from "./branded-layout";
 
 // ─── Thank You ───────────────────────────────────────────────────
 
-export function buildThankYouEmail({
-  engineerName,
-  clientName,
-  releaseTitle,
-}: {
-  engineerName: string;
-  clientName: string;
-  releaseTitle: string;
-}) {
+export function buildThankYouEmail(
+  {
+    engineerName,
+    clientName,
+    releaseTitle,
+  }: {
+    engineerName: string;
+    clientName: string;
+    releaseTitle: string;
+  },
+  brand: EmailBrand = DEFAULT_BRAND,
+) {
   return {
     subject: `Thank you — ${releaseTitle}`,
-    html: wrap(`
+    html: brandedWrap(
+      `
       ${heading(`Thank you, ${escapeHtml(clientName)}!`)}
       ${paragraph(`Thank you for working with ${escapeHtml(engineerName)} on <strong>${escapeHtml(releaseTitle)}</strong>. We hope you're happy with the result!`)}
       ${paragraph("If you have any feedback or need anything else, don't hesitate to reach out.")}
-    `),
+    `,
+      brand,
+    ),
   };
 }
 
 // ─── Testimonial Request ─────────────────────────────────────────
 
-export function buildTestimonialRequestEmail({
-  engineerName,
-  clientName,
-  releaseTitle,
-}: {
-  engineerName: string;
-  clientName: string;
-  releaseTitle: string;
-}) {
+export function buildTestimonialRequestEmail(
+  {
+    engineerName,
+    clientName,
+    releaseTitle,
+  }: {
+    engineerName: string;
+    clientName: string;
+    releaseTitle: string;
+  },
+  brand: EmailBrand = DEFAULT_BRAND,
+) {
   return {
     subject: `How was your experience? — ${releaseTitle}`,
-    html: wrap(`
+    html: brandedWrap(
+      `
       ${heading("How was your experience?")}
       ${paragraph(`Hi ${escapeHtml(clientName)},`)}
       ${paragraph(`Now that <strong>${escapeHtml(releaseTitle)}</strong> is complete, we'd love to hear your feedback. How was your experience working with ${escapeHtml(engineerName)}?`)}
       ${paragraph("A quick testimonial would mean the world — just reply to this email with your thoughts!")}
-    `),
+    `,
+      brand,
+    ),
   };
 }
 
 // ─── Payment Reminder ────────────────────────────────────────────
 
-export function buildPaymentReminderWorkflowEmail({
-  engineerName,
-  quoteNumber,
-  total,
-  currency,
-  releaseTitle,
-  portalUrl,
-  dueDate,
-}: {
-  engineerName: string;
-  quoteNumber: string;
-  total: number;
-  currency: string;
-  releaseTitle?: string | null;
-  portalUrl: string;
-  dueDate?: string | null;
-}) {
+export function buildPaymentReminderWorkflowEmail(
+  {
+    quoteNumber,
+    total,
+    currency,
+    releaseTitle,
+    portalUrl,
+    dueDate,
+  }: {
+    engineerName: string;
+    quoteNumber: string;
+    total: number;
+    currency: string;
+    releaseTitle?: string | null;
+    portalUrl: string;
+    dueDate?: string | null;
+  },
+  brand: EmailBrand = DEFAULT_BRAND,
+) {
   const formattedTotal = new Intl.NumberFormat("en-US", {
     style: "currency",
     currency,
@@ -122,14 +104,17 @@ export function buildPaymentReminderWorkflowEmail({
 
   return {
     subject: `Payment reminder — Quote ${quoteNumber}`,
-    html: wrap(`
+    html: brandedWrap(
+      `
       ${heading("Payment Reminder")}
       ${paragraph(`Friendly reminder: Quote ${escapeHtml(quoteNumber)}${projectLine} is outstanding.`)}
       <div style="margin:16px 0;padding:16px;background:#f9f9f9;border-radius:6px;border:1px solid #eee">
         <div style="font-size:20px;font-weight:700;color:#1a1a1a">${formattedTotal}</div>
         <div style="font-size:12px;color:#999;margin-top:4px">${escapeHtml(currency)}${dueLine}</div>
       </div>
-      ${cta("Pay Now", portalUrl)}
-    `),
+      ${brandedCta("Pay Now", portalUrl, brand)}
+    `,
+      brand,
+    ),
   };
 }

--- a/src/lib/email/workspace-sender.ts
+++ b/src/lib/email/workspace-sender.ts
@@ -1,6 +1,10 @@
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+import { getEntitlements, normalizePlan } from "@/lib/entitlements";
+import { DEFAULT_BRAND, type EmailBrand } from "@/lib/email-templates/branded-layout";
 
 export const DEFAULT_FROM = "Mix Architect <team@mixarchitect.com>";
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 
 /**
  * The `from` header for a workspace's outbound email. If the workspace has a
@@ -31,4 +35,44 @@ export async function getWorkspaceSenderFrom(
   const name = (ws?.name ?? "").trim() || "Mix Architect";
   const local = (data.sender_local || "noreply").replace(/[^a-z0-9._-]/gi, "") || "noreply";
   return `${name} <${local}@${data.domain}>`;
+}
+
+/**
+ * The brand (logo/name/accent/footer) for a workspace's outbound email bodies.
+ * Studio white-label only: returns the workspace's own brand when the plan
+ * grants full white-label (removePoweredBy); otherwise the Mix Architect
+ * default, so Free/Pro emails render unchanged. Server-only (service client).
+ */
+export async function getWorkspaceEmailBrand(
+  workspaceId: string | null | undefined,
+): Promise<EmailBrand> {
+  if (!workspaceId) return DEFAULT_BRAND;
+
+  const service = createSupabaseServiceClient();
+  const { data: ws } = await service
+    .from("workspaces")
+    .select("name, plan")
+    .eq("id", workspaceId)
+    .maybeSingle();
+
+  if (!ws || !getEntitlements(normalizePlan(ws.plan)).removePoweredBy) {
+    return DEFAULT_BRAND;
+  }
+
+  const { data: branding } = await service
+    .from("workspace_branding")
+    .select("logo_path, accent_color")
+    .eq("workspace_id", workspaceId)
+    .maybeSingle();
+
+  const accent =
+    branding?.accent_color && HEX_RE.test(branding.accent_color)
+      ? branding.accent_color
+      : DEFAULT_BRAND.accent;
+  const logoUrl = branding?.logo_path
+    ? service.storage.from("workspace-logos").getPublicUrl(branding.logo_path).data.publicUrl
+    : null;
+  const name = (ws.name ?? "").trim() || DEFAULT_BRAND.name;
+
+  return { name, logoUrl, accent, showPoweredBy: false };
 }

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -1,6 +1,6 @@
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { sendQuote } from "@/actions/quotes";
-import { getWorkspaceSenderFrom } from "@/lib/email/workspace-sender";
+import { getWorkspaceSenderFrom, getWorkspaceEmailBrand } from "@/lib/email/workspace-sender";
 import type { TriggerEvent, ActionType } from "@/types/payments";
 
 export type TriggerContext = {
@@ -166,11 +166,15 @@ async function handleSendEmailThankYou(context: TriggerContext): Promise<ActionR
   const { getUserDisplayName } = await import("@/lib/email/service");
   const engineerName = await getUserDisplayName(context.userId);
 
-  const { subject, html } = buildThankYouEmail({
-    engineerName,
-    clientName: release.client_name || "there",
-    releaseTitle: release.title,
-  });
+  const brand = await getWorkspaceEmailBrand(release?.workspace_id ?? null);
+  const { subject, html } = buildThankYouEmail(
+    {
+      engineerName,
+      clientName: release.client_name || "there",
+      releaseTitle: release.title,
+    },
+    brand,
+  );
 
   const { Resend } = require("resend") as typeof import("resend");
   const resend = new Resend(process.env.RESEND_API_KEY);
@@ -206,11 +210,15 @@ async function handleSendEmailTestimonialRequest(
   const { getUserDisplayName } = await import("@/lib/email/service");
   const engineerName = await getUserDisplayName(context.userId);
 
-  const { subject, html } = buildTestimonialRequestEmail({
-    engineerName,
-    clientName: release.client_name || "there",
-    releaseTitle: release.title,
-  });
+  const brand = await getWorkspaceEmailBrand(release?.workspace_id ?? null);
+  const { subject, html } = buildTestimonialRequestEmail(
+    {
+      engineerName,
+      clientName: release.client_name || "there",
+      releaseTitle: release.title,
+    },
+    brand,
+  );
 
   const { Resend } = require("resend") as typeof import("resend");
   const resend = new Resend(process.env.RESEND_API_KEY);
@@ -253,15 +261,19 @@ async function handleSendPaymentReminder(context: TriggerContext): Promise<Actio
     .eq("id", context.releaseId)
     .maybeSingle();
 
-  const { subject, html } = buildPaymentReminderWorkflowEmail({
-    engineerName,
-    quoteNumber: quote.quote_number,
-    total: Number(quote.total),
-    currency: quote.currency,
-    releaseTitle: release?.title,
-    portalUrl: `${baseUrl}/portal/quote/${quote.portal_token}`,
-    dueDate: quote.due_date,
-  });
+  const brand = await getWorkspaceEmailBrand(release?.workspace_id ?? null);
+  const { subject, html } = buildPaymentReminderWorkflowEmail(
+    {
+      engineerName,
+      quoteNumber: quote.quote_number,
+      total: Number(quote.total),
+      currency: quote.currency,
+      releaseTitle: release?.title,
+      portalUrl: `${baseUrl}/portal/quote/${quote.portal_token}`,
+      dueDate: quote.due_date,
+    },
+    brand,
+  );
 
   const { Resend } = require("resend") as typeof import("resend");
   const resend = new Resend(process.env.RESEND_API_KEY);


### PR DESCRIPTION
Completes the Studio branded-email feature. [#69](https://github.com/mixarchitect/mix-architect/pull/69) switched the **from:** address to the studio's verified domain; this switches the email **bodies** too, so a Studio client email is fully white-labeled: studio logo in the header, the studio's accent color on buttons, and a "Sent by <Studio>" footer with **zero Mix Architect chrome**.

Per your call: **Studio only.** Free/Pro emails are byte-for-byte unchanged.

## How it works
- **`branded-layout.ts`** (new) — one shared `brandedWrap`/`brandedCta`/`heading`/`paragraph`, replacing the three copy-pasted `wrap()` layouts. Header renders the logo (or studio name), footer credits the studio (or Mix Architect for the default).
- **`getWorkspaceEmailBrand(workspaceId)`** — resolves `{name, logoUrl, accent, showPoweredBy}` from `workspaces` + `workspace_branding`, **gated on the `removePoweredBy` entitlement** (Studio). Returns the Mix Architect default for any null / non-Studio / unbranded workspace — same safe-fallback pattern as the sender.
- Brand threaded through: portal notifications (×4), workflow emails (×3), the quote email, and the collaborator invite.

## Scope decisions
- **Semantic status colors kept** — approved=green, delivered=blue stay as status signals; the studio accent applies to the header, footer, and neutral CTAs.
- **Engineer-facing mail untouched** — payment-confirmation (Stripe webhook), `admin/*`, and the `service.ts` transactional dispatcher default the `brand` param, so they render exactly as before (they're platform→user, not studio→client).
- **Collaborator invite** refactored onto the shared layout; its CTA is now the neutral "Accept invitation" (it leads to the sign-in page).

## Verification
Rendered both modes and asserted the output:

| | studio logo | accent #7C3AED | MA teal | MA chrome | "Sent by Coastline Audio" |
|---|---|---|---|---|---|
| Default | ✗ | ✗ | ✓ | ✓ | ✗ |
| Studio | ✓ | ✓ | ✗ | ✗ | ✓ |

`tsc --noEmit` and `eslint` clean on all new/changed files (pre-existing `require("resend")` lint in the routes is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)