### PR TITLE
Worker: stream source-audio downloads with stall guard + progress logs

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -61,10 +61,16 @@ const TEMP_DIR = path.join(os.tmpdir(), "mix-architect-worker");
 /**
  * After this many minutes, a row stuck in 'processing'/'analyzing'/0
  * is presumed crashed and reset to its pending state so another
- * worker iteration can pick it up. Long enough that genuinely slow
- * FFmpeg jobs (5min timeout in convertAudio) finish before reclaim.
+ * worker iteration can pick it up. Must comfortably exceed the worst
+ * legitimate job: a 121 MB WAV download alone has taken ~15 min on
+ * Railway, plus FFmpeg conversion (5 min timeout in convertAudio) —
+ * 15 min nearly double-claimed a live job. A truly hung download no
+ * longer needs a tight window anyway: downloadSourceAudio aborts
+ * itself after 60s without bytes, which lands the row back in the
+ * normal failure/retry path. This sweep only covers hard crashes
+ * (SIGTERM, OOM, redeploy), where a slower retry is acceptable.
  */
-const STUCK_JOB_RECLAIM_MINUTES = 15;
+const STUCK_JOB_RECLAIM_MINUTES = 30;
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */

--- a/worker/src/storage.ts
+++ b/worker/src/storage.ts
@@ -1,5 +1,9 @@
 import { createClient } from "@supabase/supabase-js";
 import fs from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { ReadableStream as WebReadableStream } from "node:stream/web";
 import path from "node:path";
 
 /* ------------------------------------------------------------------ */
@@ -26,12 +30,20 @@ function extractStoragePath(urlOrPath: string): string {
 }
 
 /**
- * Hard ceiling on the size of an audio source the worker will buffer
- * into memory. Mirrors the cover-art bucket cap from migration 058
- * (600 MB) with headroom for re-encoded versions. Beyond this the
- * worker would OOM trying to `arrayBuffer()` the whole file.
+ * Hard ceiling on the size of an audio source the worker will write
+ * to disk. Mirrors the track-audio bucket cap from migration 058
+ * (600 MB) with headroom for re-encoded versions, as a defense
+ * against bucket-cap drift. Enforced incrementally as bytes arrive.
  */
 const MAX_AUDIO_BYTES = 700 * 1024 * 1024;
