### PR TITLE
Migrate src/middleware.ts to src/proxy.ts (Next.js 16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ A public unauthenticated read should use the anon client + RLS policies, not the
 
 ## Auth & access control
 
-- Middleware (`src/middleware.ts`) gates `/app/**` and sets the CSP.
+- The proxy (`src/proxy.ts`, Next.js 16's rename of middleware) gates `/app/**` and sets the CSP.
 - `/admin/**` gates via `requireAdmin()` in `src/app/admin/layout.tsx`.
 - API routes that mutate state (admin POSTs, etc.) MUST use `requireSameOrigin(req)` from `src/lib/origin-check.ts`.
 - Sensitive admin POSTs also rate-limit via `rateLimit(...)` from `src/lib/rate-limit.ts`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ src/
   actions/            Server actions ("use server")
   components/         UI components (kebab-case files; PascalCase exports)
   lib/                Utilities, Supabase clients, integrations
-  middleware.ts       CSP + auth gate for /app/*
+  proxy.ts            CSP + auth gate for /app/*
 worker/               Standalone Node audio worker (Docker)
   src/
     index.ts          Polling loop: conversion + analysis

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,8 +3,8 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
-// Content Security Policy is now set dynamically in middleware with per-request
-// nonces. See src/middleware.ts for the policy definition.
+// Content Security Policy is set dynamically in the proxy. See src/proxy.ts
+// for the policy definition.
 
 const nextConfig: NextConfig = {
   poweredByHeader: false,

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -16,7 +16,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
     error,
   } = await supabase.auth.getUser();
 
-  // Defense-in-depth: middleware should catch this, but guard here too
+  // Defense-in-depth: the proxy should catch this, but guard here too
   if (error || !user) {
     redirect("/auth/sign-in");
   }
@@ -125,7 +125,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
               .eq("id", user.id)
           : Promise.resolve(),
       ]);
-      // Cookie will be cleared on next response via middleware or naturally expires
+      // Cookie will be cleared on next response via the proxy or naturally expires
     } catch {
       // Non-fatal: attribution failure should never block app load
     }

--- a/src/components/theme-wrapper.tsx
+++ b/src/components/theme-wrapper.tsx
@@ -2,7 +2,7 @@ import { headers } from "next/headers";
 import { ThemeProvider } from "@/lib/theme-provider";
 
 /**
- * Async Server Component that reads the CSP nonce from middleware
+ * Async Server Component that reads the CSP nonce from the proxy
  * and passes it to the client-side ThemeProvider.
  *
  * Awaiting headers() here opts every route into dynamic rendering (the

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -52,7 +52,7 @@ function buildCsp(): string {
   ].join("; ");
 }
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const response = NextResponse.next({ request });
 
   // Expose pathname so server components (e.g. app layout) can read it


### PR DESCRIPTION
## Summary

Next.js 16 deprecates the `middleware` file convention ("The \"middleware\" file convention is deprecated. Please use \"proxy\" instead" on every build). This PR runs the official codemod (`npx @next/codemod@latest middleware-to-proxy`) to migrate:

- `src/middleware.ts` → `src/proxy.ts`, exported function renamed `middleware` → `proxy` (git shows a 98% rename — only the function name changed)
- CSP header logic, `x-next-pathname` header, Supabase auth gate on `/app/**`, and the `matcher` config are all unchanged
- Updated stale "middleware" references: `CLAUDE.md` (auth section now points at `src/proxy.ts`), `README.md` project-structure listing, `next.config.ts` comment (also dropped the outdated per-request-nonce claim), and comments in `src/app/app/layout.tsx` / `src/components/theme-wrapper.tsx`

## Verification

- `npx next build` passes with TypeScript clean
- The deprecation warning no longer appears in the build output
- The route table footer reports the layer as `ƒ Proxy (Middleware)` — the only remaining "middleware" string in the build output, which is Next.js's own label

🤖 Generated with [Claude Code](https://claude.com/claude-code)