### PR TITLE
Bump undici 7.28.0 → 7.29.0 (transitive, lockfile only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11170,9 +11170,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"


### PR DESCRIPTION
Clears the Aikido alert for 5 undici CVEs (worst: CVE-2026-13697, shared-cache poisoning in the cache interceptor; also CVE-2026-14643, CVE-2026-16729, CVE-2026-16728, CVE-2026-15157).

**Reachability**: effectively none in this codebase. undici is not a direct dependency — it arrives only via `isomorphic-dompurify → jsdom ^29.1.1 → undici ^7.25.0`, and jsdom is used purely as a headless DOM for DOMPurify SVG sanitization in the workspace-logo upload route. No code path exercises undici's cache interceptor, retry interceptor, `setCookie`, or blob-like request bodies. App/worker fetch calls use Node's bundled undici, not this npm copy; the worker lockfile contains no undici package at all.

**Change**: lockfile-only — version/resolved/integrity for `node_modules/undici`, 7.29.0 satisfies jsdom's `^7.25.0` range so nothing else moves. (Ran `npm update undici --package-lock-only`, then kept only the undici hunk; the rest was npm-version lockfile normalization noise.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)