### PR TITLE
Onboarding: getting-started checklist, re-launchable tour, plainer copy

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { ReleaseCard } from "@/components/ui/release-card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { DashboardContent } from "@/components/dashboard/dashboard-content";
+import { GettingStartedChecklist } from "@/components/onboarding/getting-started-checklist";
 import { ArtistInfoBar } from "@/components/dashboard/artist-sidebar";
 import { Plus, Sparkles, Music, Search } from "lucide-react";
 import { formatMoney } from "@/lib/format-money";
@@ -53,6 +54,8 @@ export default async function DashboardPage({ searchParams }: Props) {
 
   const user = userRes.data.user;
   let paymentsEnabled = false;
+  let checklistDismissed = false;
+  let persona: string | null = null;
 
   // Fetch user defaults + shared release memberships in parallel
   type MemberRow = { release_id: string; role: string };
@@ -64,7 +67,7 @@ export default async function DashboardPage({ searchParams }: Props) {
     const [defaultsRes, membersRes, subRes] = await Promise.all([
       supabase
         .from("user_defaults")
-        .select("payments_enabled")
+        .select("payments_enabled, checklist_dismissed, persona")
         .eq("user_id", user.id)
         .maybeSingle(),
       supabase
@@ -79,6 +82,8 @@ export default async function DashboardPage({ searchParams }: Props) {
         .maybeSingle(),
     ]);
     paymentsEnabled = defaultsRes.data?.payments_enabled ?? false;
+    checklistDismissed = defaultsRes.data?.checklist_dismissed ?? false;
+    persona = (defaultsRes.data?.persona as string) ?? null;
     sharedMemberships = (membersRes.data ?? []) as MemberRow[];
     subPlan = (subRes.data?.plan as string) ?? "free";
     subStatus = (subRes.data?.status as string) ?? "active";
@@ -96,6 +101,48 @@ export default async function DashboardPage({ searchParams }: Props) {
   const isPro = hasProAccess(subPlan, subStatus);
   const ownedReleaseCount = releases?.length ?? 0;
   const atFreeLimit = !isPro && ownedReleaseCount >= 1;
+
+  /* ── Getting-started checklist ──────────────────────────────────────
+     Steps derive from real data so the card self-completes. The audio +
+     share lookups only run while the checklist is still visible. */
+  const ownedReleaseIds = (releases ?? []).map((r) => r.id as string);
+  const hasRelease = ownedReleaseCount > 0;
+  const hasTrack = (releases ?? []).some(
+    (r) => ((r.tracks as { id: string }[] | null)?.length ?? 0) > 0,
+  );
+  // Artists don't get the client portal, so don't ask them to share one.
+  const showPortalStep = persona !== "artist";
+  let hasAudio = false;
+  let hasShared = false;
+
+  const checklistCandidate = !!user && !checklistDismissed;
+  if (checklistCandidate && ownedReleaseIds.length > 0) {
+    const [audioRes, sharesRes] = await Promise.all([
+      supabase
+        .from("track_audio_versions")
+        .select("id, tracks!inner(release_id)")
+        .in("tracks.release_id", ownedReleaseIds)
+        .limit(1),
+      showPortalStep
+        ? supabase
+            .from("brief_shares")
+            .select("id")
+            .in("release_id", ownedReleaseIds)
+            .limit(1)
+        : Promise.resolve({ data: [] }),
+    ]);
+    hasAudio = (audioRes.data?.length ?? 0) > 0;
+    hasShared = ((sharesRes.data as unknown[] | null)?.length ?? 0) > 0;
+  }
+
+  const checklistSteps = showPortalStep ? 4 : 3;
+  const checklistDone =
+    [hasRelease, hasTrack, hasAudio, ...(showPortalStep ? [hasShared] : [])].filter(Boolean)
+      .length;
+  const showChecklist = checklistCandidate && checklistDone < checklistSteps;
+  const mostRecentReleaseHref = ownedReleaseIds.length
+    ? `/app/releases/${ownedReleaseIds[0]}`
+    : null;
 
   // Fetch time entries + expenses per release for balance calculation
   const allReleaseIds = (allReleases ?? []).map((r) => r.id as string);
@@ -333,6 +380,20 @@ export default async function DashboardPage({ searchParams }: Props) {
       </div>
 
       <div>
+
+      {showChecklist && user && (
+        <GettingStartedChecklist
+          userId={user.id}
+          showPortalStep={showPortalStep}
+          progress={{
+            hasRelease,
+            hasTrack,
+            hasAudio,
+            hasShared,
+            releaseHref: mostRecentReleaseHref,
+          }}
+        />
+      )}
 
       {artistFilter && (
         <>

--- a/src/components/onboarding/getting-started-checklist.tsx
+++ b/src/components/onboarding/getting-started-checklist.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { Check, X, PlayCircle, ArrowRight } from "lucide-react";
+import { createSupabaseBrowserClient } from "@/lib/supabaseBrowserClient";
+import { cn } from "@/lib/cn";
+
+export type ChecklistProgress = {
+  hasRelease: boolean;
+  hasTrack: boolean;
+  hasAudio: boolean;
+  hasShared: boolean;
+  /** Deep link to the user's most recent release, when one exists. */
+  releaseHref: string | null;
+};
+
+/**
+ * Getting-started checklist for new users.
+ *
+ * Steps complete themselves from real data, so this doubles as a progress
+ * meter rather than a to-do the user has to maintain. It also carries the
+ * only re-entry point into the product tour — before this, the tour was
+ * reachable from a single button on the onboarding confirmation screen and
+ * was lost forever if the user chose "Go to dashboard".
+ */
+export function GettingStartedChecklist({
+  progress,
+  userId,
+  showPortalStep,
+}: {
+  progress: ChecklistProgress;
+  userId: string;
+  showPortalStep: boolean;
+}) {
+  const t = useTranslations("dashboard.checklist");
+  const [dismissed, setDismissed] = useState(false);
+
+  const steps = [
+    {
+      key: "release",
+      done: progress.hasRelease,
+      label: t("stepRelease"),
+      href: "/app/releases/new",
+    },
+    {
+      key: "track",
+      done: progress.hasTrack,
+      label: t("stepTrack"),
+      href: progress.releaseHref ?? "/app/releases/new",
+    },
+    {
+      key: "audio",
+      done: progress.hasAudio,
+      label: t("stepAudio"),
+      href: progress.releaseHref ?? "/app/releases/new",
+    },
+    ...(showPortalStep
+      ? [
+          {
+            key: "share",
+            done: progress.hasShared,
+            label: t("stepShare"),
+            href: progress.releaseHref ?? "/app/releases/new",
+          },
+        ]
+      : []),
+  ];
+
+  const doneCount = steps.filter((s) => s.done).length;
+  const allDone = doneCount === steps.length;
+
+  // Hide once everything is done — no dismiss needed.
+  if (dismissed || allDone) return null;
+
+  // Next incomplete step drives the primary CTA.
+  const nextStep = steps.find((s) => !s.done);
+
+  async function handleDismiss() {
+    setDismissed(true);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      await supabase
+        .from("user_defaults")
+        .update({ checklist_dismissed: true })
+        .eq("user_id", userId);
+    } catch {
+      /* dismissal is a convenience — a failure just means it returns later */
+    }
+  }
+
+  return (
+    <div
+      className="relative rounded-xl border border-border p-5 mb-8"
+      style={{ background: "var(--panel)" }}
+    >
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label={t("dismiss")}
+        className="absolute top-4 right-4 text-faint hover:text-text transition-colors"
+      >
+        <X size={16} />
+      </button>
+
+      <h2 className="text-sm font-semibold text-text pr-8">{t("title")}</h2>
+      <p className="mt-1 text-sm text-muted pr-8">{t("subtitle")}</p>
+
+      {/* Progress bar */}
+      <div className="mt-4 flex items-center gap-3">
+        <div className="h-1.5 flex-1 rounded-full overflow-hidden" style={{ background: "var(--panel-2)" }}>
+          <div
+            className="h-full rounded-full transition-all duration-500"
+            style={{
+              width: `${(doneCount / steps.length) * 100}%`,
+              background: "var(--signal)",
+            }}
+          />
+        </div>
+        <span className="text-xs text-muted tabular-nums shrink-0">
+          {t("progress", { done: doneCount, total: steps.length })}
+        </span>
+      </div>
+
+      <ol className="mt-4 space-y-2">
+        {steps.map((step) => (
+          <li key={step.key} className="flex items-center gap-3">
+            <span
+              className={cn(
+                "flex items-center justify-center w-5 h-5 rounded-full border shrink-0 transition-colors",
+                step.done ? "border-transparent" : "border-border",
+              )}
+              style={step.done ? { background: "var(--signal)" } : undefined}
+            >
+              {step.done && <Check size={12} style={{ color: "var(--signal-on)" }} />}
+            </span>
+            <span
+              className={cn(
+                "text-sm",
+                step.done ? "text-faint line-through" : "text-text",
+              )}
+            >
+              {step.label}
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      <div className="mt-5 flex flex-wrap items-center gap-3">
+        {nextStep && (
+          <Link
+            href={nextStep.href}
+            className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-md transition-colors"
+            style={{ background: "var(--signal)", color: "var(--signal-on)" }}
+          >
+            {t("continue")}
+            <ArrowRight size={14} />
+          </Link>
+        )}
+        <Link
+          href="/app/releases/new?tour=true"
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-signal hover:underline"
+        >
+          <PlayCircle size={14} />
+          {t("takeTour")}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/help-portal.tsx
+++ b/src/components/ui/help-portal.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { cn } from "@/lib/cn";
-import { Mail, Search, Megaphone, Activity, CheckCircle, AlertTriangle, XCircle } from "lucide-react";
+import { Mail, Search, Megaphone, Activity, CheckCircle, AlertTriangle, XCircle, PlayCircle } from "lucide-react";
 import Link from "next/link";
 import { KnowledgeBase } from "@/components/ui/knowledge-base";
 import { BugReportForm } from "@/components/ui/bug-report-form";
@@ -68,11 +68,22 @@ export function HelpPortal() {
   return (
     <div>
       {/* Header */}
-      <div className="mb-6">
-        <h1 className="text-xl font-semibold h2">{t("title")}</h1>
-        <p className="text-muted text-sm mt-1">
-          {t("description")}
-        </p>
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold h2">{t("title")}</h1>
+          <p className="text-muted text-sm mt-1">
+            {t("description")}
+          </p>
+        </div>
+        {/* The tour used to be reachable only from the onboarding
+            confirmation screen — this is its permanent re-entry point. */}
+        <Link
+          href="/app/releases/new?tour=true"
+          className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-md border border-border text-text hover:bg-panel2 transition-colors shrink-0"
+        >
+          <PlayCircle size={14} />
+          {t("takeTour")}
+        </Link>
       </div>
 
       {/* Tab bar */}

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "Einrichten",
+      "subtitle": "Vier schnelle Schritte bis zum ersten geteilten Mix.",
+      "stepRelease": "Release anlegen",
+      "stepTrack": "Song hinzufügen",
+      "stepAudio": "Audio hochladen",
+      "stepShare": "Zum Feedback teilen",
+      "progress": "{done} von {total}",
+      "continue": "Weiter",
+      "takeTour": "Tour starten",
+      "dismiss": "Ausblenden"
+    },
     "title": "Releases",
     "newRelease": "Neues Release",
     "upgrade": "Upgraden",
     "noReleases": "Noch keine Releases",
-    "noReleasesDesc": "Erstelle dein erstes Release, um Track-Briefings zu erstellen, Spezifikationen zu verwalten und deinen Mix-Workflow zu organisieren.",
+    "noReleasesDesc": "Lege ein Release an, füge deine Songs hinzu und teile sie für Feedback.",
     "createFirst": "Dein erstes Release erstellen",
     "noFilteredReleases": "Keine {filter} Releases",
     "noFilteredReleasesDesc": "Versuche, deine Suche oder Filter anzupassen.",
@@ -199,8 +211,8 @@
       "setupNote": "Richte dein Projekt ein. Du kannst diese Details später immer bearbeiten.",
       "releaseTitle": "Release-Titel *",
       "releaseTitlePlaceholder": "Midnight Drive EP",
-      "artistClient": "Künstler / Kunde",
-      "artistPlaceholder": "Künstler- oder Kundenname",
+      "artistClient": "Künstlername",
+      "artistPlaceholder": "Dein Künstler- oder Bandname",
       "releaseType": "Release-Typ",
       "format": "Format",
       "genreTags": "Genre-Tags",
@@ -769,6 +781,7 @@
     }
   },
   "help": {
+    "takeTour": "Tour starten",
     "title": "Hilfe-Center",
     "description": "Dokumentation, Fehlerberichte, Feature-Wünsche und Kontakt.",
     "articles": "Hilfe-Artikel",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "Get set up",
+      "subtitle": "Four quick steps to your first shared mix.",
+      "stepRelease": "Create a release",
+      "stepTrack": "Add a song to it",
+      "stepAudio": "Upload your audio",
+      "stepShare": "Share it for feedback",
+      "progress": "{done} of {total}",
+      "continue": "Continue",
+      "takeTour": "Take the tour",
+      "dismiss": "Dismiss"
+    },
     "title": "Releases",
     "newRelease": "New Release",
     "upgrade": "Upgrade",
     "noReleases": "No releases yet",
-    "noReleasesDesc": "Create your first release to start building track briefs, managing specs, and organizing your mix workflow.",
+    "noReleasesDesc": "Start a release, add your songs, and share them for feedback.",
     "createFirst": "Create your first release",
     "noFilteredReleases": "No {filter} releases",
     "noFilteredReleasesDesc": "Try adjusting your search or filters.",
@@ -199,8 +211,8 @@
       "setupNote": "Set up your project. You can always edit these details later.",
       "releaseTitle": "Release title *",
       "releaseTitlePlaceholder": "Midnight Drive EP",
-      "artistClient": "Artist / Client",
-      "artistPlaceholder": "Artist or client name",
+      "artistClient": "Artist name",
+      "artistPlaceholder": "Your artist or band name",
       "releaseType": "Release type",
       "format": "Format",
       "genreTags": "Genre tags",
@@ -773,6 +785,7 @@
     }
   },
   "help": {
+    "takeTour": "Take the tour",
     "title": "Help Center",
     "description": "Docs, bug reports, feature requests, and contact.",
     "articles": "Help Articles",

--- a/src/i18n/messages/es-MX.json
+++ b/src/i18n/messages/es-MX.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "Ponte en marcha",
+      "subtitle": "Cuatro pasos rápidos hasta tu primera mezcla compartida.",
+      "stepRelease": "Crea un lanzamiento",
+      "stepTrack": "Agrega una canción",
+      "stepAudio": "Sube tu audio",
+      "stepShare": "Compártelo para recibir comentarios",
+      "progress": "{done} de {total}",
+      "continue": "Continuar",
+      "takeTour": "Ver el tour",
+      "dismiss": "Descartar"
+    },
     "title": "Lanzamientos",
     "newRelease": "Nuevo Lanzamiento",
     "upgrade": "Actualizar",
     "noReleases": "No hay lanzamientos aún",
-    "noReleasesDesc": "Crea tu primer lanzamiento para empezar a construir briefs de pistas, gestionar especificaciones y organizar tu flujo de trabajo de mezcla.",
+    "noReleasesDesc": "Crea un lanzamiento, agrega tus canciones y compártelas para recibir comentarios.",
     "createFirst": "Crear tu primer lanzamiento",
     "noFilteredReleases": "No hay lanzamientos {filter}",
     "noFilteredReleasesDesc": "Intenta ajustar tu búsqueda o filtros.",
@@ -199,8 +211,8 @@
       "setupNote": "Configura tu proyecto. Siempre puedes editar estos detalles después.",
       "releaseTitle": "Título del lanzamiento *",
       "releaseTitlePlaceholder": "EP Midnight Drive",
-      "artistClient": "Artista / Cliente",
-      "artistPlaceholder": "Nombre del artista o cliente",
+      "artistClient": "Nombre del artista",
+      "artistPlaceholder": "Tu nombre de artista o banda",
       "releaseType": "Tipo de lanzamiento",
       "format": "Formato",
       "genreTags": "Etiquetas de género",
@@ -769,6 +781,7 @@
     }
   },
   "help": {
+    "takeTour": "Ver el tour",
     "title": "Centro de Ayuda",
     "description": "Documentación, reportes de errores, solicitudes de características y contacto.",
     "articles": "Artículos de Ayuda",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "Ponte en marcha",
+      "subtitle": "Cuatro pasos rápidos hasta tu primera mezcla compartida.",
+      "stepRelease": "Crea un lanzamiento",
+      "stepTrack": "Añade una canción",
+      "stepAudio": "Sube tu audio",
+      "stepShare": "Compártelo para recibir comentarios",
+      "progress": "{done} de {total}",
+      "continue": "Continuar",
+      "takeTour": "Ver el tour",
+      "dismiss": "Descartar"
+    },
     "title": "Lanzamientos",
     "newRelease": "Nuevo Lanzamiento",
     "upgrade": "Actualizar",
     "noReleases": "No hay lanzamientos aún",
-    "noReleasesDesc": "Crea tu primer lanzamiento para empezar a construir briefs de pistas, gestionar especificaciones y organizar tu flujo de mezcla.",
+    "noReleasesDesc": "Crea un lanzamiento, añade tus canciones y compártelas para recibir comentarios.",
     "createFirst": "Crear tu primer lanzamiento",
     "noFilteredReleases": "No hay lanzamientos {filter}",
     "noFilteredReleasesDesc": "Intenta ajustar tu búsqueda o filtros.",
@@ -199,8 +211,8 @@
       "setupNote": "Configura tu proyecto. Siempre puedes editar estos detalles más tarde.",
       "releaseTitle": "Título del lanzamiento *",
       "releaseTitlePlaceholder": "EP Midnight Drive",
-      "artistClient": "Artista / Cliente",
-      "artistPlaceholder": "Nombre del artista o cliente",
+      "artistClient": "Nombre del artista",
+      "artistPlaceholder": "Tu nombre de artista o banda",
       "releaseType": "Tipo de lanzamiento",
       "format": "Formato",
       "genreTags": "Etiquetas de género",
@@ -769,6 +781,7 @@
     }
   },
   "help": {
+    "takeTour": "Ver el tour",
     "title": "Centro de Ayuda",
     "description": "Documentación, reportes de errores, solicitudes de funciones y contacto.",
     "articles": "Artículos de Ayuda",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "Configuration",
+      "subtitle": "Quatre étapes rapides jusqu'à votre premier mix partagé.",
+      "stepRelease": "Créez une sortie",
+      "stepTrack": "Ajoutez un morceau",
+      "stepAudio": "Importez votre audio",
+      "stepShare": "Partagez pour avoir des retours",
+      "progress": "{done} sur {total}",
+      "continue": "Continuer",
+      "takeTour": "Suivre la visite",
+      "dismiss": "Masquer"
+    },
     "title": "Sorties",
     "newRelease": "Nouvelle sortie",
     "upgrade": "Mettre à niveau",
     "noReleases": "Aucune sortie pour le moment",
-    "noReleasesDesc": "Créez votre première sortie pour commencer à construire des briefs de pistes, gérer les spécifications et organiser votre flux de travail de mixage.",
+    "noReleasesDesc": "Créez une sortie, ajoutez vos morceaux et partagez-les pour avoir des retours.",
     "createFirst": "Créer votre première sortie",
     "noFilteredReleases": "Aucune sortie {filter}",
     "noFilteredReleasesDesc": "Essayez d'ajuster votre recherche ou vos filtres.",
@@ -199,8 +211,8 @@
       "setupNote": "Configurez votre projet. Vous pourrez toujours modifier ces détails plus tard.",
       "releaseTitle": "Titre de la sortie *",
       "releaseTitlePlaceholder": "EP Midnight Drive",
-      "artistClient": "Artiste / Client",
-      "artistPlaceholder": "Nom de l'artiste ou du client",
+      "artistClient": "Nom de l'artiste",
+      "artistPlaceholder": "Votre nom d'artiste ou de groupe",
       "releaseType": "Type de sortie",
       "format": "Format",
       "genreTags": "Tags de genre",
@@ -769,6 +781,7 @@
     }
   },
   "help": {
+    "takeTour": "Suivre la visite",
     "title": "Centre d'aide",
     "description": "Documentation, rapports de bugs, demandes de fonctionnalités et contact.",
     "articles": "Articles d'aide",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "सेटअप करें",
+      "subtitle": "आपके पहले साझा मिक्स तक चार आसान कदम।",
+      "stepRelease": "एक रिलीज़ बनाएँ",
+      "stepTrack": "एक गाना जोड़ें",
+      "stepAudio": "अपना ऑडियो अपलोड करें",
+      "stepShare": "फीडबैक के लिए साझा करें",
+      "progress": "{total} में से {done}",
+      "continue": "जारी रखें",
+      "takeTour": "टूर देखें",
+      "dismiss": "बंद करें"
+    },
     "title": "रिलीज़",
     "newRelease": "नई रिलीज़",
     "upgrade": "अपग्रेड करें",
     "noReleases": "अभी तक कोई रिलीज़ नहीं",
-    "noReleasesDesc": "ट्रैक ब्रीफ बनाने, स्पेसिफिकेशन मैनेज करने और अपने मिक्स वर्कफ्लो को ऑर्गनाइज़ करने के लिए अपनी पहली रिलीज़ बनाएं।",
+    "noReleasesDesc": "एक रिलीज़ शुरू करें, अपने गाने जोड़ें और फीडबैक के लिए साझा करें।",
     "createFirst": "अपनी पहली रिलीज़ बनाएं",
     "noFilteredReleases": "कोई {filter} रिलीज़ नहीं",
     "noFilteredReleasesDesc": "अपने सर्च या फिल्टर को एडजस्ट करने की कोशिश करें।",
@@ -199,8 +211,8 @@
       "setupNote": "अपना प्रोजेक्ट सेटअप करें। आप इन डिटेल्स को बाद में हमेशा एडिट कर सकते हैं।",
       "releaseTitle": "रिलीज़ टाइटल *",
       "releaseTitlePlaceholder": "Midnight Drive EP",
-      "artistClient": "आर्टिस्ट / क्लाइंट",
-      "artistPlaceholder": "आर्टिस्ट या क्लाइंट का नाम",
+      "artistClient": "कलाकार का नाम",
+      "artistPlaceholder": "आपका कलाकार या बैंड नाम",
       "releaseType": "रिलीज़ टाइप",
       "format": "फॉर्मेट",
       "genreTags": "जॉनर टैग्स",
@@ -769,6 +781,7 @@
     }
   },
   "help": {
+    "takeTour": "टूर देखें",
     "title": "हेल्प सेंटर",
     "description": "डॉक्स, बग रिपोर्ट्स, फीचर रिक्वेस्ट और कॉन्टैक्ट।",
     "articles": "हेल्प आर्टिकल",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "セットアップ",
+      "subtitle": "最初のミックスを共有するまで、4ステップです。",
+      "stepRelease": "リリースを作成",
+      "stepTrack": "曲を追加",
+      "stepAudio": "オーディオをアップロード",
+      "stepShare": "共有してフィードバックをもらう",
+      "progress": "{total}件中{done}件",
+      "continue": "続ける",
+      "takeTour": "ツアーを見る",
+      "dismiss": "閉じる"
+    },
     "title": "リリース",
     "newRelease": "新規リリース",
     "upgrade": "アップグレード",
     "noReleases": "リリースがありません",
