### PR TITLE
Fix two CSS variables that were never defined

### DIFF
--- a/src/app/app/onboarding/steps/confirmation-step.tsx
+++ b/src/app/app/onboarding/steps/confirmation-step.tsx
@@ -57,15 +57,15 @@ export function ConfirmationStep({
 
       {/* Summary */}
       <div className="inline-flex items-center gap-2 text-sm text-text mb-8 flex-wrap justify-center">
-        <span className="px-2.5 py-1 rounded-md text-xs font-medium" style={{ background: "var(--panel2)" }}>
+        <span className="px-2.5 py-1 rounded-md text-xs font-medium" style={{ background: "var(--panel-2)" }}>
           {t(personaKeys[persona])}
         </span>
         <span className="text-muted">&middot;</span>
-        <span className="px-2.5 py-1 rounded-md text-xs font-medium" style={{ background: "var(--panel2)" }}>
+        <span className="px-2.5 py-1 rounded-md text-xs font-medium" style={{ background: "var(--panel-2)" }}>
           {localeFlagEmojis[locale]} {localeDisplayNames[locale]}
         </span>
         <span className="text-muted">&middot;</span>
-        <span className="px-2.5 py-1 rounded-md text-xs font-medium" style={{ background: "var(--panel2)" }}>
+        <span className="px-2.5 py-1 rounded-md text-xs font-medium" style={{ background: "var(--panel-2)" }}>
           {getSymbol(currency)} {currency}
         </span>
       </div>

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -421,7 +421,7 @@ export default async function DashboardPage({ searchParams }: Props) {
       {paymentsEnabled && hasAnyFees && (
         <div
           className="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-2.5 rounded-lg text-xs mb-6"
-          style={{ background: "var(--panel2)" }}
+          style={{ background: "var(--panel-2)" }}
         >
           <span className="text-muted">
             {t("outstanding")}:{" "}

--- a/src/app/app/releases/[releaseId]/settings/settings-form.tsx
+++ b/src/app/app/releases/[releaseId]/settings/settings-form.tsx
@@ -84,7 +84,7 @@ function PillSelect({
           style={
             value === opt.value
               ? { background: "var(--signal)", color: "var(--signal-on)" }
-              : { background: "var(--panel2)", color: "var(--text-muted)" }
+              : { background: "var(--panel-2)", color: "var(--muted)" }
           }
         >
           {opt.label}
@@ -463,7 +463,7 @@ export function SettingsForm({ releaseId, role, initialMembers, hasQuotes = fals
             <div className="flex items-start gap-4">
               <div
                 className="relative w-[160px] h-[160px] rounded-lg border border-border overflow-hidden flex-shrink-0 flex items-center justify-center"
-                style={{ background: "var(--panel2)" }}
+                style={{ background: "var(--panel-2)" }}
               >
                 {coverArtMode === "preview" && coverArtUrl ? (
                   <img
@@ -481,7 +481,7 @@ export function SettingsForm({ releaseId, role, initialMembers, hasQuotes = fals
                   <div>
                     <label
                       className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md cursor-pointer transition-colors"
-                      style={{ background: "var(--panel2)", color: "var(--text-muted)" }}
+                      style={{ background: "var(--panel-2)", color: "var(--muted)" }}
                     >
                       <Upload size={14} />
                       {uploading ? tCommon("uploading") : t("uploadImage")}

--- a/src/app/app/releases/[releaseId]/sidebar-editors.tsx
+++ b/src/app/app/releases/[releaseId]/sidebar-editors.tsx
@@ -189,7 +189,7 @@ export function GlobalDirectionEditor({ releaseId, initialValue, initialStatus, 
                   setEditing(false);
                 }}
                 className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md text-muted hover:text-text transition-colors"
-                style={{ background: "var(--panel2)" }}
+                style={{ background: "var(--panel-2)" }}
               >
                 <X size={12} />
                 {tc("cancel")}

--- a/src/app/app/releases/new/page.tsx
+++ b/src/app/app/releases/new/page.tsx
@@ -68,7 +68,7 @@ function PillSelect({
           style={
             value === opt.value
               ? { background: "var(--signal)", color: "var(--signal-on)" }
-              : { background: "var(--panel2)", color: "var(--text-muted)" }
+              : { background: "var(--panel-2)", color: "var(--muted)" }
           }
         >
           {opt.label}

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -386,7 +386,7 @@ export default function SettingsPage() {
               <p className="text-xs text-muted">{t("regionCurrency.defaultCurrencyHelp")}</p>
             </div>
 
-            <div className="rounded-lg px-3 py-2" style={{ background: "var(--panel2)" }}>
+            <div className="rounded-lg px-3 py-2" style={{ background: "var(--panel-2)" }}>
               <span className="text-xs text-muted">{t("regionCurrency.preview")}: </span>
               <span className="text-sm font-medium text-text">
                 {formatCurrency(1234.56, defaultCurrency, locale)}
@@ -665,7 +665,7 @@ export default function SettingsPage() {
                     style={
                       format === opt.value
                         ? { background: "var(--signal)", color: "var(--signal-on)" }
-                        : { background: "var(--panel2)", color: "var(--text-muted)" }
+                        : { background: "var(--panel-2)", color: "var(--muted)" }
                     }
                   >
                     {opt.label}
@@ -1142,7 +1142,7 @@ function CalendarPanel() {
               </div>
             </div>
 
-            <div className="rounded-lg px-3 py-2 space-y-1.5" style={{ background: "var(--panel2)" }}>
+            <div className="rounded-lg px-3 py-2 space-y-1.5" style={{ background: "var(--panel-2)" }}>
               <p className="text-xs font-medium text-text">{t("setupTitle")}</p>
               <ul className="text-xs text-muted space-y-1 list-disc list-inside">
                 <li>{t("setupGoogle")}</li>

--- a/src/components/dashboard/artist-sidebar.tsx
+++ b/src/components/dashboard/artist-sidebar.tsx
@@ -163,7 +163,7 @@ function ArtistNameEditor({
               setError("");
             }}
             className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md text-muted hover:text-text transition-colors shrink-0"
-            style={{ background: "var(--panel2)" }}
+            style={{ background: "var(--panel-2)" }}
           >
             <X size={12} />
           </button>
@@ -298,7 +298,7 @@ function ContactInfoEditor({
                   setEditing(false);
                 }}
                 className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md text-muted hover:text-text transition-colors"
-                style={{ background: "var(--panel2)" }}
+                style={{ background: "var(--panel-2)" }}
               >
                 <X size={12} />
                 Cancel

--- a/src/components/onboarding/tour-checklist.tsx
+++ b/src/components/onboarding/tour-checklist.tsx
@@ -129,8 +129,8 @@ export function TourChecklist({
                         ? "var(--signal)"
                         : isActive
                           ? "var(--signal)"
-                          : "var(--panel2)",
-                      color: isSeen || isActive ? "var(--signal-on)" : "var(--text-muted)",
+                          : "var(--panel-2)",
+                      color: isSeen || isActive ? "var(--signal-on)" : "var(--muted)",
                       opacity: isSeen ? 0.7 : 1,
                     }}
                   >
@@ -148,7 +148,7 @@ export function TourChecklist({
                     <div
                       className="text-xs font-medium truncate"
                       style={{
-                        color: isActive ? "var(--text)" : "var(--text-muted)",
+                        color: isActive ? "var(--text)" : "var(--muted)",
                       }}
                     >
                       {topic.label}

--- a/src/components/settings/portal-branding-card.tsx
+++ b/src/components/settings/portal-branding-card.tsx
@@ -58,7 +58,7 @@ function LogoSlot({
         <div className="flex flex-col gap-2">
           <label
             className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md cursor-pointer transition-colors w-fit"
-            style={{ background: "var(--panel-2)", color: "var(--text-muted)" }}
+            style={{ background: "var(--panel-2)", color: "var(--muted)" }}
           >
             <Upload size={14} />
             {uploading ? tc("uploading") : url ? t("replace") : t("upload")}

--- a/src/components/templates/template-form.tsx
+++ b/src/components/templates/template-form.tsx
@@ -64,7 +64,7 @@ function PillSelect({
           style={
             value === opt.value
               ? { background: "var(--signal)", color: "var(--signal-on)" }
-              : { background: "var(--panel2)", color: "var(--text-muted)" }
+              : { background: "var(--panel-2)", color: "var(--muted)" }
           }
         >
           {opt.label}

--- a/src/components/ui/artist-photo-uploader.tsx
+++ b/src/components/ui/artist-photo-uploader.tsx
@@ -108,7 +108,7 @@ export function ArtistPhotoUploader({
         {/* Preview */}
         <div
           className="w-full aspect-square flex items-center justify-center"
-          style={{ background: "var(--panel2)" }}
+          style={{ background: "var(--panel-2)" }}
         >
           {displayUrl ? (
             <img src={displayUrl} alt={artistName} className="w-full h-full object-cover" />
@@ -124,7 +124,7 @@ export function ArtistPhotoUploader({
           <div className="flex items-center gap-2">
             <label
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md cursor-pointer transition-colors"
-              style={{ background: "var(--panel2)", color: "var(--text-muted)" }}
+              style={{ background: "var(--panel-2)", color: "var(--muted)" }}
             >
               <Upload size={14} />
               {uploading ? "Uploading\u2026" : "Upload"}

--- a/src/components/ui/release-card.tsx
+++ b/src/components/ui/release-card.tsx
@@ -151,7 +151,7 @@ export function ReleaseCard({
         >
           <div
             className="w-10 h-10 rounded-md flex-shrink-0 overflow-hidden flex items-center justify-center"
-            style={{ background: "var(--panel2)" }}
+            style={{ background: "var(--panel-2)" }}
           >
             {navigating ? (
               <span className="w-4 h-4 border-2 border-muted/40 border-t-muted rounded-full animate-spin" />

--- a/src/components/ui/screen-mockup.tsx
+++ b/src/components/ui/screen-mockup.tsx
@@ -45,7 +45,7 @@ function MockReleaseCard({ title, artist, type, status, tracks, completed, time 
   return (
     <div className="card px-5 py-4">
       <div className="flex items-start gap-3">
-        <div className="w-10 h-10 rounded-md shrink-0 flex items-center justify-center" style={{ background: "var(--panel2)" }}>
+        <div className="w-10 h-10 rounded-md shrink-0 flex items-center justify-center" style={{ background: "var(--panel-2)" }}>
           <Music size={18} className="text-muted opacity-30" />
         </div>
         <div className="min-w-0 flex-1">
@@ -2616,15 +2616,15 @@ function SettingsProfileMockup() {
       <PanelBody className="pt-4 space-y-3">
         <div className="space-y-1">
           <span className="text-[10px] text-muted">Display Name</span>
-          <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel2)" }}>Jordan Rivera</div>
+          <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel-2)" }}>Jordan Rivera</div>
         </div>
         <div className="space-y-1">
           <span className="text-[10px] text-muted">Company Name</span>
-          <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel2)" }}>Riverstone Audio</div>
+          <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel-2)" }}>Riverstone Audio</div>
         </div>
         <div className="space-y-1">
           <span className="text-[10px] text-muted">Email</span>
-          <div className="rounded-md px-3 py-1.5 text-xs text-muted opacity-60" style={{ background: "var(--panel2)" }}>jordan@riverstone.audio</div>
+          <div className="rounded-md px-3 py-1.5 text-xs text-muted opacity-60" style={{ background: "var(--panel-2)" }}>jordan@riverstone.audio</div>
         </div>
         <Button variant="primary" className="text-xs px-3 py-1.5">Save</Button>
       </PanelBody>
@@ -2666,19 +2666,19 @@ function SettingsRegionMockup() {
       <PanelBody className="pt-4 space-y-3">
         <div className="space-y-1">
           <span className="text-[10px] text-muted">Locale</span>
-          <div className="rounded-md px-3 py-1.5 text-xs text-text flex items-center justify-between" style={{ background: "var(--panel2)" }}>
+          <div className="rounded-md px-3 py-1.5 text-xs text-text flex items-center justify-between" style={{ background: "var(--panel-2)" }}>
             <span>🇺🇸 English</span>
             <ChevronDown size={12} className="text-muted" />
           </div>
         </div>
         <div className="space-y-1">
           <span className="text-[10px] text-muted">Currency</span>
-          <div className="rounded-md px-3 py-1.5 text-xs text-text flex items-center justify-between" style={{ background: "var(--panel2)" }}>
+          <div className="rounded-md px-3 py-1.5 text-xs text-text flex items-center justify-between" style={{ background: "var(--panel-2)" }}>
             <span>$ USD</span>
             <ChevronDown size={12} className="text-muted" />
           </div>
         </div>
-        <div className="rounded-lg px-3 py-2" style={{ background: "var(--panel2)" }}>
+        <div className="rounded-lg px-3 py-2" style={{ background: "var(--panel-2)" }}>
           <span className="text-[10px] text-muted">Preview: </span>
           <span className="text-xs font-medium text-text">$1,234.56</span>
         </div>
@@ -2708,7 +2708,7 @@ function SettingsAppearanceMockup() {
               style={
                 opt.active
                   ? { background: "var(--signal)", color: "var(--signal-on)" }
-                  : { background: "var(--panel2)", color: "var(--text-muted)" }
+                  : { background: "var(--panel-2)", color: "var(--muted)" }
               }
             >
               <opt.icon size={14} />
@@ -2788,7 +2788,7 @@ function SettingsMixDefaultsMockup() {
                 style={
                   i === 0
                     ? { background: "var(--signal)", color: "var(--signal-on)" }
-                    : { background: "var(--panel2)", color: "var(--text-muted)" }
+                    : { background: "var(--panel-2)", color: "var(--muted)" }
                 }
               >
                 {f}
@@ -2799,14 +2799,14 @@ function SettingsMixDefaultsMockup() {
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-1">
             <span className="text-[10px] text-muted">Sample Rate</span>
-            <div className="rounded-md px-3 py-1.5 text-xs text-text flex items-center justify-between" style={{ background: "var(--panel2)" }}>
+            <div className="rounded-md px-3 py-1.5 text-xs text-text flex items-center justify-between" style={{ background: "var(--panel-2)" }}>
               <span>48kHz</span>
               <ChevronDown size={12} className="text-muted" />
             </div>
           </div>
           <div className="space-y-1">
             <span className="text-[10px] text-muted">Bit Depth</span>
-            <div className="rounded-md px-3 py-1.5 text-xs text-text flex items-center justify-between" style={{ background: "var(--panel2)" }}>
+            <div className="rounded-md px-3 py-1.5 text-xs text-text flex items-center justify-between" style={{ background: "var(--panel-2)" }}>
               <span>24-bit</span>
               <ChevronDown size={12} className="text-muted" />
             </div>
@@ -2836,15 +2836,15 @@ function SettingsCalendarMockup() {
         <div className="space-y-1">
           <span className="text-[10px] text-muted">Feed URL</span>
           <div className="flex items-center gap-2">
-            <div className="flex-1 rounded-md px-3 py-1.5 text-[10px] text-muted truncate" style={{ background: "var(--panel2)" }}>
+            <div className="flex-1 rounded-md px-3 py-1.5 text-[10px] text-muted truncate" style={{ background: "var(--panel-2)" }}>
               https://mixarchitect.com/api/cal/abc123...
             </div>
-            <button className="shrink-0 p-1.5 rounded-md" style={{ background: "var(--panel2)" }}>
+            <button className="shrink-0 p-1.5 rounded-md" style={{ background: "var(--panel-2)" }}>
               <Copy size={12} className="text-muted" />
             </button>
           </div>
         </div>
-        <div className="rounded-lg px-3 py-2 text-[10px] text-muted space-y-1" style={{ background: "var(--panel2)" }}>
+        <div className="rounded-lg px-3 py-2 text-[10px] text-muted space-y-1" style={{ background: "var(--panel-2)" }}>
           <p>Add this URL to your calendar app:</p>
           <p>Google Calendar, Apple Calendar, Outlook</p>
         </div>
@@ -2903,7 +2903,7 @@ function ReleaseSettingsOverviewMockup() {
       <Rule />
       <PanelBody className="pt-3 space-y-0.5">
         {sections.map((s) => (
-          <div key={s.label} className="flex items-center gap-2.5 px-2 py-2 rounded-md" style={{ background: "var(--panel2)" }}>
+          <div key={s.label} className="flex items-center gap-2.5 px-2 py-2 rounded-md" style={{ background: "var(--panel-2)" }}>
             <s.icon size={14} className="text-muted shrink-0" />
             <div>
               <div className="text-xs font-medium text-text">{s.label}</div>
@@ -2925,17 +2925,17 @@ function ReleaseSettingsDetailsMockup() {
       <Rule />
       <PanelBody className="pt-4 space-y-3">
         <div className="flex items-start gap-3">
-          <div className="w-14 h-14 rounded-md shrink-0 flex items-center justify-center" style={{ background: "var(--panel2)" }}>
+          <div className="w-14 h-14 rounded-md shrink-0 flex items-center justify-center" style={{ background: "var(--panel-2)" }}>
             <Image size={20} className="text-muted opacity-30" />
           </div>
           <div className="flex-1 space-y-2">
             <div className="space-y-1">
               <span className="text-[10px] text-muted">Title</span>
-              <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel2)" }}>Midnight Sessions</div>
+              <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel-2)" }}>Midnight Sessions</div>
             </div>
             <div className="space-y-1">
               <span className="text-[10px] text-muted">Artist</span>
-              <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel2)" }}>Luna Park</div>
+              <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel-2)" }}>Luna Park</div>
             </div>
           </div>
         </div>
@@ -2943,7 +2943,7 @@ function ReleaseSettingsDetailsMockup() {
           <span className="text-[10px] text-muted">Type</span>
           <div className="flex gap-1.5">
             {["Single", "EP", "Album"].map((t, i) => (
-              <div key={t} className="px-2.5 py-1 text-[10px] font-medium rounded-md" style={i === 2 ? { background: "var(--signal)", color: "var(--signal-on)" } : { background: "var(--panel2)", color: "var(--text-muted)" }}>{t}</div>
+              <div key={t} className="px-2.5 py-1 text-[10px] font-medium rounded-md" style={i === 2 ? { background: "var(--signal)", color: "var(--signal-on)" } : { background: "var(--panel-2)", color: "var(--muted)" }}>{t}</div>
             ))}
           </div>
         </div>
@@ -2951,7 +2951,7 @@ function ReleaseSettingsDetailsMockup() {
           <span className="text-[10px] text-muted">Status</span>
           <div className="flex gap-1.5">
             {["Draft", "In Progress", "Ready"].map((s, i) => (
-              <div key={s} className="px-2.5 py-1 text-[10px] font-medium rounded-md" style={i === 1 ? { background: "var(--signal)", color: "var(--signal-on)" } : { background: "var(--panel2)", color: "var(--text-muted)" }}>{s}</div>
+              <div key={s} className="px-2.5 py-1 text-[10px] font-medium rounded-md" style={i === 1 ? { background: "var(--signal)", color: "var(--signal-on)" } : { background: "var(--panel-2)", color: "var(--muted)" }}>{s}</div>
             ))}
           </div>
         </div>
@@ -2963,7 +2963,7 @@ function ReleaseSettingsDetailsMockup() {
         </div>
         <div className="space-y-1">
           <span className="text-[10px] text-muted">Target Date</span>
-          <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel2)" }}>2026-04-15</div>
+          <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel-2)" }}>2026-04-15</div>
         </div>
       </PanelBody>
     </Panel>
@@ -2985,12 +2985,12 @@ function ReleaseSettingsClientMockup() {
         ].map((f) => (
           <div key={f.label} className="space-y-1">
             <span className="text-[10px] text-muted">{f.label}</span>
-            <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel2)" }}>{f.value}</div>
+            <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel-2)" }}>{f.value}</div>
           </div>
         ))}
         <div className="space-y-1">
           <span className="text-[10px] text-muted">Delivery Notes</span>
-          <div className="rounded-md px-3 py-2 text-xs text-text min-h-[48px]" style={{ background: "var(--panel2)" }}>
+          <div className="rounded-md px-3 py-2 text-xs text-text min-h-[48px]" style={{ background: "var(--panel-2)" }}>
             WAV 48kHz/24-bit. Label copy needed by April 1.
           </div>
         </div>
@@ -3016,22 +3016,22 @@ function ReleaseSettingsDistributionMockup() {
           ].map((f) => (
             <div key={f.label} className="space-y-1">
               <span className="text-[10px] text-muted">{f.label}</span>
-              <div className="rounded-md px-3 py-1.5 text-[10px] text-text" style={{ background: "var(--panel2)" }}>{f.value}</div>
+              <div className="rounded-md px-3 py-1.5 text-[10px] text-text" style={{ background: "var(--panel-2)" }}>{f.value}</div>
             </div>
           ))}
         </div>
         <div className="space-y-1">
           <span className="text-[10px] text-muted">Copyright Holder</span>
-          <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel2)" }}>Apex Records LLC</div>
+          <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel-2)" }}>Apex Records LLC</div>
         </div>
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-1">
             <span className="text-[10px] text-muted">Copyright Year</span>
-            <div className="rounded-md px-3 py-1.5 text-[10px] text-text" style={{ background: "var(--panel2)" }}>2026</div>
+            <div className="rounded-md px-3 py-1.5 text-[10px] text-text" style={{ background: "var(--panel-2)" }}>2026</div>
           </div>
           <div className="space-y-1">
             <span className="text-[10px] text-muted">P-line</span>
-            <div className="rounded-md px-3 py-1.5 text-[10px] text-text" style={{ background: "var(--panel2)" }}>Apex Records LLC</div>
+            <div className="rounded-md px-3 py-1.5 text-[10px] text-text" style={{ background: "var(--panel-2)" }}>Apex Records LLC</div>
           </div>
         </div>
       </PanelBody>
@@ -3051,21 +3051,21 @@ function ReleaseSettingsPaymentMockup() {
           <span className="text-[10px] text-muted">Payment Status</span>
           <div className="flex gap-1.5">
             {["No Fee", "Unpaid", "Partial", "Paid"].map((s, i) => (
-              <div key={s} className="px-2.5 py-1 text-[10px] font-medium rounded-md" style={i === 2 ? { background: "var(--signal)", color: "var(--signal-on)" } : { background: "var(--panel2)", color: "var(--text-muted)" }}>{s}</div>
+              <div key={s} className="px-2.5 py-1 text-[10px] font-medium rounded-md" style={i === 2 ? { background: "var(--signal)", color: "var(--signal-on)" } : { background: "var(--panel-2)", color: "var(--muted)" }}>{s}</div>
             ))}
           </div>
         </div>
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-1">
             <span className="text-[10px] text-muted">Project Fee</span>
-            <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel2)" }}>$2,500.00</div>
+            <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel-2)" }}>$2,500.00</div>
           </div>
           <div className="space-y-1">
             <span className="text-[10px] text-muted">Paid Amount</span>
-            <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel2)" }}>$1,000.00</div>
+            <div className="rounded-md px-3 py-1.5 text-xs text-text" style={{ background: "var(--panel-2)" }}>$1,000.00</div>
           </div>
         </div>
-        <div className="rounded-lg px-3 py-2" style={{ background: "var(--panel2)" }}>
+        <div className="rounded-lg px-3 py-2" style={{ background: "var(--panel-2)" }}>
           <span className="text-[10px] text-muted">Balance Due: </span>
           <span className="text-xs font-semibold text-text">$1,500.00</span>
         </div>
@@ -3083,10 +3083,10 @@ function ReleaseSettingsTeamMockup() {
       <Rule />
       <PanelBody className="pt-4 space-y-3">
         <div className="flex items-center gap-2">
-          <div className="flex-1 rounded-md px-3 py-1.5 text-xs text-muted" style={{ background: "var(--panel2)" }}>
+          <div className="flex-1 rounded-md px-3 py-1.5 text-xs text-muted" style={{ background: "var(--panel-2)" }}>
             Email address
           </div>
-          <div className="rounded-md px-3 py-1.5 text-xs text-text flex items-center gap-1" style={{ background: "var(--panel2)" }}>
+          <div className="rounded-md px-3 py-1.5 text-xs text-text flex items-center gap-1" style={{ background: "var(--panel-2)" }}>
             Collaborator
             <ChevronDown size={10} className="text-muted" />
           </div>
@@ -3101,7 +3101,7 @@ function ReleaseSettingsTeamMockup() {
             { name: "alex@studio.com", role: "Collaborator", color: "text-muted", pending: false },
             { name: "client@label.com", role: "Client", color: "text-muted", pending: true },
           ].map((m) => (
-            <div key={m.name} className="flex items-center justify-between py-1.5 px-2 rounded-md" style={{ background: "var(--panel2)" }}>
+            <div key={m.name} className="flex items-center justify-between py-1.5 px-2 rounded-md" style={{ background: "var(--panel-2)" }}>
               <div className="flex items-center gap-2">
                 <div className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-medium" style={{ background: "var(--border)" }}>
                   {m.name[0].toUpperCase()}
@@ -3716,7 +3716,7 @@ function SubmitFeatureModalMockup() {
       <PanelHeader>Submit for Feature</PanelHeader>
       <PanelBody className="space-y-4">
         <div className="flex items-center gap-3 p-3 rounded-md border border-border bg-panel">
-          <div className="w-12 h-12 rounded-md shrink-0 flex items-center justify-center" style={{ background: "var(--panel2)" }}>
+          <div className="w-12 h-12 rounded-md shrink-0 flex items-center justify-center" style={{ background: "var(--panel-2)" }}>
             <Music size={20} className="text-muted opacity-30" />
           </div>
           <div className="min-w-0">


### PR DESCRIPTION
Follow-up to the finding in #84.

## The bug

Inline styles across the app reference `var(--panel2)` and `var(--text-muted)`. **Neither variable exists.**

The defined variables are `--panel-2` and `--muted`. Only the Tailwind **theme tokens** are spelled `panel2` (globals.css: `--color-panel2: var(--panel-2)`) — which is why the `bg-panel2` *utility class* works fine while the raw inline `var(--panel2)` silently resolves to nothing.

Confirmed in a browser rather than inferred:

```
--panel-2                     #f8f8f6      defined
--panel2   (used in code)     ""           undefined
--muted                       #1414149e    defined
--text-muted (used in code)   ""           undefined
```

68 elements meant to carry a subtle secondary background were rendering **transparent**, and text meant to be muted kept its inherited color.

## The change

Replaced **54 `var(--panel2)`** and **14 `var(--text-muted)`** across 13 files. Tailwind class names untouched.

`screen-mockup.tsx` accounts for 40 of them — those are the help-article illustrations under `/app/help`, not the landing page.

## This is a real visual change

Elements gain a background they have never actually had in production. I checked every one before applying: they are all chips, pills, form fields, or list rows whose `rounded-md` and padding were **already there doing nothing visible**. The fix restores the intended design rather than altering it.

| | before | after |
|---|---|---|
| onboarding confirmation | `Engineer / Producer · English (US) · $ USD` as bare dotted text | three actual pills |
| help form mockups | labels floating over the panel | filled input fields |
| inactive status pills | invisible against the panel | subtle grey, contrasting the teal active pill |
| tour checklist step dots | transparent circles | grey "not done yet" dots |

**No regression found — nothing had been visually tuned around the missing background.**

One pairing worth noting, since it was the main risk: `tour-checklist.tsx` sets `color: signal-on` when a step is active and `color: muted` otherwise. The matching background ternary is `signal` / `panel-2`, so both branches stay correctly paired.

## Verification

Dev mode cannot hydrate under the app's CSP (`script-src` lacks `'unsafe-eval'`), so this was A/B'd against a **production build**. Because the only difference is whether a variable resolves, I toggled the variables at runtime on a single build to get a true before/after on identical pixels, in **both light and dark themes**.

Screens covered: release settings details / distribution / payment / team mockups, settings profile and calendar mockups, onboarding confirmation step, artist photo uploader, release card, tour checklist. Verified 51 affected elements on one page went from `rgba(0, 0, 0, 0)` to their intended color.

`tsc --noEmit` clean, `next build` green, eslint unchanged (the edit only alters string-literal contents inside style objects, so it cannot affect lint).

## Skipped

4 occurrences in `CoverArtEditor` (`sidebar-editors.tsx`), which #84 rewrites and already corrects — they would conflict. **Merge #84 first**, or expect that file to need a trivial resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)