### PR TITLE
Studio branded email: full-access Resend key for domain management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,12 @@ STRIPE_CONNECT_REDIRECT_URI="${NEXT_PUBLIC_APP_URL}/api/stripe/connect/callback"
 
 
 # ── Email delivery (required for notifications) ──────────────────────
+# Least-privilege "Sending access" key — used for all outbound mail.
 RESEND_API_KEY="re_..."
+# Optional. Full-access key (Domains permission) used ONLY to create/verify
+# Studio branded-email domains. Keep separate so RESEND_API_KEY stays send-only.
+# Falls back to RESEND_API_KEY if unset.
+RESEND_MANAGEMENT_API_KEY="re_..."
 
 
 # ── Cron auth (required if cron handlers are enabled) ────────────────

--- a/src/app/api/workspace/email-domain/route.ts
+++ b/src/app/api/workspace/email-domain/route.ts
@@ -6,8 +6,24 @@ import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { requireSameOrigin } from "@/lib/origin-check";
 import { getEntitlements } from "@/lib/entitlements";
 
-const resend = new Resend(process.env.RESEND_API_KEY || "re_placeholder");
+// Domain management (create/verify/get) needs a full-access Resend key with the
+// Domains permission — NOT the restricted send-only RESEND_API_KEY used by every
+// other send site. Prefer a dedicated management key so the send key can stay
+// least-privilege; fall back to RESEND_API_KEY for single-full-access-key setups.
+const resend = new Resend(
+  process.env.RESEND_MANAGEMENT_API_KEY || process.env.RESEND_API_KEY || "re_placeholder",
+);
 const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+
+// Resend's "only send emails" restriction surfaces on domain-management calls
+// when the key lacks the Domains permission — turn it into an actionable hint.
+function domainMgmtError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : "";
+  if (/restricted|only send|permission|unauthorized|forbidden/i.test(msg)) {
+    return "The email service key can't manage domains yet. Please try again later or contact support.";
+  }
+  return msg || "Failed to add domain.";
+}
 
 /**
  * POST /api/workspace/email-domain
@@ -76,10 +92,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ domain, status: d.status ?? "pending", records: d.records ?? [] });
     } catch (err) {
       console.error("[workspace/email-domain] add failed:", err);
-      return NextResponse.json(
-        { error: err instanceof Error ? err.message : "Failed to add domain." },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: domainMgmtError(err) }, { status: 500 });
     }
   }
 


### PR DESCRIPTION
## The bug (found during Studio smoke test)
Adding a branded-email domain failed with **"This API key is restricted to only send emails"** → 500.

`resend.domains.create/verify/get` require a Resend key with the **Domains** permission. The shared `RESEND_API_KEY` is — correctly — a least-privilege *send-only* key (it's used across ~7 send sites), so it can't manage domains.

## Fix
- The domain-management route now uses **`RESEND_MANAGEMENT_API_KEY`** (full-access), falling back to `RESEND_API_KEY` if unset. The send key stays least-privilege.
- Resend's permission error is mapped to a friendly, non-leaky message instead of surfacing the raw "restricted to only send emails" string to customers.
- Documented the new var in `.env.example`.

Only `src/app/api/workspace/email-domain/route.ts` uses `resend.domains.*`, so this is the single touch point. The custom-portal-domain flow (Vercel API) is unaffected — it already verified fine in testing.

## Config needed (Vercel)
Set **`RESEND_MANAGEMENT_API_KEY`** to a Resend key with **Full access** (or at least Domains). Then redeploy and retry the domain add.

`tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)