### PR TITLE
Security: close identity-override + CSRF gaps in the Studio-era surface

### DIFF
--- a/src/actions/quotes.ts
+++ b/src/actions/quotes.ts
@@ -9,6 +9,7 @@ import {
   buildUnsubscribeUrl,
 } from "@/lib/email/service";
 import { buildQuoteReceivedEmail } from "@/lib/email-templates/quote-emails";
+import { sendQuoteCore } from "@/lib/quotes/send-quote-core";
 import {
   getWorkspaceSenderFrom,
   getWorkspaceEmailBrand,
@@ -433,119 +434,24 @@ export async function deleteQuote(
 }
 
 /**
- * Send a quote. Can be called from both authenticated (server action) and
- * service-client contexts (workflow engine).
- *
- * @param quoteId - The quote ID to send
- * @param options.serviceContext - If provided, uses service client instead of
- *   requiring auth. Must include userId for ownership verification.
+ * Send a quote (server action). Identity is always the signed-in session
+ * user — there is deliberately no identity/service override here: this is
+ * a network-reachable action, so any parameter is attacker-controlled.
+ * Server-side automation (workflow engine) calls sendQuoteCore directly
+ * with a trusted userId instead.
  */
-export async function sendQuote(
-  quoteId: string,
-  options?: { serviceContext?: { userId: string } },
-): Promise<{ error?: string }> {
-  let supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>;
-  let userId: string;
+export async function sendQuote(quoteId: string): Promise<{ error?: string }> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" };
 
-  if (options?.serviceContext) {
-    // Service-client context (workflow engine, webhooks)
-    supabase = createSupabaseServiceClient() as unknown as Awaited<ReturnType<typeof createSupabaseServerClient>>;
-    userId = options.serviceContext.userId;
-  } else {
-    // Authenticated context (server action)
-    supabase = await createSupabaseServerClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) return { error: "Not authenticated" };
-    userId = user.id;
-  }
-
-  const { data: quote } = await supabase
-    .from("quotes")
-    .select("*")
-    .eq("id", quoteId)
-    .eq("user_id", userId)
-    .maybeSingle();
-
-  if (!quote) return { error: "Quote not found" };
-  if (quote.status !== "draft") return { error: "Only draft quotes can be sent" };
-  if (!quote.client_email) return { error: "Client email is required to send" };
-
-  // Update status
-  const { error } = await supabase
-    .from("quotes")
-    .update({ status: "sent", issued_at: new Date().toISOString() })
-    .eq("id", quoteId);
-
-  if (error) return { error: error.message };
-
-  // Send email to client
-  const displayName = await getUserDisplayName(userId);
-  const portalUrl = `${process.env.NEXT_PUBLIC_APP_URL ?? "https://mixarchitect.com"}/portal/quote/${quote.portal_token}`;
-
-  // Get release title if linked
-  let releaseTitle: string | undefined;
-  if (quote.release_id) {
-    const { data: release } = await supabase
-      .from("releases")
-      .select("title")
-      .eq("id", quote.release_id)
-      .maybeSingle();
-    releaseTitle = release?.title;
-  }
-
-  // Get unsubscribe token for the engineer
-  const serviceClient = createSupabaseServiceClient();
-  const { data: prefs } = await serviceClient
-    .from("email_preferences")
-    .select("unsubscribe_token")
-    .eq("user_id", userId)
-    .maybeSingle();
-
-  const unsubscribeUrl = prefs?.unsubscribe_token
-    ? buildUnsubscribeUrl(prefs.unsubscribe_token, "payment_received")
-    : undefined;
-
-  const brand = await getWorkspaceEmailBrand(quote.workspace_id);
-  const email = buildQuoteReceivedEmail(
-    {
-      engineerName: displayName,
-      quoteNumber: quote.quote_number,
-      total: quote.total,
-      currency: quote.currency,
-      releaseTitle,
-      portalUrl,
-      unsubscribeUrl,
-      documentType: quote.document_type ?? "quote",
-    },
-    brand,
+  return sendQuoteCore(
+    supabase as unknown as ReturnType<typeof createSupabaseServiceClient>,
+    user.id,
+    quoteId,
   );
-
-  // Send directly via Resend (client email, not engineer's preference system)
-  const resendKey = process.env.RESEND_API_KEY;
-  if (resendKey) {
-    const { Resend } = require("resend") as typeof import("resend");
-    const resend = new Resend(resendKey);
-    try {
-      await resend.emails.send({
-        from: await getWorkspaceSenderFrom(quote.workspace_id),
-        replyTo: await getWorkspaceReplyTo(quote.workspace_id),
-        to: quote.client_email,
-        subject: email.subject,
-        html: email.html,
-      });
-    } catch (err) {
-      console.error("[quotes] failed to send quote email:", err);
-    }
-  }
-
-  revalidatePath("/app/quotes");
-  if (quote.release_id) {
-    revalidatePath(`/app/releases/${quote.release_id}`);
-  }
-
-  return {};
 }
 
 export async function duplicateQuote(

--- a/src/app/api/admin/log-activity/route.ts
+++ b/src/app/api/admin/log-activity/route.ts
@@ -92,7 +92,30 @@ export async function POST(req: NextRequest) {
     // Signup side effects: welcome email to the user + admin alert.
     // Awaited (not fire-and-forget) so Vercel doesn't terminate the sends
     // when the handler returns.
+    //
+    // Replay guards — this endpoint is reachable by any signed-in user, so
+    // "signup" must not be re-fireable: (a) only within 1h of account
+    // creation, (b) only if no welcome email was ever logged for this user.
+    // Without these, a user could re-post {eventType:"signup"} in a loop and
+    // spam every admin + re-send themselves welcome mail.
     if (eventType === "signup" && user.email) {
+      const accountAgeMs = Date.now() - new Date(user.created_at).getTime();
+      if (accountAgeMs > 60 * 60 * 1000) {
+        return NextResponse.json({ ok: true });
+      }
+
+      const dedupeSvc = createSupabaseServiceClient();
+      const { data: priorWelcome } = await dedupeSvc
+        .from("email_log")
+        .select("id")
+        .eq("user_id", user.id)
+        .eq("category", "welcome")
+        .limit(1)
+        .maybeSingle();
+      if (priorWelcome) {
+        return NextResponse.json({ ok: true });
+      }
+
       const displayName =
         user.user_metadata?.display_name ?? user.email.split("@")[0];
 

--- a/src/app/api/attributions/attribute-signup/route.ts
+++ b/src/app/api/attributions/attribute-signup/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 /**
  * POST /api/attributions/attribute-signup
@@ -16,6 +17,9 @@ import { rateLimit, getClientIp } from "@/lib/rate-limit";
  * user's profile.
  */
 export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
   const ip = getClientIp(req);
   const { success } = rateLimit(`attribution-signup:${ip}`, 10, 60_000);
   if (!success) {

--- a/src/app/api/calendar/generate-token/route.ts
+++ b/src/app/api/calendar/generate-token/route.ts
@@ -2,8 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { generateFeedToken } from "@/lib/calendar";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 export async function POST(request: NextRequest) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const ip = getClientIp(request);
   const { success } = rateLimit(`calendar-token:${ip}`, 5, 60_000);
   if (!success) {

--- a/src/app/api/convert/route.ts
+++ b/src/app/api/convert/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { isConvertible } from "@/lib/conversion-formats";
 import { logActivity } from "@/lib/activity-logger";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 /**
  * POST /api/convert
@@ -16,6 +17,9 @@ import { rateLimit, getClientIp } from "@/lib/rate-limit";
  *   - New:        { jobId, status: "pending" }
  */
 export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
   const ip = getClientIp(req);
   const { success } = rateLimit(`convert:${ip}`, 10, 60_000);
   if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });

--- a/src/app/api/cron/check-distribution/route.ts
+++ b/src/app/api/cron/check-distribution/route.ts
@@ -23,7 +23,9 @@ const MAX_ERRORS = 5; // circuit breaker
  */
 export async function GET(request: NextRequest) {
   const secret = request.headers.get("authorization");
-  if (!secret) {
+  // Fail closed if CRON_SECRET is unset — otherwise the expected digest is
+  // of the literal "Bearer undefined", which an attacker can simply send.
+  if (!secret || !process.env.CRON_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const actual = crypto.createHash('sha256').update(secret).digest();

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
 
 /**
  * POST /api/csp-report
@@ -18,6 +19,10 @@ import { NextRequest, NextResponse } from "next/server";
  * to prevent a hostile page from spamming the endpoint.
  */
 export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+  const { success } = rateLimit(`csp-report:${ip}`, 20, 60_000);
+  if (!success) return NextResponse.json({ ok: true });
+
   try {
     const payload = await req.json().catch(() => null);
     if (!payload) {

--- a/src/app/api/integrations/[provider]/connect/route.ts
+++ b/src/app/api/integrations/[provider]/connect/route.ts
@@ -10,10 +10,14 @@ import {
 } from "@/lib/integrations/oauth";
 import type { IntegrationProvider } from "@/lib/integrations/types";
 import crypto from "crypto";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 type RouteParams = { params: Promise<{ provider: string }> };
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const { provider } = await params;
 
   if (!isValidProvider(provider)) {

--- a/src/app/api/integrations/disconnect/[id]/route.ts
+++ b/src/app/api/integrations/disconnect/[id]/route.ts
@@ -3,10 +3,14 @@ import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { revokeProviderToken } from "@/lib/integrations/oauth";
 import type { IntegrationProvider } from "@/lib/integrations/types";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const { id } = await params;
 
   const ip = getClientIp(request);

--- a/src/app/api/notify/route.ts
+++ b/src/app/api/notify/route.ts
@@ -5,6 +5,7 @@ import { notifyReleaseMembers, type NotificationType } from "@/lib/notifications
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { emailReleaseMembers } from "@/lib/email/release-email";
 import { buildNewCommentEmail } from "@/lib/email-templates/transactional";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 /**
  * POST /api/notify
@@ -12,6 +13,9 @@ import { buildNewCommentEmail } from "@/lib/email-templates/transactional";
  * Authenticates the caller and notifies all release members except the caller.
  */
 export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
   const ip = getClientIp(req);
   const { success } = rateLimit(`notify:${ip}`, 30, 60_000);
   if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });

--- a/src/app/api/perf/ingest/route.ts
+++ b/src/app/api/perf/ingest/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 /** Shape of a single metric sent from the client. */
 interface PerfMetricPayload {
@@ -32,6 +33,9 @@ const MAX_BATCH = 50;
  * Authenticated — user must be logged in.
  */
 export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
   const ip = getClientIp(req);
   const { success } = rateLimit(`perf-ingest:${ip}`, 10, 60_000);
   if (!success) {

--- a/src/app/api/portal/comment/route.ts
+++ b/src/app/api/portal/comment/route.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { notifyReleaseMembers } from "@/lib/notifications/service";
@@ -183,7 +184,14 @@ export async function DELETE(req: NextRequest) {
       .eq("id", comment_id)
       .maybeSingle();
 
-    if (!comment || !comment.delete_token || comment.delete_token !== delete_token) {
+    // Constant-time token compare (hash first so lengths always match).
+    const tokenMatches =
+      !!comment?.delete_token &&
+      crypto.timingSafeEqual(
+        crypto.createHash("sha256").update(String(delete_token)).digest(),
+        crypto.createHash("sha256").update(comment.delete_token).digest(),
+      );
+    if (!comment || !tokenMatches) {
       return NextResponse.json(
         { error: "Cannot delete this comment" },
         { status: 403 },

--- a/src/app/api/releases/[releaseId]/distribution/[distId]/route.ts
+++ b/src/app/api/releases/[releaseId]/distribution/[distId]/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 type RouteContext = {
   params: Promise<{ releaseId: string; distId: string }>;
 };
 
 export async function PATCH(request: NextRequest, { params }: RouteContext) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const ip = getClientIp(request);
   const { success } = rateLimit(`dist-update:${ip}`, 20, 60_000);
   if (!success) {
@@ -72,6 +76,9 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
 }
 
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const ip = getClientIp(request);
   const { success } = rateLimit(`dist-delete:${ip}`, 20, 60_000);
   if (!success) {

--- a/src/app/api/releases/[releaseId]/distribution/bulk-submit/route.ts
+++ b/src/app/api/releases/[releaseId]/distribution/bulk-submit/route.ts
@@ -2,12 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { PLATFORMS } from "@/lib/distribution/platforms";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 type RouteContext = { params: Promise<{ releaseId: string }> };
 
 const validPlatforms = new Set<string>(PLATFORMS.map((p) => p.id));
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const ip = getClientIp(request);
   const { success } = rateLimit(`dist-bulk:${ip}`, 10, 60_000);
   if (!success) {

--- a/src/app/api/releases/[releaseId]/distribution/check-now/route.ts
+++ b/src/app/api/releases/[releaseId]/distribution/check-now/route.ts
@@ -11,10 +11,14 @@ import {
 } from "@/lib/distribution/apple-music-detection";
 import { notifyReleaseMembers } from "@/lib/notifications/service";
 import { getPlatformLabel } from "@/lib/distribution/platforms";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 type RouteContext = { params: Promise<{ releaseId: string }> };
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const ip = getClientIp(request);
   const { success } = rateLimit(`dist-check:${ip}`, 3, 60_000);
   if (!success) {

--- a/src/app/api/releases/[releaseId]/distribution/route.ts
+++ b/src/app/api/releases/[releaseId]/distribution/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { PLATFORMS } from "@/lib/distribution/platforms";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 type RouteContext = { params: Promise<{ releaseId: string }> };
 
@@ -41,6 +42,9 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 }
 
 export async function POST(request: NextRequest, { params }: RouteContext) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const ip = getClientIp(request);
   const { success } = rateLimit(`dist-add:${ip}`, 20, 60_000);
   if (!success) {

--- a/src/app/api/send-invite/route.ts
+++ b/src/app/api/send-invite/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
 import {
   getWorkspaceSenderFrom,
   getWorkspaceEmailBrand,
@@ -48,6 +49,9 @@ function buildInviteHtml(
 }
 
 export async function POST(request: NextRequest) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const ip = getClientIp(request);
   const { success } = rateLimit(`invite:${ip}`, 10, 60_000);
   if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
@@ -59,15 +63,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const { email, role, releaseTitle, inviterEmail, releaseId } = body as {
+  const { email, role, releaseTitle, releaseId } = body as {
     email?: string;
     role?: string;
     releaseTitle?: string;
-    inviterEmail?: string;
     releaseId?: string;
   };
 
-  if (!email || !role || !releaseTitle || !inviterEmail || !releaseId) {
+  if (!email || !role || !releaseTitle || !releaseId) {
     return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
   }
 
@@ -90,7 +93,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // Send email
+  // Send email. Inviter identity comes from the session — a body-supplied
+  // inviterEmail would let any authenticated user impersonate someone else
+  // in the invite.
+  const inviterEmail = user.email ?? "A collaborator";
   const appUrl = new URL(request.url).origin;
   const brand = await getWorkspaceEmailBrand(release.workspace_id);
 

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { stripe } from "@/lib/stripe-server";
 import { getStripePriceId, type BillingInterval, type PaidPlan } from "@/lib/pricing";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 /**
  * POST /api/stripe/checkout
@@ -12,6 +13,9 @@ import { rateLimit, getClientIp } from "@/lib/rate-limit";
  *   - interval: "monthly" | "annual" (default: "monthly")
  */
 export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
   const ip = getClientIp(req);
   const { success } = rateLimit(`stripe-checkout:${ip}`, 10, 60_000);
   if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });

--- a/src/app/api/stripe/connect/authorize/route.ts
+++ b/src/app/api/stripe/connect/authorize/route.ts
@@ -4,8 +4,12 @@ import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { encodeOAuthState } from "@/lib/integrations/oauth";
 import type { OAuthState } from "@/lib/integrations/types";
 import crypto from "crypto";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 export async function POST(request: NextRequest) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const ip = getClientIp(request);
   const { success } = rateLimit(`stripe-connect:${ip}`, 5, 60_000);
   if (!success) {

--- a/src/app/api/stripe/connect/disconnect/route.ts
+++ b/src/app/api/stripe/connect/disconnect/route.ts
@@ -3,8 +3,12 @@ import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { stripe } from "@/lib/stripe-server";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 export async function POST(request: NextRequest) {
+  const originErr = requireSameOrigin(request);
+  if (originErr) return originErr;
+
   const ip = getClientIp(request);
   const { success } = rateLimit(`stripe-disconnect:${ip}`, 10, 60_000);
   if (!success) {

--- a/src/app/api/stripe/portal/route.ts
+++ b/src/app/api/stripe/portal/route.ts
@@ -2,12 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { stripe } from "@/lib/stripe-server";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 /**
  * POST /api/stripe/portal
  * Creates a Stripe Customer Portal session for managing billing.
  */
 export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
   const ip = getClientIp(req);
   const { success } = rateLimit(`stripe-portal:${ip}`, 10, 60_000);
   if (!success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });

--- a/src/app/api/stripe/verify-checkout-session/route.ts
+++ b/src/app/api/stripe/verify-checkout-session/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { stripe } from "@/lib/stripe-server";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { requireSameOrigin } from "@/lib/origin-check";
 
 /**
  * POST /api/stripe/verify-checkout-session
@@ -21,6 +22,9 @@ import { rateLimit, getClientIp } from "@/lib/rate-limit";
  *   { verified: false, reason: string }
  */
 export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
   const ip = getClientIp(req);
   const { success } = rateLimit(`verify-checkout:${ip}`, 30, 60_000);
   if (!success) {

--- a/src/app/app/releases/[releaseId]/settings/settings-form.tsx
+++ b/src/app/app/releases/[releaseId]/settings/settings-form.tsx
@@ -376,8 +376,7 @@ export function SettingsForm({ releaseId, role, initialMembers, hasQuotes = fals
               email: sentEmail,
               role: sentRole,
               releaseTitle: title,
-              inviterEmail: user?.email ?? "A team member",
-              releaseId,
+                  releaseId,
             }),
           });
         } catch {
@@ -402,7 +401,6 @@ export function SettingsForm({ releaseId, role, initialMembers, hasQuotes = fals
           email: member.invited_email,
           role: member.role,
           releaseTitle: title,
-          inviterEmail: user?.email ?? "A team member",
           releaseId,
         }),
       });

--- a/src/lib/quotes/send-quote-core.ts
+++ b/src/lib/quotes/send-quote-core.ts
@@ -1,0 +1,117 @@
+import { revalidatePath } from "next/cache";
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+import { getUserDisplayName, buildUnsubscribeUrl } from "@/lib/email/service";
+import { buildQuoteReceivedEmail } from "@/lib/email-templates/quote-emails";
+import {
+  getWorkspaceSenderFrom,
+  getWorkspaceEmailBrand,
+  getWorkspaceReplyTo,
+} from "@/lib/email/workspace-sender";
+
+type SupabaseLike = ReturnType<typeof createSupabaseServiceClient>;
+
+/**
+ * Send a quote as `userId`: flip draft → sent and email the client.
+ *
+ * NOT a server action — this module has no "use server", so the
+ * `userId` identity parameter is never reachable from the network.
+ * Callers are responsible for supplying a trusted identity:
+ *  - src/actions/quotes.ts `sendQuote` (session-derived user + RLS client)
+ *  - src/lib/workflow-engine.ts (service client + the job row's user_id)
+ *
+ * The previous design exposed this identity override as an options
+ * param on the exported server action itself, which let any caller
+ * invoke it with an arbitrary userId and the RLS-bypassing service
+ * client. Keep it here, out of the action surface.
+ */
+export async function sendQuoteCore(
+  supabase: SupabaseLike,
+  userId: string,
+  quoteId: string,
+): Promise<{ error?: string }> {
+  const { data: quote } = await supabase
+    .from("quotes")
+    .select("*")
+    .eq("id", quoteId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (!quote) return { error: "Quote not found" };
+  if (quote.status !== "draft") return { error: "Only draft quotes can be sent" };
+  if (!quote.client_email) return { error: "Client email is required to send" };
+
+  // Update status
+  const { error } = await supabase
+    .from("quotes")
+    .update({ status: "sent", issued_at: new Date().toISOString() })
+    .eq("id", quoteId);
+
+  if (error) return { error: error.message };
+
+  // Send email to client
+  const displayName = await getUserDisplayName(userId);
+  const portalUrl = `${process.env.NEXT_PUBLIC_APP_URL ?? "https://mixarchitect.com"}/portal/quote/${quote.portal_token}`;
+
+  // Get release title if linked
+  let releaseTitle: string | undefined;
+  if (quote.release_id) {
+    const { data: release } = await supabase
+      .from("releases")
+      .select("title")
+      .eq("id", quote.release_id)
+      .maybeSingle();
+    releaseTitle = release?.title;
+  }
+
+  // Get unsubscribe token for the engineer
+  const serviceClient = createSupabaseServiceClient();
+  const { data: prefs } = await serviceClient
+    .from("email_preferences")
+    .select("unsubscribe_token")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  const unsubscribeUrl = prefs?.unsubscribe_token
+    ? buildUnsubscribeUrl(prefs.unsubscribe_token, "payment_received")
+    : undefined;
+
+  const brand = await getWorkspaceEmailBrand(quote.workspace_id);
+  const email = buildQuoteReceivedEmail(
+    {
+      engineerName: displayName,
+      quoteNumber: quote.quote_number,
+      total: quote.total,
+      currency: quote.currency,
+      releaseTitle,
+      portalUrl,
+      unsubscribeUrl,
+      documentType: quote.document_type ?? "quote",
+    },
+    brand,
+  );
+
+  // Send directly via Resend (client email, not engineer's preference system)
+  const resendKey = process.env.RESEND_API_KEY;
+  if (resendKey) {
+    const { Resend } = require("resend") as typeof import("resend");
+    const resend = new Resend(resendKey);
+    try {
+      await resend.emails.send({
+        from: await getWorkspaceSenderFrom(quote.workspace_id),
+        replyTo: await getWorkspaceReplyTo(quote.workspace_id),
+        to: quote.client_email,
+        subject: email.subject,
+        html: email.html,
+      });
+    } catch (err) {
+      console.error("[quotes] failed to send quote email:", err);
+    }
+  }
+
+  revalidatePath("/app/quotes");
+  if (quote.release_id) {
+    revalidatePath(`/app/releases/${quote.release_id}`);
+  }
+
+  return {};
+}

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -1,5 +1,5 @@
 import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
-import { sendQuote } from "@/actions/quotes";
+import { sendQuoteCore } from "@/lib/quotes/send-quote-core";
 import {
   getWorkspaceSenderFrom,
   getWorkspaceEmailBrand,
@@ -117,10 +117,9 @@ async function handleSendInvoice(context: TriggerContext): Promise<ActionResult>
     return { skipped: true, reason: "No unsent draft quote found" };
   }
 
-  // Use service context since workflow engine runs outside auth (e.g. webhooks)
-  const result = await sendQuote(quote.id, {
-    serviceContext: { userId: context.userId },
-  });
+  // The workflow engine runs outside auth (webhooks/cron), so call the
+  // non-action core with the service client + the job row's user_id.
+  const result = await sendQuoteCore(supabase, context.userId, quote.id);
   if (result.error) {
     throw new Error(result.error);
   }

--- a/supabase/migrations/080_align_definer_fn_revokes.sql
+++ b/supabase/migrations/080_align_definer_fn_revokes.sql
@@ -1,0 +1,24 @@
+-- Align EXECUTE revokes on SECURITY DEFINER functions with the project
+-- convention: revoke from public AND anon (Supabase's default privileges
+-- grant EXECUTE to anon/authenticated explicitly, so revoking public alone
+-- is insufficient — see migration 065); authenticated keeps EXECUTE only
+-- where the function is intentionally user-callable (RLS helpers, RPCs).
+--
+-- CREATE OR REPLACE preserves prior grants, so several later migrations
+-- (067, 068, 069, 070, 071, 074) silently relied on earlier revokes or
+-- omitted one leg. No behavior change intended — this restates the target
+-- state explicitly so it is drift-proof and auditable in one place.
+
+-- Trigger-invoked only (return type `trigger` — not RPC-callable anyway):
+revoke execute on function public.sync_workspace_plan_from_subscription() from public, anon, authenticated;
+revoke execute on function public.stamp_owner_workspace_id() from public, anon, authenticated;
+revoke execute on function public.stamp_release_workspace_id() from public, anon, authenticated;
+revoke execute on function public.handle_new_user() from public, anon, authenticated;
+
+-- Used inside RLS policies / called via RPC by signed-in users:
+-- authenticated must keep EXECUTE; anon and public must not have it.
+revoke execute on function public.admin_workspace_ids() from public, anon;
+revoke execute on function public.claim_pending_invites() from public, anon;
+revoke execute on function public.accessible_release_ids(text) from public, anon;
+revoke execute on function public.user_workspace_ids() from public, anon;
+revoke execute on function public.owned_workspace_ids() from public, anon;


### PR DESCRIPTION
Security review of everything added since the last audit — workspaces, team invites, branded email, notifications, uploads. **No permission changes for legitimate users:** every fix either removes an override only an attacker could use, or adds a check the app's own same-origin fetches already satisfy.

## 🔴 HIGH — `sendQuote` server action accepted an identity override
```ts
sendQuote(quoteId, { serviceContext: { userId } })   // exported "use server"
```
Because this was an exported server action, the `userId` parameter was **network-reachable**. A caller could pass any `userId`, and the action would then run against the **RLS-bypassing service client** — sending that user's draft quotes to their clients and flipping quote status.

**Fix:** split the logic into `src/lib/quotes/send-quote-core.ts`. That module has no `"use server"`, so the identity parameter isn't reachable from the network. The action now derives identity from the session only; the workflow engine (webhooks/cron) calls the core directly with the service client and the job row's `user_id`. Behavior for both real callers is unchanged.

## 🟠 MEDIUM
| Issue | Fix |
|---|---|
| `send-invite` trusted body-supplied `inviterEmail` → any authed user could send invites appearing to be from anyone | Derive from session; callers updated |
| `admin/log-activity` had no replay guard on `"signup"` — any signed-in user could re-post it in a loop to re-send welcome mail and **spam every admin** | Only fires within 1h of account creation **and** only if no welcome email was ever logged for that user |
| `cron/check-distribution` didn't fail closed when `CRON_SECRET` is unset (expected digest became `"Bearer undefined"`) | Added the guard `weekly-digest` already had |
| **17 cookie-auth mutating routes** missing `requireSameOrigin` (the project's own CSRF convention per CLAUDE.md) | Added to attribute-signup, calendar/generate-token, convert, integrations connect/disconnect, notify, perf/ingest, 4 distribution routes, send-invite, and 5 stripe routes |

Deliberately **not** added to token/signature-authenticated endpoints (`portal/*`, `stripe/webhook`, `email/unsubscribe`, OAuth callback) — those legitimately have no `Origin` header and adding it would break them.

## 🟡 LOW
- `portal/comment` DELETE compared `delete_token` with `!==` (timing oracle) → now sha256 + `timingSafeEqual`, matching the earlier cron-secret fix.
- `csp-report` had no rate limit despite its docblock claiming one, while being unauthenticated and logging attacker-controlled JSON → 20/min/IP.

## 🗄️ Migration 080 — SECURITY DEFINER EXECUTE revokes (**already applied to prod**)
Later migrations relied on `CREATE OR REPLACE` preserving grants and each omitted a leg, so **`anon` still had EXECUTE** on `accessible_release_ids`, `admin_workspace_ids`, `handle_new_user`, `stamp_owner_workspace_id`, and `sync_workspace_plan_from_subscription`.

Verified before/after in prod — `anon` now `false` on all 9 functions, and `authenticated` retains EXECUTE on exactly the 5 RLS helpers that need it. Regression-checked that release access and invite claiming still resolve.

## Reviewed and intentionally left alone
- **CSP `unsafe-inline` without a nonce** — documented deliberate trade-off in `middleware.ts`; reverting needs the layout to thread the nonce (separate change).
- **GET-based unsubscribe** — required by one-click unsubscribe clients.
- **Browser-side writes** (`workspace_members` role changes, `workspace_branding` upserts) — mediated by owner-scoped RLS, which I verified.
- **Workspace-shared RLS** (migrations 069/071 letting engineers/viewers write shared rows) — deliberate per those files' headers.
- **`workspace-logos` public bucket + SVG** — sanitized server-side with DOMPurify on a server-derived path; acceptable as-is.

`tsc` clean; `eslint` clean apart from the pre-existing `require("resend")` lazy-init pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)