-    "noReleasesDesc": "最初のリリースを作成して、トラック概要の作成、仕様の管理、ミックスワークフローの整理を開始しましょう。",
+    "noReleasesDesc": "リリースを作成し、曲を追加して、共有してフィードバックをもらいましょう。",
     "createFirst": "最初のリリースを作成",
     "noFilteredReleases": "{filter}のリリースがありません",
     "noFilteredReleasesDesc": "検索やフィルターを調整してください。",
@@ -199,8 +211,8 @@
       "setupNote": "プロジェクトを設定してください。詳細はいつでも編集できます。",
       "releaseTitle": "リリースタイトル *",
       "releaseTitlePlaceholder": "Midnight Drive EP",
-      "artistClient": "アーティスト／クライアント",
-      "artistPlaceholder": "アーティストまたはクライアント名",
+      "artistClient": "アーティスト名",
+      "artistPlaceholder": "アーティスト名またはバンド名",
       "releaseType": "リリースタイプ",
       "format": "フォーマット",
       "genreTags": "ジャンルタグ",
@@ -769,6 +781,7 @@
     }
   },
   "help": {
+    "takeTour": "ツアーを見る",
     "title": "ヘルプセンター",
     "description": "ドキュメント、バグ報告、機能リクエスト、お問い合わせ。",
     "articles": "ヘルプ記事",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "시작 설정",
+      "subtitle": "첫 믹스를 공유하기까지 네 단계면 됩니다.",
+      "stepRelease": "릴리스 만들기",
+      "stepTrack": "곡 추가하기",
+      "stepAudio": "오디오 업로드",
+      "stepShare": "공유하고 피드백 받기",
+      "progress": "{total}개 중 {done}개",
+      "continue": "계속",
+      "takeTour": "둘러보기",
+      "dismiss": "닫기"
+    },
     "title": "릴리스",
     "newRelease": "새 릴리스",
     "upgrade": "업그레이드",
     "noReleases": "릴리스가 없습니다",
