### PR TITLE
Geo-aware locale detection with browser language priority

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -14,11 +14,62 @@ function getMessageFile(locale: string): string {
   return localeToFile[locale] || locale.split("-")[0];
 }
 
+// Map an ISO 3166-1 alpha-2 country (from Vercel's x-vercel-ip-country
+// geo header) to a supported locale. Only countries with one clear
+// dominant supported language are listed; multilingual countries
+// (e.g. BE, CH, SG) are intentionally absent so the browser's
+// Accept-Language decides instead of a coin-flip on region.
+const countryToLocale: Record<string, Locale> = {
+  US: "en-US",
+  GB: "en-GB",
+  CA: "en-CA",
+  AU: "en-AU",
+  NZ: "en-AU",
+  IE: "en-IE",
+  NG: "en-NG",
+  DE: "de-DE",
+  AT: "de-DE",
+  FR: "fr-FR",
+  ES: "es-ES",
+  MX: "es-MX",
+  AR: "es-MX",
+  CO: "es-MX",
+  CL: "es-MX",
+  PE: "es-MX",
+  VE: "es-MX",
+  EC: "es-MX",
+  GT: "es-MX",
+  BO: "es-MX",
+  DO: "es-MX",
+  HN: "es-MX",
+  PY: "es-MX",
+  SV: "es-MX",
+  NI: "es-MX",
+  CR: "es-MX",
+  PA: "es-MX",
+  UY: "es-MX",
+  BR: "pt-BR",
+  PT: "pt-BR",
+  SE: "sv-SE",
+  IN: "hi-IN",
+  JP: "ja-JP",
+  KR: "ko-KR",
+  CN: "zh-CN",
+};
+
 /**
  * Match an Accept-Language header against supported locales.
  * Tries exact match first (e.g., pt-BR), then language prefix (e.g., fr → fr-FR).
+ * `geoLocale` (from the visitor's country) refines prefix matches: a bare
+ * "en" from Canada resolves to en-CA rather than en-US, but an explicit
+ * regional tag like en-GB is respected regardless of location. When the
+ * header matches no supported language at all, falls back to the geo
+ * locale, then the default.
  */
-function detectLocaleFromHeader(acceptLanguage: string): Locale {
+function detectLocaleFromHeader(
+  acceptLanguage: string,
+  geoLocale: Locale | undefined,
+): Locale {
   // Parse Accept-Language into sorted preference list
   const preferred = acceptLanguage
     .split(",")
@@ -33,24 +84,40 @@ function detectLocaleFromHeader(acceptLanguage: string): Locale {
     const exact = locales.find((l) => l.toLowerCase() === tag.toLowerCase());
     if (exact) return exact;
 
-    // Language prefix match (e.g., fr → fr-FR, es → es-ES)
+    // Language prefix match (e.g., fr → fr-FR, es → es-ES), preferring the
+    // visitor's regional variant when it speaks the same language
     const lang = tag.split("-")[0].toLowerCase();
+    if (geoLocale && geoLocale.split("-")[0].toLowerCase() === lang) {
+      return geoLocale;
+    }
     const prefix = locales.find((l) => l.split("-")[0].toLowerCase() === lang);
     if (prefix) return prefix;
   }
 
-  return defaultLocale;
+  return geoLocale ?? defaultLocale;
 }
 
 export default getRequestConfig(async () => {
   const cookieStore = await cookies();
-  let locale = cookieStore.get("NEXT_LOCALE")?.value;
+  const cookieLocale = cookieStore.get("NEXT_LOCALE")?.value;
+  // Ignore unknown cookie values so a stale/hand-edited cookie can't
+  // point getMessageFile at a message file that doesn't exist
+  let locale: string | undefined = locales.includes(cookieLocale as Locale)
+    ? cookieLocale
+    : undefined;
 
-  // Auto-detect from browser Accept-Language when no cookie is set
+  // No explicit choice: browser Accept-Language decides the language,
+  // with the geo country (Vercel sets x-vercel-ip-country in prod;
+  // absent in local dev) refining the regional variant and serving as
+  // the fallback when the browser language is unsupported or missing
   if (!locale) {
     const headerStore = await headers();
+    const country = headerStore.get("x-vercel-ip-country")?.toUpperCase();
+    const geoLocale = country ? countryToLocale[country] : undefined;
     const acceptLanguage = headerStore.get("accept-language");
-    locale = acceptLanguage ? detectLocaleFromHeader(acceptLanguage) : defaultLocale;
+    locale = acceptLanguage
+      ? detectLocaleFromHeader(acceptLanguage, geoLocale)
+      : geoLocale ?? defaultLocale;
   }
 
   const messageFile = getMessageFile(locale);


### PR DESCRIPTION
## What

Visitors now get the landing page (and all localized pages) in a language matching their location, without overriding their browser's language preference. Locale resolution order in `src/i18n/request.ts`:

1. **`NEXT_LOCALE` cookie** — explicit language-switcher choice always wins. Unknown cookie values are now ignored instead of crashing the message-file import.
2. **Browser `Accept-Language`** — decides the language. The visitor's country (Vercel's `x-vercel-ip-country` header) refines bare language tags to the regional variant: `en` from Canada resolves to `en-CA` (CAD pricing), `es` from Argentina to `es-MX` — while an explicit `en-GB` browser stays `en-GB` anywhere.
3. **Geo country** — fallback when the browser sends no `Accept-Language` or an unsupported language (Italian-language browser visiting from Germany gets German).
4. **`en-US`** default.

Only countries with one clear dominant supported language are mapped; multilingual countries (BE, CH, SG, TW/HK) are intentionally unmapped so the browser language decides.

## Notes

- No middleware or caching changes: the request config already read cookies/headers, so rendering dynamics are unchanged. Local dev has no geo header and behaves as before.
- Verified locally via curl with simulated `x-vercel-ip-country` / `Accept-Language` / cookie combinations (8 precedence cases inc. cookie override, geo refinement, and unsupported-language fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)