### PR TITLE
Fix: bind Tailwind dark: variant to [data-theme=dark] (next-themes)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,13 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/* Dark mode is driven by next-themes via [data-theme="dark"] on <html>, not the
+   OS prefers-color-scheme. Bind Tailwind's `dark:` variant to that attribute so
+   every dark: utility matches the app's actual theme (e.g. the portal's per-theme
+   studio logo). Without this, dark: defaults to prefers-color-scheme and mis-fires
+   whenever the chosen theme differs from the OS. */
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
 /* Toast slide-in animation */
 @keyframes toast-slide-in {
   from { opacity: 0; transform: translateX(100%); }


### PR DESCRIPTION
## The bug (found in the Studio portal)
A dark-themed portal was showing the **light** studio logo (dark "TIIX" text) instead of the uploaded **dark-mode** logo.

## Root cause (global, not just the logo)
The app themes via **next-themes** (`attribute="data-theme"` → `[data-theme="dark"]` on `<html>`), but **Tailwind v4's `dark:` variant defaulted to `prefers-color-scheme`** (the OS) because no dark strategy was configured. So all **72 `dark:` utilities** keyed off the OS instead of the chosen theme — wrong whenever they differ (e.g. app set to dark on a light-mode OS). The portal's per-theme logo (`dark:hidden` / `hidden dark:block`) is where it became visible.

## Fix
One line in `globals.css` — the Tailwind v4 pattern for data-attribute dark mode:
```css
@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
```

## Verified (standalone Tailwind compile)
- `.dark\:hidden` now emits `&:where([data-theme="dark"], [data-theme="dark"] *)`
- **0** utilities still use `prefers-color-scheme` (was the bug)
- CSS compiles clean (tailwindcss v4.3.2)

No effect for users whose OS matches their chosen theme (the common case); only corrects the mismatched case — including your dark portal now showing the dark logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)