-    "noReleasesDesc": "첫 번째 릴리스를 만들어 트랙 브리프를 작성하고, 스펙을 관리하고, 믹스 워크플로우를 정리해보세요.",
+    "noReleasesDesc": "릴리스를 만들고 곡을 추가한 다음 공유해 피드백을 받아 보세요.",
     "createFirst": "첫 번째 릴리스 만들기",
     "noFilteredReleases": "{filter} 릴리스가 없습니다",
     "noFilteredReleasesDesc": "검색어나 필터를 조정해보세요.",
@@ -199,8 +211,8 @@
       "setupNote": "프로젝트를 설정하세요. 이 세부 사항은 언제든지 편집할 수 있습니다.",
       "releaseTitle": "릴리스 제목 *",
       "releaseTitlePlaceholder": "Midnight Drive EP",
-      "artistClient": "아티스트 / 클라이언트",
-      "artistPlaceholder": "아티스트 또는 클라이언트 이름",
+      "artistClient": "아티스트 이름",
+      "artistPlaceholder": "아티스트 또는 밴드 이름",
       "releaseType": "릴리스 타입",
       "format": "포맷",
       "genreTags": "장르 태그",
@@ -769,6 +781,7 @@
     }
   },
   "help": {
+    "takeTour": "둘러보기",
     "title": "도움말 센터",
     "description": "문서, 버그 신고, 기능 요청, 연락처.",
     "articles": "도움말 문서",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "Comece por aqui",
+      "subtitle": "Quatro passos rápidos até a sua primeira mix compartilhada.",
+      "stepRelease": "Crie um lançamento",
+      "stepTrack": "Adicione uma música",
+      "stepAudio": "Envie seu áudio",
+      "stepShare": "Compartilhe para receber feedback",
+      "progress": "{done} de {total}",
+      "continue": "Continuar",
+      "takeTour": "Fazer o tour",
+      "dismiss": "Dispensar"
+    },
     "title": "Lançamentos",
     "newRelease": "Novo Lançamento",
     "upgrade": "Fazer Upgrade",
     "noReleases": "Nenhum lançamento ainda",
