### PR TITLE
Track page: lead with Audio; cover art gains drag and drop

### DIFF
--- a/src/app/app/releases/[releaseId]/sidebar-editors.tsx
+++ b/src/app/app/releases/[releaseId]/sidebar-editors.tsx
@@ -475,7 +475,11 @@ export function CoverArtEditor({ releaseId, initialUrl, role }: CoverArtEditorPr
   const [url, setUrl] = useState(initialUrl ?? "");
   const [urlInput, setUrlInput] = useState("");
   const [uploading, setUploading] = useState(false);
+  const [dragging, setDragging] = useState(false);
   const [error, setError] = useState("");
+  // dragenter/dragleave fire for every child element, so count depth rather
+  // than clearing the highlight on the first leave.
+  const dragDepth = useRef(0);
   const router = useRouter();
 
   async function handleUpload(file: File) {
@@ -552,55 +556,80 @@ export function CoverArtEditor({ releaseId, initialUrl, role }: CoverArtEditorPr
   if (editing) {
     return (
       <div className="rounded-lg border border-border overflow-hidden">
-        {/* Preview */}
-        <div
-          className="w-full aspect-square flex items-center justify-center"
-          style={{ background: "var(--panel2)" }}
+        {/* Drop zone doubles as the preview. Clicking it opens the file picker,
+            so the whole square is a target rather than just the small button. */}
+        <label
+          onDragEnter={(e) => {
+            e.preventDefault();
+            dragDepth.current += 1;
+            setDragging(true);
+          }}
+          onDragOver={(e) => e.preventDefault()}
+          onDragLeave={(e) => {
+            e.preventDefault();
+            dragDepth.current -= 1;
+            if (dragDepth.current <= 0) setDragging(false);
+          }}
+          onDrop={(e) => {
+            e.preventDefault();
+            dragDepth.current = 0;
+            setDragging(false);
+            const f = e.dataTransfer.files?.[0];
+            if (f) handleUpload(f);
+          }}
+          className="relative w-full aspect-square flex flex-col items-center justify-center gap-2 cursor-pointer transition-colors"
+          style={{
+            background: dragging
+              ? "color-mix(in srgb, var(--signal) 15%, var(--panel-2))"
+              : "var(--panel-2)",
+            outline: dragging ? "2px dashed var(--signal)" : "2px dashed transparent",
+            outlineOffset: "-8px",
+          }}
         >
-          {url ? (
-            <img src={url} alt="Cover art" className="w-full h-full object-cover" />
+          {url && !dragging ? (
+            <>
+              <img src={url} alt="" className="absolute inset-0 w-full h-full object-cover" />
+              <div className="absolute inset-0 bg-black/55 opacity-0 hover:opacity-100 transition-opacity flex flex-col items-center justify-center gap-2 px-4 text-center">
+                <Upload size={22} className="text-white" />
+                <span className="text-xs text-white">{t("dropOrClick")}</span>
+              </div>
+            </>
           ) : (
-            <ImageIcon size={48} className="text-muted opacity-30" />
+            <div className="flex flex-col items-center gap-2 px-4 text-center pointer-events-none">
+              {dragging ? (
+                <Upload size={40} className="text-signal" />
+              ) : (
+                <ImageIcon size={40} className="text-muted opacity-30" />
+              )}
+              <span className="text-xs text-text">
+                {dragging ? t("dropToUpload") : t("dropOrClick")}
+              </span>
+              {!dragging && (
+                <span className="text-[11px] text-faint">{t("imageFormats")}</span>
+              )}
+            </div>
           )}
-        </div>
+
+          <input
+            type="file"
+            accept="image/png,image/jpeg,image/jpg,image/webp,image/gif"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) handleUpload(f);
+              e.target.value = "";
+            }}
+            disabled={uploading}
+          />
+        </label>
 
         {/* Controls */}
-        <div className="p-3 space-y-2" style={{ background: "var(--panel)" }}>
-          {error && (
-            <p className="text-xs text-red-500">{error}</p>
-          )}
+        <div className="p-3 space-y-3" style={{ background: "var(--panel)" }}>
+          {error && <p className="text-xs text-red-500">{error}</p>}
+          {uploading && <p className="text-xs text-muted">{tc("uploading")}</p>}
 
-          <div className="flex items-center gap-2">
-            <label
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md cursor-pointer transition-colors"
-              style={{ background: "var(--panel2)", color: "var(--text-muted)" }}
-            >
-              <Upload size={14} />
-              {uploading ? tc("uploading") : "Upload"}
-              <input
-                type="file"
-                accept="image/png,image/jpeg,image/jpg,image/webp,image/gif"
-                className="hidden"
-                onChange={(e) => {
-                  const f = e.target.files?.[0];
-                  if (f) handleUpload(f);
-                }}
-                disabled={uploading}
-              />
-            </label>
-            {url && (
-              <button
-                type="button"
-                onClick={handleRemove}
-                className="inline-flex items-center gap-1 text-xs text-red-500 hover:text-red-400 transition-colors"
-              >
-                <X size={12} /> Remove
-              </button>
-            )}
-          </div>
-
-          <div className="space-y-1">
-            <span className="text-[10px] text-muted uppercase tracking-wider">{t("pasteUrl")}</span>
+          <div className="space-y-1.5">
+            <span className="text-[11px] text-muted">{t("pasteUrl")}</span>
             <div className="flex gap-1.5">
               <input
                 type="url"
@@ -613,6 +642,7 @@ export function CoverArtEditor({ releaseId, initialUrl, role }: CoverArtEditorPr
                 type="button"
                 onClick={handleUrlSave}
                 disabled={!urlInput.trim()}
+                aria-label={tc("save")}
                 className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md transition-colors disabled:opacity-40"
                 style={{ background: "var(--signal)", color: "var(--signal-on)" }}
               >
@@ -621,17 +651,28 @@ export function CoverArtEditor({ releaseId, initialUrl, role }: CoverArtEditorPr
             </div>
           </div>
 
-          <button
-            type="button"
-            onClick={() => {
-              setUrlInput("");
-              setError("");
-              setEditing(false);
-            }}
-            className="inline-flex items-center gap-1 text-xs text-muted hover:text-text transition-colors"
-          >
-            <X size={12} /> {tc("cancel")}
-          </button>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                setUrlInput("");
+                setError("");
+                setEditing(false);
+              }}
+              className="inline-flex items-center gap-1 text-xs text-muted hover:text-text transition-colors"
+            >
+              <X size={12} /> {tc("cancel")}
+            </button>
+            {url && (
+              <button
+                type="button"
+                onClick={handleRemove}
+                className="inline-flex items-center gap-1 text-xs text-red-500 hover:text-red-400 transition-colors"
+              >
+                <X size={12} /> {t("removeCoverArt")}
+              </button>
+            )}
+          </div>
         </div>
       </div>
     );
@@ -658,7 +699,7 @@ export function CoverArtEditor({ releaseId, initialUrl, role }: CoverArtEditorPr
       ) : (
         <div
           className="w-full aspect-square flex flex-col items-center justify-center gap-2"
-          style={{ background: "var(--panel2)" }}
+          style={{ background: "var(--panel-2)" }}
         >
           <ImageIcon size={40} className="text-muted opacity-30" />
           <span className="text-xs text-muted">{t("addCoverArt")}</span>

--- a/src/app/app/releases/[releaseId]/tracks/[trackId]/track-detail-client.tsx
+++ b/src/app/app/releases/[releaseId]/tracks/[trackId]/track-detail-client.tsx
@@ -29,12 +29,15 @@ import { PortalTrackEditor } from "./portal-track-editor";
 import { MobileInspector } from "@/components/ui/mobile-inspector";
 import { useFeatureVisibility } from "@/lib/features/feature-visibility-context";
 
+// Audio leads: it is what people open a track to do. The rest is reference.
 const ALL_TABS = [
-  { id: "brief", label: "Brief" },
   { id: "audio", label: "Audio" },
+  { id: "brief", label: "Brief" },
   { id: "delivery", label: "Delivery" },
   { id: "notes", label: "Notes" },
 ];
+
+const DEFAULT_TAB = ALL_TABS[0].id;
 
 const EMOTIONAL_SUGGESTIONS = [
   "aggressive", "intimate", "spacious", "gritty", "polished", "warm",
@@ -179,12 +182,12 @@ export function TrackDetailClient({
 
   const TAB_IDS = TABS.map((t) => t.id);
   const [activeTab, setActiveTab] = useState(() => {
-    if (typeof window === "undefined") return "intent";
+    if (typeof window === "undefined") return DEFAULT_TAB;
     const hash = window.location.hash.replace("#", "");
     // Support old hash values for backwards compat
     if (hash === "intent" || hash === "specs") return "brief";
     if (hash === "distribution" || hash === "portal") return "delivery";
-    return TAB_IDS.includes(hash) ? hash : "brief";
+    return TAB_IDS.includes(hash) ? hash : DEFAULT_TAB;
   });
 
   const handleTabChange = useCallback((tab: string) => {

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -345,7 +345,11 @@
     "noFinancialDataTitle": "Noch keine Finanzdaten",
     "noFinancialDataDesc": "Erstellen Sie ein Angebot oder erfassen Sie Zeit, um die Finanzen für diese Veröffentlichung zu verfolgen.",
     "newQuote": "Neues Angebot",
-    "logTime": "Zeit erfassen"
+    "logTime": "Zeit erfassen",
+    "dropOrClick": "Bild hierher ziehen oder klicken zum Auswählen",
+    "dropToUpload": "Zum Hochladen loslassen",
+    "imageFormats": "PNG, JPG, WebP oder GIF, bis 5 MB",
+    "removeCoverArt": "Entfernen"
   },
   "releaseSettings": {
     "title": "Release-Einstellungen",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -345,7 +345,11 @@
     "noFinancialDataTitle": "No financial data yet",
     "noFinancialDataDesc": "Create a quote or log time to start tracking finances for this release.",
     "newQuote": "New Quote",
-    "logTime": "Log Time"
+    "logTime": "Log Time",
+    "dropOrClick": "Drag an image here, or click to browse",
+    "dropToUpload": "Drop to upload",
+    "imageFormats": "PNG, JPG, WebP or GIF, up to 5MB",
+    "removeCoverArt": "Remove"
   },
   "releaseSettings": {
     "title": "Release Settings",

--- a/src/i18n/messages/es-MX.json
+++ b/src/i18n/messages/es-MX.json
@@ -345,7 +345,11 @@
     "noFinancialDataTitle": "Sin datos financieros aún",
     "noFinancialDataDesc": "Crea una cotización o registra tiempo para comenzar a rastrear las finanzas de este lanzamiento.",
     "newQuote": "Nueva cotización",
-    "logTime": "Registrar tiempo"
+    "logTime": "Registrar tiempo",
+    "dropOrClick": "Arrastra una imagen aquí o haz clic para buscarla",
+    "dropToUpload": "Suelta para subir",
+    "imageFormats": "PNG, JPG, WebP o GIF, hasta 5 MB",
+    "removeCoverArt": "Quitar"
   },
   "releaseSettings": {
     "title": "Configuración del Lanzamiento",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -345,7 +345,11 @@
     "noFinancialDataTitle": "Sin datos financieros aún",
     "noFinancialDataDesc": "Crea un presupuesto o registra tiempo para comenzar a rastrear las finanzas de este lanzamiento.",
     "newQuote": "Nuevo presupuesto",
-    "logTime": "Registrar tiempo"
+    "logTime": "Registrar tiempo",
+    "dropOrClick": "Arrastra una imagen aquí o haz clic para buscarla",
+    "dropToUpload": "Suelta para subir",
+    "imageFormats": "PNG, JPG, WebP o GIF, hasta 5 MB",
+    "removeCoverArt": "Quitar"
   },
   "releaseSettings": {
     "title": "Configuración del Lanzamiento",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -345,7 +345,11 @@
     "noFinancialDataTitle": "Aucune donnée financière",
     "noFinancialDataDesc": "Créez un devis ou enregistrez du temps pour commencer à suivre les finances de cette sortie.",
     "newQuote": "Nouveau devis",
-    "logTime": "Enregistrer le temps"
+    "logTime": "Enregistrer le temps",
+    "dropOrClick": "Glissez une image ici ou cliquez pour parcourir",
+    "dropToUpload": "Relâchez pour envoyer",
+    "imageFormats": "PNG, JPG, WebP ou GIF, jusqu'à 5 Mo",
+    "removeCoverArt": "Retirer"
   },
   "releaseSettings": {
     "title": "Paramètres de sortie",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -345,7 +345,11 @@
     "portalPaymentStatus": "पेमेंट स्टेटस",
     "portalDistribution": "डिस्ट्रिब्यूशन",
     "portalLyrics": "लिरिक्स",
-    "portalRequirePayment": "पेमेंट आवश्यक"
+    "portalRequirePayment": "पेमेंट आवश्यक",
+    "dropOrClick": "यहां इमेज ड्रैग करें, या चुनने के लिए क्लिक करें",
+    "dropToUpload": "अपलोड करने के लिए छोड़ें",
+    "imageFormats": "PNG, JPG, WebP या GIF, 5MB तक",
+    "removeCoverArt": "हटाएं"
   },
   "releaseSettings": {
     "title": "रिलीज़ सेटिंग्स",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -345,7 +345,11 @@
     "portalPaymentStatus": "支払い状況",
     "portalDistribution": "配信",
     "portalLyrics": "歌詞",
-    "portalRequirePayment": "支払いを要求"
+    "portalRequirePayment": "支払いを要求",
+    "dropOrClick": "画像をここにドラッグ、またはクリックして選択",
+    "dropToUpload": "ドロップしてアップロード",
+    "imageFormats": "PNG、JPG、WebP、GIF（5MBまで）",
+    "removeCoverArt": "削除"
   },
   "releaseSettings": {
     "title": "リリース設定",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -345,7 +345,11 @@
     "portalPaymentStatus": "결제 상태",
     "portalDistribution": "배급",
     "portalLyrics": "가사",
-    "portalRequirePayment": "결제 필요"
+    "portalRequirePayment": "결제 필요",
+    "dropOrClick": "여기에 이미지를 끌어다 놓거나 클릭해서 선택하세요",
+    "dropToUpload": "놓으면 업로드됩니다",
+    "imageFormats": "PNG, JPG, WebP 또는 GIF, 최대 5MB",
+    "removeCoverArt": "제거"
   },
   "releaseSettings": {
     "title": "릴리스 설정",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -345,7 +345,11 @@
     "noFinancialDataTitle": "Nenhum dado financeiro ainda",
     "noFinancialDataDesc": "Crie um orçamento ou registre tempo para começar a acompanhar as finanças deste lançamento.",
     "newQuote": "Novo orçamento",
-    "logTime": "Registrar tempo"
+    "logTime": "Registrar tempo",
+    "dropOrClick": "Arraste uma imagem aqui ou clique para procurar",
+    "dropToUpload": "Solte para enviar",
+    "imageFormats": "PNG, JPG, WebP ou GIF, até 5 MB",
+    "removeCoverArt": "Remover"
   },
   "releaseSettings": {
     "title": "Configurações do Lançamento",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -345,7 +345,11 @@
     "portalPaymentStatus": "Betalningsstatus",
     "portalDistribution": "Distribution",
     "portalLyrics": "Låttext",
-    "portalRequirePayment": "Kräv betalning"
+    "portalRequirePayment": "Kräv betalning",
+    "dropOrClick": "Dra en bild hit, eller klicka för att bläddra",
+    "dropToUpload": "Släpp för att ladda upp",
+    "imageFormats": "PNG, JPG, WebP eller GIF, upp till 5 MB",
+    "removeCoverArt": "Ta bort"
   },
   "releaseSettings": {
     "title": "Releaseinställningar",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -345,7 +345,11 @@
     "portalPaymentStatus": "付款状态",
     "portalDistribution": "发行",
     "portalLyrics": "歌词",
-    "portalRequirePayment": "需要付款"
+    "portalRequirePayment": "需要付款",
+    "dropOrClick": "将图片拖到此处，或点击浏览",
+    "dropToUpload": "松开即可上传",
+    "imageFormats": "PNG、JPG、WebP 或 GIF，最大 5MB",
+    "removeCoverArt": "移除"
   },
   "releaseSettings": {
     "title": "发行设置",


### PR DESCRIPTION
Two things from testing feedback, plus a CSS bug found while verifying the second.

## 1. Audio tab first

`Audio → Brief → Delivery → Notes`, and Audio is now the tab you land on. Playing and commenting is what people open a track to do; the brief is reference they consult.

Deep links still work — `#brief`, `#delivery`, `#notes`, plus the legacy `#intent`, `#specs`, `#distribution`, `#portal` values.

**Latent bug fixed in the same initializer:** it returned `"intent"` during server render, which stopped being a valid tab id when the tabs were renamed, so no tab content rendered server-side. It now returns the default tab.

## 2. Cover art: drag and drop, and a clearer choice

**The answer to "does it have drag and drop?" was no.** The square was a plain `div`.

Now the square *is* the drop target and the file picker:

- Drag an image onto it, **or** click anywhere in it to browse
- States what it accepts: "PNG, JPG, WebP or GIF, up to 5MB"
- On drag: dashed accent border, tinted background, "Drop to upload"
- Pasting a URL is unchanged, just no longer competing with a small button

`dragenter`/`dragleave` fire for every child element, so the highlight uses a **depth counter** instead of clearing on the first leave — otherwise it flickers as the cursor crosses the icon and text inside the zone.

Four new strings, translated into all 10 locales.

## 3. A CSS variable that does not exist

While verifying the drop zone I found its background was resolving to **transparent**. The component styles with `var(--panel2)` — but the variable is `--panel-2`. Only the *Tailwind token* is `panel2` (`--color-panel2`), so the `bg-panel2` utility class works while the inline `var(--panel2)` silently does nothing.

Confirmed live in the browser:

```
--panel-2                 →  #f8f8f6      ✅ defined
--panel2   (used in code) →  ""           ❌ undefined
--muted                   →  #1414149e    ✅ defined
--text-muted (used in code) → ""          ❌ undefined
```

Fixed in the cover art editor. **Left alone: 55 other `var(--panel2)` call sites across 12 files, and 14 `var(--text-muted)` ones.** Fixing those makes elements across the app gain backgrounds they have never had — a real visual change that deserves its own PR rather than riding along with this one. Happy to do it next.

## Verification

Dev mode cannot hydrate under the app's CSP (`script-src` has no `'unsafe-eval'`), so this was verified against a **production build** through a temporary unauthenticated route rendering the real component, since `/app/**` needs a login. The route was removed before commit.

Confirmed by driving the actual DOM:

| step | result |
|---|---|
| idle | not highlighted |
| `dragenter` on zone | highlighted, "Drop to upload" |
| `dragenter` on child | still highlighted |
| **`dragleave` on child** | **still highlighted** ← depth counter |
| `dragleave` on zone | cleared, back to idle |
| drop `notes.txt` (`text/plain`) | rejected: "Invalid image type. Use PNG, JPG, WebP, or GIF." |

`tsc --noEmit` clean, `next build` green, and eslint reports the same 9 problems before and after (no new issues — the drop-zone `<label>` wraps its input, so no a11y regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)