### PR TITLE
Migrations 083-086: email provisioning, welcome outbox, audio quality alerts, signup attribution

### DIFF
--- a/supabase/migrations/083_provision_email_preferences.sql
+++ b/supabase/migrations/083_provision_email_preferences.sql
@@ -1,0 +1,43 @@
+-- New signups never got an email_preferences row, which silently excluded them
+-- from preference-gated sends. Provision it in handle_new_user and backfill.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public'
+AS $function$
+DECLARE
+  v_workspace_id uuid;
+  v_name text;
+BEGIN
+  INSERT INTO public.profiles (id, full_name)
+  VALUES (new.id, coalesce(new.raw_user_meta_data->>'full_name', ''));
+
+  v_name := coalesce(
+    nullif(trim(new.raw_user_meta_data->>'full_name'), ''),
+    nullif(split_part(coalesce(new.email, ''), '@', 1), ''),
+    'My'
+  ) || '''s Workspace';
+
+  INSERT INTO public.workspaces (owner_user_id, name, plan)
+  VALUES (new.id, v_name, 'free')
+  RETURNING id INTO v_workspace_id;
+
+  INSERT INTO public.workspace_members (workspace_id, user_id, invited_email, role, accepted_at)
+  VALUES (v_workspace_id, new.id, coalesce(new.email, new.id::text), 'owner', now());
+
+  INSERT INTO public.email_preferences (user_id)
+  VALUES (new.id)
+  ON CONFLICT (user_id) DO NOTHING;
+
+  RETURN new;
+END;
+$function$;
+
+INSERT INTO public.email_preferences (user_id)
+SELECT p.id
+FROM public.profiles p
+LEFT JOIN public.email_preferences ep ON ep.user_id = p.id
+WHERE ep.user_id IS NULL
+ON CONFLICT (user_id) DO NOTHING;

--- a/supabase/migrations/084_welcome_email_outbox.sql
+++ b/supabase/migrations/084_welcome_email_outbox.sql
@@ -1,0 +1,80 @@
+-- The welcome email used to be triggered by a client-side fetch that keyed the
+-- recipient off the caller's session cookie. Confirmation-gated signUp() creates
+-- no session, so the send either never fired (401) or went to whoever was
+-- already signed in. Enqueue the send in the DB instead, at user creation, with
+-- the recipient taken from the created auth.users row; the app drains the
+-- outbox server-side (signup route, auth callback, activity log, cron).
+
+CREATE TABLE IF NOT EXISTS public.email_outbox (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  to_email text NOT NULL,
+  display_name text,
+  category text NOT NULL DEFAULT 'welcome',
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'processing', 'sent', 'skipped', 'failed')),
+  attempts integer NOT NULL DEFAULT 0,
+  last_error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  processed_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS email_outbox_pending_idx
+  ON public.email_outbox (status, created_at)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS email_outbox_user_idx
+  ON public.email_outbox (user_id);
+
+-- Service-role only, like email_log: RLS on, no policies.
+ALTER TABLE public.email_outbox ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public'
+AS $function$
+DECLARE
+  v_workspace_id uuid;
+  v_name text;
+BEGIN
+  INSERT INTO public.profiles (id, full_name)
+  VALUES (new.id, coalesce(new.raw_user_meta_data->>'full_name', ''));
+
+  v_name := coalesce(
+    nullif(trim(new.raw_user_meta_data->>'full_name'), ''),
+    nullif(split_part(coalesce(new.email, ''), '@', 1), ''),
+    'My'
+  ) || '''s Workspace';
+
+  INSERT INTO public.workspaces (owner_user_id, name, plan)
+  VALUES (new.id, v_name, 'free')
+  RETURNING id INTO v_workspace_id;
+
+  INSERT INTO public.workspace_members (workspace_id, user_id, invited_email, role, accepted_at)
+  VALUES (v_workspace_id, new.id, coalesce(new.email, new.id::text), 'owner', now());
+
+  INSERT INTO public.email_preferences (user_id)
+  VALUES (new.id)
+  ON CONFLICT (user_id) DO NOTHING;
+
+  IF new.email IS NOT NULL THEN
+    INSERT INTO public.email_outbox (user_id, to_email, display_name, category)
+    VALUES (
+      new.id,
+      new.email,
+      coalesce(
+        nullif(trim(new.raw_user_meta_data->>'full_name'), ''),
+        split_part(new.email, '@', 1)
+      ),
+      'welcome'
+    );
+  END IF;
+
+  RETURN new;
+END;
+$function$;
+
+-- Deliberately no backfill: existing accounts should not receive a welcome
+-- email days after signing up.