-    "noReleasesDesc": "Crie seu primeiro lançamento para começar a construir briefings de faixas, gerenciar especificações e organizar seu fluxo de mixagem.",
+    "noReleasesDesc": "Crie um lançamento, adicione suas músicas e compartilhe para receber feedback.",
     "createFirst": "Criar seu primeiro lançamento",
     "noFilteredReleases": "Nenhum lançamento {filter}",
     "noFilteredReleasesDesc": "Tente ajustar sua pesquisa ou filtros.",
@@ -199,8 +211,8 @@
       "setupNote": "Configure seu projeto. Você sempre pode editar esses detalhes depois.",
       "releaseTitle": "Título do lançamento *",
       "releaseTitlePlaceholder": "EP Midnight Drive",
-      "artistClient": "Artista / Cliente",
-      "artistPlaceholder": "Nome do artista ou cliente",
+      "artistClient": "Nome do artista",
+      "artistPlaceholder": "Seu nome de artista ou banda",
       "releaseType": "Tipo de lançamento",
       "format": "Formato",
       "genreTags": "Tags de gênero",
@@ -769,6 +781,7 @@
     }
   },
   "help": {
+    "takeTour": "Fazer o tour",
     "title": "Central de Ajuda",
     "description": "Docs, relatórios de bug, solicitações de funcionalidades e contato.",
     "articles": "Artigos de Ajuda",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "Kom igång",
+      "subtitle": "Fyra snabba steg till din första delade mix.",
+      "stepRelease": "Skapa en release",
+      "stepTrack": "Lägg till en låt",
+      "stepAudio": "Ladda upp ditt ljud",
+      "stepShare": "Dela för feedback",
+      "progress": "{done} av {total}",
+      "continue": "Fortsätt",
+      "takeTour": "Ta rundturen",
+      "dismiss": "Avfärda"
+    },
     "title": "Releaser",
     "newRelease": "Ny release",
     "upgrade": "Uppgradera",
     "noReleases": "Inga releaser ännu",
