### PR TITLE
First-user postmortem: welcome-email outbox, clip detector v2, quality alerts, waveform metrics, attribution

### DIFF
--- a/src/app/admin/performance/page.tsx
+++ b/src/app/admin/performance/page.tsx
@@ -11,6 +11,8 @@ const PRESET_KEYS = ["today", "yesterday", "7d", "30d", "90d", "365d"] as const;
 const METRIC_BUDGETS: Record<string, number> = {
   "wavesurfer:init": 150,
   "waveform:render": 500,
+  "waveform:render:warm": 500,
+  "waveform:render:cold": 2500,
   "waveform:seek": 50,
   "waveform:resize": 100,
   "playback:start:warm": 100,

--- a/src/app/api/admin/log-activity/route.ts
+++ b/src/app/api/admin/log-activity/route.ts
@@ -3,48 +3,7 @@ import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { logActivity, type ActivityEventType } from "@/lib/activity-logger";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { requireSameOrigin } from "@/lib/origin-check";
-import { sendTransactionalEmail, buildUnsubscribeUrl, getUserEmail } from "@/lib/email/service";
-import { buildWelcomeEmail } from "@/lib/email-templates/transactional";
-import { buildAdminEmail } from "@/lib/email-templates/admin-notification";
-import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
-
-/**
- * Email all admins that a new user signed up. Internal ops alert — sent
- * directly (not through the user-preference system), never throws.
- */
-async function notifyAdminsOfSignup(newUserEmail: string, newUserName: string) {
-  try {
-    const key = process.env.RESEND_API_KEY;
-    if (!key) return;
-    const svc = createSupabaseServiceClient();
-    const { data: admins } = await svc.from("profiles").select("id").eq("is_admin", true);
-    if (!admins || admins.length === 0) return;
-
-    const emails = (
-      await Promise.all(admins.map((a) => getUserEmail(a.id as string)))
-    ).filter((e): e is string => !!e);
-    if (emails.length === 0) return;
-
-    const { Resend } = require("resend") as typeof import("resend");
-    const resend = new Resend(key);
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://mixarchitect.com";
-    const { subject, html } = buildAdminEmail({
-      subject: `New signup: ${newUserEmail}`,
-      heading: "New user signed up",
-      body: `${newUserName} (${newUserEmail}) just created a Mix Architect account.`,
-      ctaLabel: "View subscribers",
-      ctaUrl: `${appUrl}/admin/subscribers`,
-    });
-    await resend.emails.send({
-      from: "Mix Architect <team@mixarchitect.com>",
-      to: emails,
-      subject,
-      html,
-    });
-  } catch (err) {
-    console.error("[log-activity] admin signup alert failed (non-fatal):", err);
-  }
-}
+import { drainEmailOutbox } from "@/lib/email/outbox";
 
 const ALLOWED_EVENTS: Set<string> = new Set([
   "login",
@@ -89,67 +48,13 @@ export async function POST(req: NextRequest) {
 
     logActivity(user.id, eventType as ActivityEventType, metadata, { ip: getClientIp(req), userAgent: req.headers.get("user-agent") ?? undefined });
 
-    // Signup side effects: welcome email to the user + admin alert.
-    // Awaited (not fire-and-forget) so Vercel doesn't terminate the sends
-    // when the handler returns.
-    //
-    // Replay guards — this endpoint is reachable by any signed-in user, so
-    // "signup" must not be re-fireable: (a) only within 1h of account
-    // creation, (b) only if no welcome email was ever logged for this user.
-    // Without these, a user could re-post {eventType:"signup"} in a loop and
-    // spam every admin + re-send themselves welcome mail.
-    if (eventType === "signup" && user.email) {
-      const accountAgeMs = Date.now() - new Date(user.created_at).getTime();
-      if (accountAgeMs > 60 * 60 * 1000) {
-        return NextResponse.json({ ok: true });
-      }
-
-      const dedupeSvc = createSupabaseServiceClient();
-      const { data: priorWelcome } = await dedupeSvc
-        .from("email_log")
-        .select("id")
-        .eq("user_id", user.id)
-        .eq("category", "welcome")
-        .limit(1)
-        .maybeSingle();
-      if (priorWelcome) {
-        return NextResponse.json({ ok: true });
-      }
-
-      const displayName =
-        user.user_metadata?.display_name ?? user.email.split("@")[0];
-
-      // Welcome email to the new user.
-      try {
-        const svc = createSupabaseServiceClient();
-        await svc
-          .from("email_preferences")
-          .upsert({ user_id: user.id }, { onConflict: "user_id" });
-
-        const { data: prefs } = await svc
-          .from("email_preferences")
-          .select("unsubscribe_token")
-          .eq("user_id", user.id)
-          .maybeSingle();
-
-        const unsubscribeUrl = prefs?.unsubscribe_token
-          ? buildUnsubscribeUrl(prefs.unsubscribe_token, "welcome")
-          : undefined;
-
-        const { subject, html } = buildWelcomeEmail({ displayName, unsubscribeUrl });
-        await sendTransactionalEmail({
-          userId: user.id,
-          to: user.email,
-          category: "welcome",
-          subject,
-          html,
-        });
-      } catch (err) {
-        console.error("[log-activity] welcome email error:", err);
-      }
-
-      // Alert admins that a new user joined.
-      await notifyAdminsOfSignup(user.email, displayName);
+    // Signup/login side effect: deliver any pending welcome email from the
+    // outbox seeded by handle_new_user(). Awaited (not fire-and-forget) so
+    // Vercel doesn't terminate the send when the handler returns. Re-posting
+    // the event can't re-send or spam admins — the drain only processes rows
+    // still in 'pending' for THIS user, claimed with a conditional update.
+    if (eventType === "signup" || eventType === "login") {
+      await drainEmailOutbox({ userId: user.id });
     }
 
     return NextResponse.json({ ok: true });

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
+import { requireSameOrigin } from "@/lib/origin-check";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { drainEmailOutbox } from "@/lib/email/outbox";
+import { logActivity } from "@/lib/activity-logger";
+import { recordSignupAttribution } from "@/lib/attribution-capture";
+
+/**
+ * POST /api/auth/signup
+ *
+ * Server-side signup so the post-signup side effects (welcome email via the
+ * email_outbox seeded by handle_new_user, activity log) run before the
+ * response returns — they used to depend on a client-side fetch that carried
+ * no session and silently 401'd. The password only transits to Supabase Auth;
+ * it is never stored or logged here.
+ */
+export async function POST(req: NextRequest) {
+  const originErr = requireSameOrigin(req);
+  if (originErr) return originErr;
+
+  const ip = getClientIp(req);
+  const { success } = rateLimit(`signup:${ip}`, 10, 3_600_000);
+  if (!success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  let body: { email?: unknown; password?: unknown; fullName?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const email = typeof body.email === "string" ? body.email.trim() : "";
+  const password = typeof body.password === "string" ? body.password : "";
+  const fullName =
+    typeof body.fullName === "string" && body.fullName.trim()
+      ? body.fullName.trim()
+      : undefined;
+
+  if (!email || !email.includes("@") || !password) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const supabase = await createSupabaseServerClient({ allowCookieWrite: true });
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      data: { full_name: fullName },
+      emailRedirectTo: `${req.nextUrl.origin}/auth/callback`,
+    },
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message, code: error.code },
+      { status: 400 },
+    );
+  }
+
+  // For an address that already has a confirmed account, Supabase returns an
+  // obfuscated user with no identities and no new auth.users row — skip the
+  // side effects for it, and the identical response leaks nothing about
+  // account existence.
+  if (data.user && (data.user.identities?.length ?? 0) > 0) {
+    logActivity(data.user.id, "signup", { method: "email" }, {
+      ip,
+      userAgent: req.headers.get("user-agent") ?? undefined,
+    });
+    await recordSignupAttribution(req, data.user);
+    await drainEmailOutbox({ userId: data.user.id });
+  }
+
+  return NextResponse.json({ ok: true, hasSession: !!data.session });
+}

--- a/src/app/api/cron/email-outbox/route.ts
+++ b/src/app/api/cron/email-outbox/route.ts
@@ -1,0 +1,29 @@
+import crypto from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { drainEmailOutbox } from "@/lib/email/outbox";
+
+/**
+ * Cron job: safety net for the welcome-email outbox. The normal delivery
+ * paths are the signup route, the auth callback, and the activity-log
+ * endpoint; this sweep catches anything they missed (e.g. a Resend outage
+ * during signup). Secured by CRON_SECRET header.
+ */
+export async function GET(request: NextRequest) {
+  const secret = request.headers.get("authorization");
+  // Fail closed if CRON_SECRET is unset — otherwise the expected digest is
+  // of the literal "Bearer undefined", which an attacker can simply send.
+  if (!secret || !process.env.CRON_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const actual = crypto.createHash("sha256").update(secret).digest();
+  const expected = crypto
+    .createHash("sha256")
+    .update(`Bearer ${process.env.CRON_SECRET}`)
+    .digest();
+  if (!crypto.timingSafeEqual(actual, expected)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const settled = await drainEmailOutbox({ limit: 25 });
+  return NextResponse.json({ ok: true, settled });
+}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 import { getSafeRedirectUrl } from "@/lib/safe-redirect";
+import { drainEmailOutbox } from "@/lib/email/outbox";
+import { recordSignupAttribution } from "@/lib/attribution-capture";
 
 /**
  * Supabase Auth callback handler.
@@ -40,9 +42,17 @@ export async function GET(request: NextRequest) {
       },
     );
 
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!error) {
+      // First authenticated server touchpoint for email-confirmation and
+      // OAuth signups — deliver any pending welcome email and record signup
+      // attribution now. Neither blocks the redirect: both helpers catch
+      // their own errors, and attribution skips accounts older than an hour.
+      if (data.user) {
+        await recordSignupAttribution(request, data.user);
+        await drainEmailOutbox({ userId: data.user.id });
+      }
       return response;
     }
   }

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -132,26 +132,41 @@ function SignInPageContent() {
         });
         if (error) throw error;
       } else {
-        const { error } = await supabase.auth.signUp({
-          email,
-          password,
-          options: {
-            data: { full_name: fullName.trim() || undefined },
-            emailRedirectTo: `${window.location.origin}/auth/callback`,
-          },
+        // Server-side signup: the route runs the welcome-email outbox drain
+        // and activity log before responding, so they can't be skipped by
+        // closing the tab (the old client-side path silently 401'd because
+        // confirmation-gated signUp() carries no session).
+        const res = await fetch("/api/auth/signup", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email,
+            password,
+            fullName: fullName.trim() || undefined,
+          }),
         });
-        if (error) throw error;
-      }
-
-      // Fire-and-forget activity log
-      logActivityClient(mode === "signin" ? "login" : "signup", { method: "email" });
-      if (mode === "signup") trackGA4Event("signup_start", { source: "auth_page" });
-
-      if (mode === "signup") {
+        const payload = (await res.json()) as {
+          error?: string;
+          code?: string;
+          hasSession?: boolean;
+        };
+        if (!res.ok) {
+          throw Object.assign(new Error(payload.error ?? t("somethingWrong")), {
+            code: payload.code,
+          });
+        }
+        trackGA4Event("signup_start", { source: "auth_page" });
+        if (payload.hasSession) {
+          window.location.href = "/app";
+          return;
+        }
         setConfirmationSent(true);
         setLoading(false);
         return;
       }
+
+      // Fire-and-forget activity log (signup is logged server-side)
+      logActivityClient("login", { method: "email" });
 
       // Full page load so session cookies are ready for server-side checks
       window.location.href = "/app";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { PerfOverlayLoader } from "@/components/dev/perf-overlay-loader";
 import { PerfReporterInit } from "@/components/perf-reporter-init";
 import { OpenPanelAnalytics } from "@/components/analytics/OpenPanelAnalytics";
 import { GoogleAnalytics } from "@/components/analytics/GoogleAnalytics";
+import { AttributionCapture } from "@/components/attribution-capture";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -55,6 +56,7 @@ export default function RootLayout({
           {children}
           <OpenPanelAnalytics />
           <GoogleAnalytics />
+          <AttributionCapture />
           <PerfReporterInit />
           <PerfOverlayLoader />
         </ThemeWrapper>

--- a/src/components/attribution-capture.tsx
+++ b/src/components/attribution-capture.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+
+const COOKIE = "mix_attribution_touch";
+const MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+/**
+ * First-touch attribution capture. On the first page view without a touch
+ * cookie, records the external referrer, landing page, and UTM params in a
+ * 30-day cookie. The signup route reads it server-side and writes a
+ * signup_attributions row (source: utm / organic / direct). First touch
+ * wins: later visits never overwrite the cookie.
+ */
+export function AttributionCapture() {
+  useEffect(() => {
+    if (document.cookie.split("; ").some((c) => c.startsWith(`${COOKIE}=`))) {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    let referrer: string | null = document.referrer || null;
+    try {
+      if (referrer && new URL(referrer).origin === window.location.origin) {
+        referrer = null;
+      }
+    } catch {
+      referrer = null;
+    }
+    const clip = (v: string | null, max: number) => (v ? v.slice(0, max) : null);
+    const touch = {
+      referrer: clip(referrer, 500),
+      landing_page: clip(window.location.pathname + window.location.search, 500),
+      utm_source: clip(params.get("utm_source"), 200),
+      utm_medium: clip(params.get("utm_medium"), 200),
+      utm_campaign: clip(params.get("utm_campaign"), 200),
+      utm_term: clip(params.get("utm_term"), 200),
+      utm_content: clip(params.get("utm_content"), 200),
+    };
+    document.cookie = `${COOKIE}=${encodeURIComponent(JSON.stringify(touch))}; path=/; max-age=${MAX_AGE_SECONDS}; SameSite=Lax`;
+  }, []);
+  return null;
+}

--- a/src/components/ui/audio-player.tsx
+++ b/src/components/ui/audio-player.tsx
@@ -586,10 +586,20 @@ export function AudioPlayer({
         duration: activeVersion.duration_seconds ?? undefined,
       });
       perf.end("wavesurfer:init");
-      perf.start("waveform:render", { trackId: activeVersion.id });
+      // "warm" = cached peaks + duration supplied, so ready fires without
+      // touching the network. "cold" = wavesurfer must fetch/decode audio
+      // (or await loadedmetadata) first — network-bound by design, and the
+      // reason a single p50 hid multi-second first renders on mobile.
+      const renderMetric =
+        activeVersion.waveform_peaks && activeVersion.duration_seconds
+          ? "waveform:render:warm"
+          : "waveform:render:cold";
+      perf.start(renderMetric, { trackId: activeVersion.id });
 
       // Error handling — retry once after a short delay.
       // Freshly uploaded files may not be available at the CDN immediately.
+      // Pass the cached peaks + duration so the retry renders from cache
+      // instead of fetching and decoding the full lossless file.
       let retried = false;
       ws.on("error", (err) => {
         console.warn("[audio-player] WaveSurfer load error:", err);
@@ -597,7 +607,11 @@ export function AudioPlayer({
           retried = true;
           retryTimeout = setTimeout(() => {
             if (!cancelled && ws && container.isConnected) {
-              ws.load(activeVersion.audio_url);
+              ws.load(
+                activeVersion.audio_url,
+                activeVersion.waveform_peaks ?? undefined,
+                activeVersion.duration_seconds ?? undefined,
+              );
             }
           }, 1500);
         }
@@ -605,7 +619,7 @@ export function AudioPlayer({
 
       ws.on("ready", () => {
         if (cancelled) return;
-        perf.end("waveform:render");
+        perf.end(renderMetric);
         perf.captureMemory("memory:after-waveform-load");
         setIsReady(true);
 

--- a/src/components/ui/notification-bell.tsx
+++ b/src/components/ui/notification-bell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback } from "react";
-import { AlertTriangle, Bell, Check, MessageSquare, GitCommitHorizontal, DollarSign, ShieldCheck, X, Upload, UserPlus, Download, Radio } from "lucide-react";
+import { Activity, AlertTriangle, Bell, Check, MessageSquare, GitCommitHorizontal, DollarSign, ShieldCheck, X, Upload, UserPlus, Download, Radio, Scissors, Volume2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/cn";
 import { useNotifications, type Notification } from "@/lib/notifications/use-notifications";
@@ -203,6 +203,12 @@ function NotificationIcon({ type }: { type: string }) {
       return <AlertTriangle size={16} strokeWidth={1.5} className={cls} />;
     case "distribution_live":
       return <Radio size={16} strokeWidth={1.5} className={cls} />;
+    case "clipping_detected":
+      return <Scissors size={16} strokeWidth={1.5} className={cls} />;
+    case "loudness_mismatch":
+      return <Volume2 size={16} strokeWidth={1.5} className={cls} />;
+    case "true_peak_over":
+      return <Activity size={16} strokeWidth={1.5} className={cls} />;
     default:
       return <Bell size={16} strokeWidth={1.5} className={cls} />;
   }

--- a/src/lib/attribution-capture.ts
+++ b/src/lib/attribution-capture.ts
@@ -1,0 +1,74 @@
+import type { NextRequest } from "next/server";
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+
+const TOUCH_COOKIE = "mix_attribution_touch";
+const REFERRAL_COOKIE = "mix_attribution_id";
+const MAX_ACCOUNT_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * Record how a new signup found the app, from the first-touch cookie set by
+ * AttributionCapture. Never throws; a missing cookie still records a
+ * 'direct' row so no signup is untraceable. Skips users on the
+ * engineer-referral path (they get linked to their click row separately)
+ * and accounts older than an hour (so the auth callback can call this on
+ * every code exchange without stamping old users).
+ */
+export async function recordSignupAttribution(
+  req: NextRequest,
+  user: { id: string; created_at?: string },
+): Promise<void> {
+  try {
+    if (req.cookies.get(REFERRAL_COOKIE)?.value) return;
+    if (
+      user.created_at &&
+      Date.now() - new Date(user.created_at).getTime() > MAX_ACCOUNT_AGE_MS
+    ) {
+      return;
+    }
+
+    const svc = createSupabaseServiceClient();
+    const { data: existing } = await svc
+      .from("signup_attributions")
+      .select("id")
+      .eq("attributed_user_id", user.id)
+      .limit(1)
+      .maybeSingle();
+    if (existing) return;
+
+    let touch: Record<string, unknown> = {};
+    const raw = req.cookies.get(TOUCH_COOKIE)?.value;
+    if (raw) {
+      try {
+        touch = JSON.parse(decodeURIComponent(raw)) as Record<string, unknown>;
+      } catch {
+        touch = {};
+      }
+    }
+    const clean = (v: unknown, max: number) =>
+      typeof v === "string" && v ? v.slice(0, max) : null;
+
+    const utmSource = clean(touch.utm_source, 200);
+    const referrer = clean(touch.referrer, 500);
+    const source = utmSource ? "utm" : referrer ? "organic" : "direct";
+
+    const { error } = await svc.from("signup_attributions").insert({
+      attributed_user_id: user.id,
+      source,
+      page_type: "landing",
+      status: "signed_up",
+      signed_up_at: new Date().toISOString(),
+      referrer,
+      landing_page: clean(touch.landing_page, 500),
+      utm_source: utmSource,
+      utm_medium: clean(touch.utm_medium, 200),
+      utm_campaign: clean(touch.utm_campaign, 200),
+      utm_term: clean(touch.utm_term, 200),
+      utm_content: clean(touch.utm_content, 200),
+    });
+    if (error) {
+      console.error("[attribution] signup attribution insert failed:", error);
+    }
+  } catch (err) {
+    console.error("[attribution] signup attribution failed:", err);
+  }
+}

--- a/src/lib/email/outbox.ts
+++ b/src/lib/email/outbox.ts
@@ -1,0 +1,182 @@
+/**
+ * Drains the email_outbox table seeded by the handle_new_user() DB trigger.
+ *
+ * The outbox exists because the welcome email must not depend on the browser:
+ * the trigger enqueues a row with the recipient taken from the created
+ * auth.users record, and this drain runs from every server-side touchpoint
+ * where a session first exists (signup route, auth callback, activity log)
+ * plus a cron safety net. Rows are claimed with a conditional update so
+ * concurrent drains cannot double-send.
+ */
+
+import { createSupabaseServiceClient } from "@/lib/supabaseServiceClient";
+import {
+  sendTransactionalEmail,
+  buildUnsubscribeUrl,
+  getUserEmail,
+} from "@/lib/email/service";
+import { buildWelcomeEmail } from "@/lib/email-templates/transactional";
+import { buildAdminEmail } from "@/lib/email-templates/admin-notification";
+
+const MAX_ATTEMPTS = 3;
+
+type OutboxRow = {
+  id: string;
+  user_id: string;
+  to_email: string;
+  display_name: string | null;
+  category: string;
+  attempts: number;
+};
+
+/**
+ * Process pending outbox rows. Pass userId to drain a single user's rows
+ * (the post-signup / post-login path); omit it for the cron sweep.
+ * Never throws. Returns the number of rows that reached a terminal state.
+ */
+export async function drainEmailOutbox(
+  opts: { userId?: string; limit?: number } = {},
+): Promise<number> {
+  const { userId, limit = 10 } = opts;
+  const svc = createSupabaseServiceClient();
+
+  try {
+    let query = svc
+      .from("email_outbox")
+      .select("id, user_id, to_email, display_name, category, attempts")
+      .eq("status", "pending")
+      .lt("attempts", MAX_ATTEMPTS)
+      .order("created_at", { ascending: true })
+      .limit(limit);
+    if (userId) query = query.eq("user_id", userId);
+
+    const { data: rows, error } = await query;
+    if (error) {
+      console.error("[email/outbox] select failed:", error);
+      return 0;
+    }
+    if (!rows || rows.length === 0) return 0;
+
+    let settled = 0;
+    for (const row of rows as OutboxRow[]) {
+      const attempts = row.attempts + 1;
+      const { data: claimed } = await svc
+        .from("email_outbox")
+        .update({ status: "processing", attempts })
+        .eq("id", row.id)
+        .eq("status", "pending")
+        .select("id");
+      if (!claimed || claimed.length === 0) continue;
+
+      // The admin signup alert rides on the first delivery attempt so admins
+      // hear about the signup even if the welcome email itself fails.
+      if (row.category === "welcome" && attempts === 1) {
+        await notifyAdminsOfSignup(row.to_email, row.display_name ?? row.to_email);
+      }
+
+      let outcome: "sent" | "skipped" | "retry";
+      if (row.category === "welcome") {
+        outcome = await sendWelcome(svc, row);
+      } else {
+        // Unknown categories are terminal: better a skipped row than a
+        // poison message that blocks the pending sweep forever.
+        outcome = "skipped";
+      }
+
+      if (outcome === "retry" && attempts < MAX_ATTEMPTS) {
+        await svc
+          .from("email_outbox")
+          .update({ status: "pending" })
+          .eq("id", row.id);
+        continue;
+      }
+
+      await svc
+        .from("email_outbox")
+        .update({
+          status: outcome === "retry" ? "failed" : outcome,
+          processed_at: new Date().toISOString(),
+        })
+        .eq("id", row.id);
+      settled += 1;
+    }
+    return settled;
+  } catch (err) {
+    console.error("[email/outbox] drain failed:", err);
+    return 0;
+  }
+}
+
+async function sendWelcome(
+  svc: ReturnType<typeof createSupabaseServiceClient>,
+  row: OutboxRow,
+): Promise<"sent" | "skipped" | "retry"> {
+  const { data: prefs } = await svc
+    .from("email_preferences")
+    .select("unsubscribe_token")
+    .eq("user_id", row.user_id)
+    .maybeSingle();
+
+  const unsubscribeUrl = prefs?.unsubscribe_token
+    ? buildUnsubscribeUrl(prefs.unsubscribe_token, "welcome")
+    : undefined;
+
+  const displayName = row.display_name ?? row.to_email.split("@")[0];
+  const { subject, html } = buildWelcomeEmail({ displayName, unsubscribeUrl });
+
+  const result = await sendTransactionalEmail({
+    userId: row.user_id,
+    to: row.to_email,
+    category: "welcome",
+    subject,
+    html,
+  });
+
+  if (result === "sent") return "sent";
+  if (result === "skipped_preference" || result === "skipped_rate_limit") {
+    return "skipped";
+  }
+  await svc
+    .from("email_outbox")
+    .update({ last_error: result })
+    .eq("id", row.id);
+  return "retry";
+}
+
+/**
+ * Email all admins that a new user signed up. Internal ops alert — sent
+ * directly (not through the user-preference system), never throws.
+ */
+async function notifyAdminsOfSignup(newUserEmail: string, newUserName: string) {
+  try {
+    const key = process.env.RESEND_API_KEY;
+    if (!key) return;
+    const svc = createSupabaseServiceClient();
+    const { data: admins } = await svc.from("profiles").select("id").eq("is_admin", true);
+    if (!admins || admins.length === 0) return;
+
+    const emails = (
+      await Promise.all(admins.map((a) => getUserEmail(a.id as string)))
+    ).filter((e): e is string => !!e);
+    if (emails.length === 0) return;
+
+    const { Resend } = await import("resend");
+    const resend = new Resend(key);
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://mixarchitect.com";
+    const { subject, html } = buildAdminEmail({
+      subject: `New signup: ${newUserEmail}`,
+      heading: "New user signed up",
+      body: `${newUserName} (${newUserEmail}) just created a Mix Architect account.`,
+      ctaLabel: "View subscribers",
+      ctaUrl: `${appUrl}/admin/subscribers`,
+    });
+    await resend.emails.send({
+      from: "Mix Architect <team@mixarchitect.com>",
+      to: emails,
+      subject,
+      html,
+    });
+  } catch (err) {
+    console.error("[email/outbox] admin signup alert failed (non-fatal):", err);
+  }
+}

--- a/src/lib/email/service.ts
+++ b/src/lib/email/service.ts
@@ -49,6 +49,13 @@ type SendTransactionalEmailParams = {
   html: string;
 };
 
+export type SendOutcome =
+  | "sent"
+  | "failed"
+  | "skipped_preference"
+  | "skipped_rate_limit"
+  | "not_configured";
+
 /**
  * Send a transactional email with preference checking, rate limiting, and logging.
  * This function never throws. All outcomes are logged to email_log.
@@ -59,7 +66,7 @@ export async function sendTransactionalEmail({
   category,
   subject,
   html,
-}: SendTransactionalEmailParams): Promise<void> {
+}: SendTransactionalEmailParams): Promise<SendOutcome> {
   const supabase = createSupabaseServiceClient();
 
   try {
@@ -85,7 +92,7 @@ export async function sendTransactionalEmail({
           subject,
           status: "skipped_preference",
         });
-        return;
+        return "skipped_preference";
       }
     }
 
@@ -104,14 +111,24 @@ export async function sendTransactionalEmail({
         subject,
         status: "skipped_rate_limit",
       });
-      return;
+      return "skipped_rate_limit";
     }
 
     // 3. Send via Resend
     const resend = getResend();
     if (!resend) {
+      // A missing key must still leave a trail — a silent no-op here is what
+      // hid the broken welcome flow for five days.
       console.warn("[email/service] Resend not configured, skipping email");
-      return;
+      await logEmail(supabase, {
+        userId,
+        to,
+        category,
+        subject,
+        status: "failed",
+        error: "RESEND_API_KEY not configured",
+      });
+      return "not_configured";
     }
 
     // Get unsubscribe token for the List-Unsubscribe header
@@ -149,7 +166,7 @@ export async function sendTransactionalEmail({
         status: "failed",
         error: error.message,
       });
-      return;
+      return "failed";
     }
 
     await logEmail(supabase, {
@@ -160,6 +177,7 @@ export async function sendTransactionalEmail({
       status: "sent",
       resendId: data?.id,
     });
+    return "sent";
   } catch (err) {
     console.error("[email/service] unexpected error:", err);
     await logEmail(supabase, {
@@ -172,6 +190,7 @@ export async function sendTransactionalEmail({
     }).catch(() => {
       // Last-resort: even logging failed, just swallow
     });
+    return "failed";
   }
 }
 

--- a/src/lib/notifications/service.ts
+++ b/src/lib/notifications/service.ts
@@ -16,7 +16,12 @@ export type NotificationType =
   | "collaborator_joined"
   | "export_complete"
   | "spec_mismatch"
-  | "distribution_live";
+  | "distribution_live"
+  | "feature_submission_approved"
+  | "feature_submission_declined"
+  | "clipping_detected"
+  | "loudness_mismatch"
+  | "true_peak_over";
 
 type CreateNotificationParams = {
   userId: string;

--- a/src/lib/perf-reporter.ts
+++ b/src/lib/perf-reporter.ts
@@ -31,7 +31,10 @@ interface QueuedMetric {
 /** Metrics we care about collecting in production. */
 const COLLECTED_METRICS = new Set([
   "wavesurfer:init",
+  // Legacy single-bucket name, kept so older deployed clients still report.
   "waveform:render",
+  "waveform:render:warm",
+  "waveform:render:cold",
   "waveform:seek",
   "waveform:resize",
   "playback:start:warm",

--- a/src/types/attribution.ts
+++ b/src/types/attribution.ts
@@ -1,6 +1,11 @@
-export type AttributionSource = "portal_branding" | "post_action_prompt";
+export type AttributionSource =
+  | "portal_branding"
+  | "post_action_prompt"
+  | "utm"
+  | "organic"
+  | "direct";
 
-export type AttributionPageType = "delivery_portal";
+export type AttributionPageType = "delivery_portal" | "landing";
 
 export type AttributionStatus = "clicked" | "signed_up";
 
@@ -14,4 +19,11 @@ export interface SignupAttribution {
   clicked_at: string;
   signed_up_at: string | null;
   created_at: string;
+  referrer: string | null;
+  landing_page: string | null;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  utm_term: string | null;
+  utm_content: string | null;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/weekly-digest",
       "schedule": "0 14 * * 1"
+    },
+    {
+      "path": "/api/cron/email-outbox",
+      "schedule": "30 * * * *"
     }
   ]
 }

--- a/worker/src/clip.ts
+++ b/worker/src/clip.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+
+/* ------------------------------------------------------------------ */
+/*  Clipped-sample counting                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * A decoded sample counts as clipped at/above this absolute value.
+ *
+ * FFmpeg's int→float conversion divides by 2^(bits-1), so positive full
+ * scale lands just below 1.0 (32767/32768 for 16-bit) while negative full
+ * scale is exactly -1.0. The threshold sits above 16-bit positive rail
+ * minus one code (32766/32768 ≈ 0.999939) so only true rail samples count,
+ * for any integer bit depth. Float sources can legitimately exceed 1.0;
+ * those count too, since they clip on any integer export.
+ */
+const CLIP_THRESHOLD = 0.99995;
+
+const FFMPEG_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Count samples at digital full scale by streaming the file's PCM through
+ * FFmpeg at native sample rate and channel count (no downmix — a single
+ * clipped channel must be visible).
+ *
+ * This replaces the earlier astats "Peak count" parse: that field counts
+ * occurrences of the channel's own min/max, not full scale, so every
+ * non-silent stereo file reported exactly 2 regardless of level.
+ */
+export function countClippedSamples(filePath: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const ff = spawn("ffmpeg", [
+      "-nostats",
+      "-hide_banner",
+      "-i", filePath,
+      "-f", "f32le",
+      "-acodec", "pcm_f32le",
+      "-",
+    ]);
+
+    let clipped = 0;
+    // Bytes carried over when a chunk boundary splits a 4-byte float.
+    let carry = Buffer.alloc(0);
+    let stderr = "";
+    let timedOut = false;
+
+    const killTimer = setTimeout(() => {
+      timedOut = true;
+      ff.kill("SIGKILL");
+    }, FFMPEG_TIMEOUT_MS);
+
+    ff.stdout.on("data", (chunk: Buffer) => {
+      const buf = carry.length > 0 ? Buffer.concat([carry, chunk]) : chunk;
+      const sampleCount = Math.floor(buf.length / 4);
+      for (let i = 0; i < sampleCount; i++) {
+        const v = buf.readFloatLE(i * 4);
+        if (v >= CLIP_THRESHOLD || v <= -CLIP_THRESHOLD) clipped++;
+      }
+      // Copy (not view) the ≤3-byte remainder so the full chunk can be GC'd.
+      carry = Buffer.from(buf.subarray(sampleCount * 4));
+    });
+    ff.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    ff.once("error", (err) => {
+      clearTimeout(killTimer);
+      reject(err);
+    });
+    ff.once("close", (code) => {
+      clearTimeout(killTimer);
+      if (timedOut) {
+        return reject(
+          new Error(`ffmpeg clip scan killed after ${FFMPEG_TIMEOUT_MS}ms`),
+        );
+      }
+      if (code !== 0) {
+        return reject(
+          new Error(
+            `ffmpeg clip scan exited with code ${code}: ${stderr.slice(-512)}`,
+          ),
+        );
+      }
+      resolve(clipped);
+    });
+  });
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -23,10 +23,15 @@ import {
 } from "./converter.js";
 import { analyzeLoudness } from "./loudness.js";
 import { computeWaveformPeaks } from "./peaks.js";
+import { countClippedSamples } from "./clip.js";
 
 /** Current loudness analysis algorithm version. Bump when parser or
- *  FFmpeg filter chain changes in a way that should trigger reanalysis. */
-const LOUDNESS_ANALYSIS_VERSION = 1;
+ *  FFmpeg filter chain changes in a way that should trigger reanalysis.
+ *  v2: clip_sample_count now counted from real PCM (clip.ts) instead of
+ *  astats "Peak count", which pinned at 2 on every stereo file. To
+ *  re-analyze existing rows after deploying, null out their
+ *  analysis_version (the backfill selector keys on IS NULL). */
+const LOUDNESS_ANALYSIS_VERSION = 2;
 
 /**
  * Strip absolute filesystem paths + the tmpdir root from an error
@@ -437,7 +442,7 @@ async function processNextAnalysis() {
     // peaks then run in parallel (both read the same file from
     // different processes; OS page cache makes the second read cheap).
     const info = await probeSource(sourcePath);
-    const [loudness, peaks] = await Promise.all([
+    const [loudness, peaks, clipCount] = await Promise.all([
       analyzeLoudness(sourcePath),
       // Peak generation is best-effort — never fail the whole analysis
       // if it can't be computed (corrupt file, exotic codec, etc.).
@@ -448,6 +453,12 @@ async function processNextAnalysis() {
             return null as number[][] | null;
           })
         : Promise.resolve(null),
+      // Also best-effort: better a null clip count than no analysis at
+      // all. Null (unknown) must never be reported as 0 (clean).
+      countClippedSamples(sourcePath).catch((err) => {
+        console.warn(`  Clip scan failed:`, err.message);
+        return null as number | null;
+      }),
     ]);
     const format = normalizeFormat(info.formatName, info.codecName);
     const lossy = isLossyCodec(info.codecName);
@@ -460,11 +471,15 @@ async function processNextAnalysis() {
       sample_peak_dbfs: loudness.samplePeakDbfs,
       true_peak_dbtp: loudness.truePeakDbtp,
       dc_offset: loudness.dcOffset,
-      clip_sample_count: loudness.clipSampleCount,
+      clip_sample_count: clipCount,
       analysis_version: LOUDNESS_ANALYSIS_VERSION,
       // Clear the claim timestamp now that the row is no longer in
       // an in-progress state, so the reclaim sweep ignores it.
       analysis_started_at: null,
+      // Written on backfill too: legacy rows have peaks but no duration,
+      // and without it wavesurfer waits on loadedmetadata of the full
+      // file before first paint even though the peaks are cached.
+      duration_seconds: info.duration > 0 ? info.duration : null,
     };
 
     // Always populate peaks when computed — even on backfill rows so
@@ -479,7 +494,6 @@ async function processNextAnalysis() {
       update.channels = info.channels;
       update.codec = info.codecName;
       update.file_format = format;
-      update.duration_seconds = info.duration > 0 ? info.duration : null;
       update.spec_analysis_status = "complete";
     }
 
@@ -494,7 +508,7 @@ async function processNextAnalysis() {
       `  Detected: ${format}, ${info.sampleRate}Hz, ${lossy ? "lossy" : `${info.bitDepth}-bit`}, ${info.channels}ch`,
     );
     console.log(
-      `  Loudness: ${fmt(loudness.integratedLufs, "LUFS")}, true peak ${fmt(loudness.truePeakDbtp, "dBTP")}, ${loudness.clipSampleCount ?? "?"} clipped`,
+      `  Loudness: ${fmt(loudness.integratedLufs, "LUFS")}, true peak ${fmt(loudness.truePeakDbtp, "dBTP")}, ${clipCount ?? "?"} clipped`,
     );
     console.log(
       `  Peaks: ${peaks ? `${peaks[0]?.length ?? 0} buckets cached` : "skipped"}`,

--- a/worker/src/loudness.test.ts
+++ b/worker/src/loudness.test.ts
@@ -98,11 +98,6 @@ test("parses astats DC offset from Overall block (not per-channel)", () => {
   assertEq(result.dcOffset, 0.00001, "dcOffset");
 });
 
-test("parses astats Peak count from Overall block", () => {
-  const result = parseLoudnessOutput(CANONICAL_OUTPUT);
-  assertEq(result.clipSampleCount, 1247, "clipSampleCount");
-});
-
 test("returns null for silence (-inf LUFS)", () => {
   const silent = `
 [Parsed_ebur128_0 @ 0x0] Summary:
@@ -170,7 +165,6 @@ test("handles missing astats (returns null, not throw)", () => {
   const result = parseLoudnessOutput(ebur128Only);
   assertEq(result.integratedLufs, -14, "integratedLufs still parses");
   assertEq(result.dcOffset, null, "dcOffset null when astats missing");
-  assertEq(result.clipSampleCount, null, "clipSampleCount null when astats missing");
 });
 
 /* ------------------------------------------------------------------ */

--- a/worker/src/loudness.ts
+++ b/worker/src/loudness.ts
@@ -18,8 +18,6 @@ export type LoudnessResult = {
   truePeakDbtp: number | null;
   /** DC offset as a fraction of full scale (abs value across channels). */
   dcOffset: number | null;
-  /** Number of samples at exactly ±full-scale (strict digital clipping). */
-  clipSampleCount: number | null;
 };
 
 /* ------------------------------------------------------------------ */
@@ -75,7 +73,6 @@ export function parseLoudnessOutput(stderr: string): LoudnessResult {
     samplePeakDbfs: extractEbur128("Sample peak", "Peak", "dBFS", stderr),
     truePeakDbtp: extractEbur128("True peak", "Peak", "dBFS", stderr),
     dcOffset: extractAstatsOverallAbsDcOffset(stderr),
-    clipSampleCount: extractAstatsOverallPeakCount(stderr),
   };
 }
 
@@ -131,16 +128,10 @@ function extractAstatsOverallAbsDcOffset(stderr: string): number | null {
   return Math.abs(value);
 }
 
-function extractAstatsOverallPeakCount(stderr: string): number | null {
-  const block = getAstatsOverallBlock(stderr);
-  if (!block) return null;
-  // Peak count is the number of samples at exactly ±full-scale.
-  // Format: "Peak count: 0" or "Peak count: 1247"
-  const match = block.match(/Peak count:\s+(\d+)/);
-  if (!match) return null;
-  const value = parseInt(match[1], 10);
-  return Number.isFinite(value) ? value : null;
-}
+// Clipped-sample counting used to parse astats "Peak count" here, but that
+// field counts occurrences of the channel's OWN min/max (not full scale),
+// so every non-silent stereo file reported exactly 2. Real counting now
+// lives in clip.ts, on actual PCM.
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */


### PR DESCRIPTION
## Summary

App and worker side of the first-organic-user postmortem fixes. The DB side is migrations 083–086 (#86), **already applied to production** — this PR is what makes the fixes active.

### Welcome email (P0-1)
- New server-side `POST /api/auth/signup` (same-origin + rate-limited): performs `signUp`, logs the signup activity, records attribution, and drains the user's `email_outbox` **before responding** — closing the tab can no longer skip the send. The sign-in page's signup branch posts here instead of calling `supabase.auth.signUp` client-side.
- `src/lib/email/outbox.ts` drains outbox rows with conditional-update claims (no double-sends across concurrent drains), retries transient failures up to 3 attempts, and fires the admin signup alert on the first attempt.
- Drains also run from `/auth/callback` (covers email-confirmation and OAuth signups), from log-activity signup/login events, and from a new hourly cron `/api/cron/email-outbox` as a safety net.
- `sendTransactionalEmail` returns its outcome and writes a `failed` `email_log` row when `RESEND_API_KEY` is missing — the silent no-op that hid this bug for five days is gone.

### Clip detector (P1-2)
- Root cause: `clip_sample_count` was FFmpeg astats' "Peak count", which counts occurrences of the channel's **own** min/max, not full scale — every stereo file read exactly 2 regardless of level, so the clipping UI flag was dead code. `worker/src/clip.ts` now streams native-rate PCM and counts samples at the digital rail.
- `LOUDNESS_ANALYSIS_VERSION` → 2. Backfill analyses now also write `duration_seconds` (legacy rows with cached peaks stop stalling on `loadedmetadata`).

### Quality alerts (P1-1) + waveform metrics (P1-3) + attribution (P2-4)
- Bell icons and `NotificationType` entries for `clipping_detected` / `loudness_mismatch` / `true_peak_over`.
- `waveform:render` split into `:warm` / `:cold` so network-bound first renders stop hiding inside one p50; the load-error retry passes cached peaks + duration instead of refetching the full 47 MB WAV.
- `AttributionCapture` sets a 30-day first-touch cookie; `recordSignupAttribution` writes `signup_attributions` rows with `utm` / `organic` / `direct` sources.

## Verified
- End-to-end throwaway signup against prod: outbox `sent`, one `email_log` row addressed to the signup's own address, prefs + attribution + activity rows all present **before any confirmation click**; welcome email delivered. Test user deleted.
- UTM cookie capture verified in-browser; `tsc`, `eslint` (changed files), and the worker build/tests are clean.

## After merge
1. Deploy the worker, then re-analyze existing files:
   ```sql
   update track_audio_versions set analysis_version = null where analysis_version <= 1;
   ```
2. The new cron is hourly — requires Vercel Pro (Hobby is daily-only with a 2-cron cap). If on Hobby, fold the drain into the daily cron instead.
3. `CRON_SECRET` must be set (it already is for the existing crons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)