--- a/supabase/migrations/085_audio_quality_alerts.sql
+++ b/supabase/migrations/085_audio_quality_alerts.sql
@@ -1,0 +1,289 @@
+-- ── Migration 085: Audio quality alerts ────────────────────
+-- The analyzer measured loudness, true peak, and clipping and then dropped
+-- them: user_defaults.default_* was read by nothing, track_specs.target_loudness
+-- was null on every track, and check_spec_mismatch() compared only the four
+-- format dimensions against tracks.target_* columns that were never seeded.
+--
+-- This migration wires the chain together:
+--   1. tracks.target_lufs (numeric) — the loudness target the trigger reads.
+--   2. BEFORE INSERT triggers seed tracks.target_* and track_specs display
+--      fields from the release owner's user_defaults (DB-side, so no app
+--      code path can skip it), plus a backfill for existing rows.
+--   3. check_spec_mismatch() gains loudness / true-peak / clipping arms with
+--      distinct notification types.
+--   4. notifications type CHECK re-declared — including distribution_live,
+--      which migration 052 accidentally dropped (its inserts have been
+--      failing the CHECK in production since).
+
+ALTER TABLE public.tracks ADD COLUMN IF NOT EXISTS target_lufs numeric(6,2);
+
+ALTER TABLE public.notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+ALTER TABLE public.notifications ADD CONSTRAINT notifications_type_check CHECK (type IN (
+  'comment',
+  'portal_comment',
+  'status_change',
+  'payment_update',
+  'approval',
+  'audio_upload',
+  'collaborator_joined',
+  'export_complete',
+  'spec_mismatch',
+  'distribution_live',
+  'feature_submission_approved',
+  'feature_submission_declined',
+  'clipping_detected',
+  'loudness_mismatch',
+  'true_peak_over'
+));
+
+-- ── Parsing helpers for the text-typed user_defaults fields ─────────
+
+-- '48kHz' → 48000, '44.1kHz' → 44100, '96000' → 96000
+CREATE OR REPLACE FUNCTION public.parse_sample_rate_hz(t text)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+SET search_path TO 'pg_catalog', 'public'
+AS $$
+  SELECT CASE
+    WHEN n IS NULL THEN NULL
+    WHEN n < 1000 THEN (n * 1000)::integer
+    ELSE n::integer
+  END
+  FROM (SELECT (regexp_match(coalesce(t, ''), '\d+(?:\.\d+)?'))[1]::numeric AS n) x;
+$$;
+
+-- '24-bit' → 24
+CREATE OR REPLACE FUNCTION public.parse_bit_depth(t text)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+SET search_path TO 'pg_catalog', 'public'
+AS $$
+  SELECT (regexp_match(coalesce(t, ''), '\d+'))[1]::integer;
+$$;
+
+-- '-14 LUFS' → -14
+CREATE OR REPLACE FUNCTION public.parse_lufs(t text)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+SET search_path TO 'pg_catalog', 'public'
+AS $$
+  SELECT (regexp_match(coalesce(t, ''), '-?\d+(?:\.\d+)?'))[1]::numeric;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.parse_sample_rate_hz(text) FROM public, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.parse_bit_depth(text) FROM public, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.parse_lufs(text) FROM public, anon, authenticated;
+
+-- ── Seed targets at creation ────────────────────────────────────────
+-- BEFORE INSERT (filling NEW in place) rather than AFTER INSERT rows in
+-- another table, so the app's own track_specs inserts (bare or
+-- template-seeded) never hit a conflict and template values always win.
+
+CREATE OR REPLACE FUNCTION public.seed_track_targets()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public'
+AS $function$
+DECLARE
+  v_d RECORD;
+BEGIN
+  SELECT d.default_sample_rate, d.default_bit_depth, d.default_loudness
+  INTO v_d
+  FROM public.releases r
+  JOIN public.user_defaults d ON d.user_id = r.user_id
+  WHERE r.id = NEW.release_id;
+
+  IF FOUND THEN
+    NEW.target_sample_rate := coalesce(NEW.target_sample_rate, public.parse_sample_rate_hz(v_d.default_sample_rate));
+    NEW.target_bit_depth := coalesce(NEW.target_bit_depth, public.parse_bit_depth(v_d.default_bit_depth));
+    NEW.target_lufs := coalesce(NEW.target_lufs, public.parse_lufs(v_d.default_loudness));
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.seed_track_targets() FROM public, anon, authenticated;
+
+DROP TRIGGER IF EXISTS tracks_seed_targets ON public.tracks;
+CREATE TRIGGER tracks_seed_targets
+  BEFORE INSERT ON public.tracks
+  FOR EACH ROW
+  EXECUTE FUNCTION public.seed_track_targets();
+
+CREATE OR REPLACE FUNCTION public.seed_track_spec_defaults()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public'
+AS $function$
+DECLARE
+  v_d RECORD;
+BEGIN
+  SELECT d.default_sample_rate, d.default_bit_depth, d.default_loudness
+  INTO v_d
+  FROM public.tracks t
+  JOIN public.releases r ON r.id = t.release_id
+  JOIN public.user_defaults d ON d.user_id = r.user_id
+  WHERE t.id = NEW.track_id;
+
+  IF FOUND THEN
+    NEW.target_loudness := coalesce(NEW.target_loudness, v_d.default_loudness);
+    NEW.sample_rate := coalesce(NEW.sample_rate, v_d.default_sample_rate);
+    NEW.bit_depth := coalesce(NEW.bit_depth, v_d.default_bit_depth);
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.seed_track_spec_defaults() FROM public, anon, authenticated;
+
+DROP TRIGGER IF EXISTS track_specs_seed_defaults ON public.track_specs;
+CREATE TRIGGER track_specs_seed_defaults
+  BEFORE INSERT ON public.track_specs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.seed_track_spec_defaults();
+
+-- ── Backfill existing rows ──────────────────────────────────────────
+
+UPDATE public.tracks t
+SET target_sample_rate = coalesce(t.target_sample_rate, public.parse_sample_rate_hz(d.default_sample_rate)),
+    target_bit_depth = coalesce(t.target_bit_depth, public.parse_bit_depth(d.default_bit_depth)),
+    target_lufs = coalesce(t.target_lufs, public.parse_lufs(d.default_loudness))
+FROM public.releases r
+JOIN public.user_defaults d ON d.user_id = r.user_id
+WHERE r.id = t.release_id;
+
+UPDATE public.track_specs s
+SET target_loudness = coalesce(s.target_loudness, d.default_loudness),
+    sample_rate = coalesce(s.sample_rate, d.default_sample_rate),
+    bit_depth = coalesce(s.bit_depth, d.default_bit_depth)
+FROM public.tracks t
+JOIN public.releases r ON r.id = t.release_id
+JOIN public.user_defaults d ON d.user_id = r.user_id
+WHERE t.id = s.track_id;
+
+-- ── Extend the analysis trigger ─────────────────────────────────────
+-- Fires on first completion AND on re-analysis (analysis_version change),
+-- so rows re-processed after the clip-detector fix can alert. Each alert
+-- type dedupes per track so re-analysis never floods the bell.
+--
+-- The clipping arm requires BOTH a large count and sample peak at the rail,
+-- mirroring computeQualitySnapshot() in audio-player-shared.ts: legacy rows
+-- still carrying the astats "Peak count" floor of 2 can never fire it.
+
+CREATE OR REPLACE FUNCTION public.check_spec_mismatch()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public'
+AS $function$
+DECLARE
+  v_track RECORD;
+  v_completed boolean;
+  v_reanalyzed boolean;
+BEGIN
+  v_completed := NEW.spec_analysis_status = 'complete'
+    AND (OLD.spec_analysis_status IS DISTINCT FROM 'complete');
+  v_reanalyzed := NEW.analysis_version IS DISTINCT FROM OLD.analysis_version
+    AND coalesce(NEW.analysis_version, 0) > 0;
+
+  IF NOT (v_completed OR v_reanalyzed) THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT t.id, t.title, t.release_id, r.user_id,
+         t.target_sample_rate, t.target_bit_depth, t.target_channels,
+         t.target_format, t.target_lufs
+  INTO v_track
+  FROM tracks t
+  JOIN releases r ON r.id = t.release_id
+  WHERE t.id = NEW.track_id;
+
+  -- Format-dimension mismatch: unchanged behavior, first completion only.
+  IF v_completed AND (
+       (v_track.target_sample_rate IS NOT NULL AND NEW.sample_rate IS NOT NULL
+        AND v_track.target_sample_rate != NEW.sample_rate)
+    OR (v_track.target_bit_depth IS NOT NULL AND NEW.bit_depth IS NOT NULL
+        AND v_track.target_bit_depth != NEW.bit_depth)
+    OR (v_track.target_channels IS NOT NULL AND NEW.channels IS NOT NULL
+        AND v_track.target_channels != NEW.channels)
+    OR (v_track.target_format IS NOT NULL AND NEW.file_format IS NOT NULL
+        AND LOWER(v_track.target_format) != LOWER(NEW.file_format))
+  ) THEN
+    INSERT INTO notifications (user_id, type, title, body, release_id, track_id, created_at)
+    VALUES (
+      v_track.user_id,
+      'spec_mismatch',
+      format('Spec mismatch: %s', v_track.title),
+      'Uploaded audio does not match the target delivery specs.',
+      v_track.release_id, v_track.id, NOW()
+    );
+  END IF;
+
+  -- Loudness off target (±1 LU tolerance).
+  IF v_track.target_lufs IS NOT NULL AND NEW.measured_lufs IS NOT NULL
+     AND abs(NEW.measured_lufs - v_track.target_lufs) > 1.0
+     AND NOT EXISTS (
+       SELECT 1 FROM notifications n
+       WHERE n.track_id = v_track.id AND n.type = 'loudness_mismatch'
+     )
+  THEN
+    INSERT INTO notifications (user_id, type, title, body, release_id, track_id, created_at)
+    VALUES (
+      v_track.user_id,
+      'loudness_mismatch',
+      format('Loudness off target: %s', v_track.title),
+      format('Measured %s LUFS against a %s LUFS target.',
+             round(NEW.measured_lufs::numeric, 1), round(v_track.target_lufs, 1)),
+      v_track.release_id, v_track.id, NOW()
+    );
+  END IF;
+
+  -- True peak over the ceiling. Needs no user-set target: over -0.1 dBTP is
+  -- objectively wrong for delivery, which is what makes this alert work for
+  -- the user who configured nothing. Sample peak at/over 0 dBFS is implied.
+  IF NEW.true_peak_dbtp IS NOT NULL AND NEW.true_peak_dbtp > -0.1
+     AND NOT EXISTS (
+       SELECT 1 FROM notifications n
+       WHERE n.track_id = v_track.id AND n.type = 'true_peak_over'
+     )
+  THEN
+    INSERT INTO notifications (user_id, type, title, body, release_id, track_id, created_at)
+    VALUES (
+      v_track.user_id,
+      'true_peak_over',
+      format('True peak over ceiling: %s', v_track.title),
+      format('True peak is %s dBTP. Lossy encodes will distort; keep it under -1 dBTP.',
+             round(NEW.true_peak_dbtp::numeric, 1)),
+      v_track.release_id, v_track.id, NOW()
+    );
+  END IF;
+
+  -- Digital clipping.
+  IF coalesce(NEW.clip_sample_count, 0) > 1000
+     AND coalesce(NEW.sample_peak_dbfs, -100) >= -0.1
+     AND NOT EXISTS (
+       SELECT 1 FROM notifications n
+       WHERE n.track_id = v_track.id AND n.type = 'clipping_detected'
+     )
+  THEN
+    INSERT INTO notifications (user_id, type, title, body, release_id, track_id, created_at)
+    VALUES (
+      v_track.user_id,
+      'clipping_detected',
+      format('Clipping detected: %s', v_track.title),
+      format('%s samples at digital full scale.', NEW.clip_sample_count),
+      v_track.release_id, v_track.id, NOW()
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+-- Re-apply the 059/065 hardening that CREATE OR REPLACE would otherwise drop.
+REVOKE EXECUTE ON FUNCTION public.check_spec_mismatch() FROM public, anon, authenticated;

--- a/supabase/migrations/086_organic_signup_attribution.sql
+++ b/supabase/migrations/086_organic_signup_attribution.sql
@@ -1,0 +1,24 @@
+-- Organic signup attribution. signup_attributions previously modelled only
+-- the engineer-referral path (portal_branding / post_action_prompt), so a
+-- cold organic signup recorded no source at all. Add first-touch fields and
+-- source values for utm / organic / direct signups, captured from a
+-- client-set cookie at signup time.
+
+ALTER TABLE public.signup_attributions
+  DROP CONSTRAINT IF EXISTS valid_source;
+ALTER TABLE public.signup_attributions
+  ADD CONSTRAINT valid_source CHECK (source IN (
+    'portal_branding', 'post_action_prompt', 'utm', 'organic', 'direct'
+  ));
+
+ALTER TABLE public.signup_attributions
+  ADD COLUMN IF NOT EXISTS referrer text,
+  ADD COLUMN IF NOT EXISTS landing_page text,
+  ADD COLUMN IF NOT EXISTS utm_source text,
+  ADD COLUMN IF NOT EXISTS utm_medium text,
+  ADD COLUMN IF NOT EXISTS utm_campaign text,
+  ADD COLUMN IF NOT EXISTS utm_term text,
+  ADD COLUMN IF NOT EXISTS utm_content text;
+
+CREATE INDEX IF NOT EXISTS idx_attributions_user
+  ON public.signup_attributions(attributed_user_id);


### PR DESCRIPTION
## Summary

Records four migrations from the first-organic-user postmortem in the repo's migration history. **All four are already applied to the production database** (via the Supabase MCP on 2026-08-09) — merging this does not change the DB, it brings the repo in line with prod.

- **083** — `handle_new_user()` now provisions an `email_preferences` row on signup, plus a backfill (5 of 10 profiles had no row and were silently excluded from preference-gated sends).
- **084** — new `email_outbox` table, seeded by `handle_new_user()` with the recipient taken from the created `auth.users` row. Fixes the welcome-email bug where the recipient came from the caller's session cookie (no session → never sent; stale session → sent to the wrong account). The app-side drain code ships separately.
- **085** — wires the three disconnected spec stores together: `tracks.target_lufs` column, BEFORE INSERT triggers seeding `tracks.target_*` and `track_specs` from `user_defaults` (+ backfill of all existing tracks), and new `loudness_mismatch` / `true_peak_over` / `clipping_detected` arms in `check_spec_mismatch()`, deduped per track. Also **restores `distribution_live`** to the notifications type CHECK — migration 052 accidentally dropped it and those inserts have been failing in production since.
- **086** — `signup_attributions` gains `utm` / `organic` / `direct` sources and `referrer` / `landing_page` / `utm_*` columns so organic signups are traceable before ad spend starts.

## Verification (run against prod after applying)

- `profiles` without `email_preferences`: **0** (was 5)
- `tracks` with null `target_lufs` / `target_sample_rate`: **0** (was 15–16 of 17)
- Trigger live-fired on a −31.6 LUFS test file: exactly one `loudness_mismatch`, and no false `clipping_detected` despite the legacy `clip_sample_count = 2` floor (the sample-peak gate held).
- Throwaway signup produced an outbox row + `email_log` row addressed to the signup's own address (test user deleted afterwards).

The companion app/worker changes (outbox drain routes, clip detector v2, waveform metrics, attribution capture) follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)