+
+/**
+ * Abort a download only if NO bytes arrive for this long. Large WAVs
+ * (100 MB+) legitimately take 10+ minutes on slow storage links, so
+ * there is deliberately no overall timeout — a transfer that keeps
+ * trickling bytes is alive, one that goes silent for a minute is not.
+ */
+const DOWNLOAD_STALL_TIMEOUT_MS = 60_000;
 
 export async function downloadSourceAudio(
   audioUrlOrPath: string,
@@ -45,32 +57,97 @@ export async function downloadSourceAudio(
 
   const storagePath = extractStoragePath(audioUrlOrPath);
 
-  // Download via service role (works for both public and private buckets).
-  // We rely on the bucket's file_size_limit (600 MB, set in migration 058)
-  // to reject oversize uploads server-side before they ever reach storage.
-  // The post-download buffer.length check below is a cheap defense against
-  // bucket-cap drift. The previous version also called .info() pre-download
-  // for a HEAD-style size check, but that endpoint was slow/hanging in
-  // practice and made every analysis run take minutes. The bucket cap +
-  // post-download buffer check covers the same threat with no extra round
-  // trip.
-  const { data, error } = await supabase.storage
-    .from("track-audio")
-    .download(storagePath);
+  // Streamed download straight to disk via the storage object endpoint
+  // with service-role auth (works for both public and private buckets).
+  // supabase-js's .download() buffers the entire body in memory and
+  // gives no progress signal — a 121 MB WAV once took ~10 minutes with
+  // zero log output and nearly got the row reclaimed as stuck. Streaming
+  // keeps memory flat and lets the stall guard distinguish "slow but
+  // alive" from "hung".
+  const objectUrl = `${supabaseUrl}/storage/v1/object/track-audio/${storagePath
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/")}`;
 
-  if (error || !data) {
-    throw new Error(`Download failed for ${storagePath}: ${error?.message ?? "no data"}`);
-  }
+  const controller = new AbortController();
+  let stallTimer: NodeJS.Timeout | undefined;
+  let stalledAtBytes: number | null = null;
+  let received = 0;
 
-  const buffer = Buffer.from(await data.arrayBuffer());
+  const armStallGuard = () => {
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => {
+      stalledAtBytes = received;
+      controller.abort();
+    }, DOWNLOAD_STALL_TIMEOUT_MS);
+  };
 
-  if (buffer.length > MAX_AUDIO_BYTES) {
-    throw new Error(
-      `Source audio too large (${buffer.length} bytes > ${MAX_AUDIO_BYTES} cap): ${storagePath}`,
+  const startedAt = Date.now();
+  console.log(`[storage] ⬇ download start: ${storagePath}`);
+
+  try {
+    armStallGuard();
+    const response = await fetch(objectUrl, {
+      headers: {
+        Authorization: `Bearer ${supabaseServiceKey}`,
+        apikey: supabaseServiceKey,
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok || !response.body) {
+      await response.body?.cancel().catch(() => {});
+      throw new Error(
+        `Download failed for ${storagePath}: HTTP ${response.status}`,
+      );
+    }
+
+    const declaredLen = Number(response.headers.get("content-length") ?? 0);
+    if (declaredLen > 0) {
+      console.log(`[storage]   size: ${formatMb(declaredLen)} MB`);
+      if (declaredLen > MAX_AUDIO_BYTES) {
+        await response.body.cancel().catch(() => {});
+        throw new Error(
+          `Source audio too large (${declaredLen} bytes > ${MAX_AUDIO_BYTES} cap): ${storagePath}`,
+        );
+      }
+    }
+
+    await pipeline(
+      Readable.fromWeb(response.body as WebReadableStream),
+      async function* (source: AsyncIterable<Buffer>) {
+        for await (const chunk of source) {
+          armStallGuard();
+          received += chunk.length;
+          if (received > MAX_AUDIO_BYTES) {
+            throw new Error(
+              `Source audio too large (${received}+ bytes > ${MAX_AUDIO_BYTES} cap): ${storagePath}`,
+            );
+          }
+          yield chunk;
+        }
+      },
+      createWriteStream(resolved),
     );
+  } catch (err) {
+    if (stalledAtBytes !== null) {
+      throw new Error(
+        `Download stalled for ${storagePath}: no bytes for ${DOWNLOAD_STALL_TIMEOUT_MS / 1000}s after ${formatMb(stalledAtBytes)} MB`,
+      );
+    }
+    throw err;
+  } finally {
+    if (stallTimer) clearTimeout(stallTimer);
   }
 
-  await fs.writeFile(resolved, buffer);
+  const seconds = (Date.now() - startedAt) / 1000;
+  console.log(
+    `[storage] ✔ download complete: ${storagePath} — ${formatMb(received)} MB in ${seconds.toFixed(1)}s (${formatMb(received / Math.max(seconds, 0.001))} MB/s)`,
+  );
+}
+
+function formatMb(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(1);
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Problem

`downloadSourceAudio()` used supabase-js `.download()`, which buffers the entire body in memory with no progress signal and no timeout. Observed 2026-08-09 on Railway: a 121 MB WAV took ~8-15 minutes to download, during which the single-threaded polling loop produced zero log output and looked hung — the 15-minute reclaim sweep nearly double-claimed a row that was actually progressing.

## Changes

**`worker/src/storage.ts`** — streamed download:
- Fetches the storage object endpoint directly with service-role auth headers and pipes the body straight to disk (`stream/promises.pipeline`), keeping memory flat instead of buffering whole WAVs.
- Logs `⬇ download start` (with content-length when available) and `✔ download complete` with MB / seconds / MB/s, so slow storage is visible in Railway logs.
- **Stall guard instead of a hard timeout**: aborts only when no bytes arrive for 60s (timer re-arms per chunk; also covers "headers never arrive"). Slow-but-alive transfers of large files are untouched. On stall it throws, landing in the existing failure paths in `worker/src/index.ts` that reset the row for retry.
- `MAX_AUDIO_BYTES` (700 MB) now enforced incrementally as bytes arrive, plus an early bail on an oversize `content-length`.

**`worker/src/index.ts`** — `STUCK_JOB_RECLAIM_MINUTES` 15 → 30. Download alone can approach the old window and double-claim a live job. The stall guard makes the wider window safe: hung downloads self-abort in 60s via the normal failure path, so the sweep only needs to catch hard crashes (SIGTERM / OOM / redeploy).

## Verification

- `tsc --noEmit` clean.
- Smoke-tested against a local HTTP server standing in for Supabase storage: happy path (5 MB streamed to disk, size verified, both log lines emitted), HTTP 404 throws, oversize content-length rejected before streaming, and a mid-transfer stall aborted at exactly 60.0s with a clear error.
- Confirmed the per-segment URL encoding matches how `audio_url` paths are stored (bare `userId/trackId/vN.ext`, nothing pre-encoded), so no existing row can double-encode.

Worker-only change; Railway auto-deploys the worker from `main` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)