-    "noReleasesDesc": "Skapa din första release för att börja bygga spårinstruktioner, hantera specifikationer och organisera ditt mixarbetsflöde.",
+    "noReleasesDesc": "Skapa en release, lägg till dina låtar och dela dem för feedback.",
     "createFirst": "Skapa din första release",
     "noFilteredReleases": "Inga {filter} releaser",
     "noFilteredReleasesDesc": "Försök justera din sökning eller filter.",
@@ -199,8 +211,8 @@
       "setupNote": "Konfigurera ditt projekt. Du kan alltid redigera dessa detaljer senare.",
       "releaseTitle": "Releasetitel *",
       "releaseTitlePlaceholder": "Midnight Drive EP",
-      "artistClient": "Artist / Klient",
-      "artistPlaceholder": "Artist- eller klientnamn",
+      "artistClient": "Artistnamn",
+      "artistPlaceholder": "Ditt artist- eller bandnamn",
       "releaseType": "Releasetyp",
       "format": "Format",
       "genreTags": "Genretaggar",
@@ -769,6 +781,7 @@
     }
   },
   "help": {
+    "takeTour": "Ta rundturen",
     "title": "Hjälpcenter",
     "description": "Dokumentation, buggrapporter, funktionsförfrågningar och kontakt.",
     "articles": "Hjälpartiklar",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -160,11 +160,23 @@
     }
   },
   "dashboard": {
+    "checklist": {
+      "title": "开始设置",
+      "subtitle": "四个简单步骤，分享你的第一首混音。",
+      "stepRelease": "创建一个发行",
+      "stepTrack": "添加一首歌",
+      "stepAudio": "上传你的音频",
+      "stepShare": "分享以获取反馈",
+      "progress": "{total} 项中的 {done} 项",
+      "continue": "继续",
+      "takeTour": "查看导览",
+      "dismiss": "关闭"
+    },
     "title": "发行追踪器",
     "newRelease": "新建发行",
     "upgrade": "升级",
     "noReleases": "暂无发行",
-    "noReleasesDesc": "创建您的第一个发行，开始构建歌曲简介、管理规格并整理您的混音工作流程。",
+    "noReleasesDesc": "创建一个发行，添加你的歌曲，然后分享获取反馈。",
     "createFirst": "创建您的首个发行",
     "noFilteredReleases": "没有 {filter} 发行",
     "noFilteredReleasesDesc": "尝试调整您的搜索或过滤条件。",
@@ -199,8 +211,8 @@
       "setupNote": "设置您的项目。您随时可以编辑这些详细信息。",
       "releaseTitle": "发行标题 *",
       "releaseTitlePlaceholder": "Midnight Drive EP",
-      "artistClient": "艺人 / 客户",
-      "artistPlaceholder": "艺人或客户名称",
+      "artistClient": "艺人名称",
+      "artistPlaceholder": "你的艺人或乐队名称",
       "releaseType": "发行类型",
       "format": "格式",
       "genreTags": "风格标签",
@@ -769,6 +781,7 @@
     }
   },
   "help": {
+    "takeTour": "查看导览",
     "title": "帮助中心",
     "description": "文档、问题反馈、功能请求和联系方式。",
     "articles": "帮助文章",

--- a/supabase/migrations/081_checklist_dismissed.sql
+++ b/supabase/migrations/081_checklist_dismissed.sql
@@ -1,0 +1,9 @@
+-- Getting-started checklist dismissal.
+--
+-- The dashboard shows a 4-step checklist (create release → add track →
+-- upload audio → share) to new users. Steps auto-complete from real data,
+-- and the whole card disappears once all four are done — this column only
+-- records an explicit "dismiss" so it stays dismissed across devices.
+
+alter table public.user_defaults
+  add column if not exists checklist_dismissed boolean not null default false;


### PR DESCRIPTION
Addresses the tester feedback that **musicians (not engineers) didn't know how to get started**. Investigation found three concrete causes — all fixed here.

## 1. The product tour was a one-shot, single-use path
There are **14 tour steps** across 4 topics, and they were reachable from **exactly one button** on the onboarding confirmation screen. Choosing the other button ("Go to dashboard") forfeited the entire tour **permanently** — no re-entry point existed anywhere in the codebase.

**Fix:** "Take the tour" now lives in the Help Center header and in the new dashboard checklist. Both link to `?tour=true`, which the existing tour hook already handles on any navigation — no tour-engine changes needed.

## 2. A new user hit a dead-end empty state
The dashboard showed a bare "No releases yet" card whose only CTA duplicated the header button — no sense of what comes after step one.

**Fix:** a getting-started checklist:
```
Get set up
Four quick steps to your first shared mix.
▓▓▓▓▓▓░░░░░░  1 of 4
 ✓ Create a release
 ○ Add a song to it
 ○ Upload your audio
 ○ Share it for feedback
[Continue →]   ▶ Take the tour
```
- Steps **complete themselves from real data** (releases, tracks, `track_audio_versions`, `brief_shares`) — it's a progress meter, not a to-do list to maintain, and it disappears once all steps are done.
- The audio/share lookups **only run while the checklist is visible**, so there's no added cost for established users.
- Dismissible → `user_defaults.checklist_dismissed` (**migration 081, already applied to prod**).
- The share step is **hidden for the artist persona**, which doesn't get the client portal — asking them to share one would dead-end.

## 3. Engineer jargon on the critical path
The first sentence an artist read was *"start building **track briefs**, managing **specs**, and organizing your **mix workflow**"*, and the first form asked for **"Artist / Client"** — for someone releasing their own music.

| Before | After |
|---|---|
| "Create your first release to start building track briefs, managing specs, and organizing your mix workflow." | "Start a release, add your songs, and share them for feedback." |
| "Artist / Client" | "Artist name" |
| "Artist or client name" | "Your artist or band name" |

## i18n
New `dashboard.checklist` (10 keys) + `help.takeTour`, translated across **all 11 locales**; key parity verified programmatically.

## Verification
`tsc` clean. `eslint` clean on the new component (the 2 errors reported in `page.tsx` / `help-portal.tsx` are pre-existing on `main`).

## Known follow-up (not in this PR)
The tour's `dashboard` topic targets a release card, so it still no-ops on a truly empty dashboard. Lower priority now that the checklist covers that moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)