### PR TITLE
Rail pill inset, full-width player bar, fix dead synopsis model

### DIFF
--- a/src/app/api/admin/analytics/synopsis/route.ts
+++ b/src/app/api/admin/analytics/synopsis/route.ts
@@ -134,15 +134,18 @@ export async function GET(req: NextRequest) {
     // Fetch GA4 data
     const data = await getAllGA4TrafficData(range);
 
-    // Generate synopsis with Claude
+    // Generate synopsis with Claude. claude-sonnet-4-20250514 was retired
+    // 2026-06-15 and began returning 404, which is why the synopsis card
+    // showed "Unable to generate synopsis" on every load.
     const anthropic = new Anthropic({ apiKey });
     const message = await anthropic.messages.create({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 500,
+      model: "claude-opus-5",
+      max_tokens: 1000,
       messages: [{ role: "user", content: buildPrompt(data, range) }],
     });
 
-    const synopsis = message.content[0].type === "text" ? message.content[0].text : "";
+    const textBlock = message.content.find((b) => b.type === "text");
+    const synopsis = textBlock && textBlock.type === "text" ? textBlock.text : "";
 
     // Cache the result
     setCachedSynopsis(range, synopsis);

--- a/src/components/ui/mini-player.tsx
+++ b/src/components/ui/mini-player.tsx
@@ -37,7 +37,9 @@ export function MiniPlayer() {
   const trackUrl = `/app/releases/${trackMeta.releaseId}/tracks/${trackMeta.trackId}`;
 
   return (
-    <div className="fixed bottom-16 md:bottom-0 left-0 right-0 md:left-16 z-40 bg-panel border-t border-border shadow-lg safe-bottom">
+    // Full viewport width: z-40 sits above the rail (z-20), so the bar runs
+    // edge to edge instead of starting at a stale rail-width offset.
+    <div className="fixed bottom-16 md:bottom-0 left-0 right-0 z-40 bg-panel border-t border-border shadow-lg safe-bottom">
       {/* Thin progress bar at top edge */}
       <div className="h-0.5 bg-border">
         <div

--- a/src/components/ui/rail.tsx
+++ b/src/components/ui/rail.tsx
@@ -42,7 +42,10 @@ export function Rail() {
         // without hovering.
         "w-14 hover:w-48 xl:w-48 overflow-hidden",
         "bg-panel border-r border-border",
-        "flex-col py-3 gap-1",
+        // Horizontal padding insets the rounded active pill from the rail
+        // edges (matching the admin sidebar) instead of letting its corners
+        // collide with the container border.
+        "flex-col py-3 px-2 gap-1",
         "transition-[width] duration-200 ease-out",
       )}
       style={{ height: "calc(100dvh - 3.5rem)" }}
@@ -102,7 +105,9 @@ function NavItem({
       <Link
         href={href}
         className={cn(
-          "flex items-center gap-3 w-full px-4 h-10 rounded-md",
+          // px-2 here + px-2 on the nav keeps the icon centered in the 56px
+          // collapsed rail (8 + 8 + 12 = 28px, the rail's midline).
+          "flex items-center gap-3 w-full px-2 h-10 rounded-md",
           "text-muted transition-all duration-150",
           "hover:text-text hover:bg-panel2",
           "focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-signal-muted",


### PR DESCRIPTION
Three follow-ups from production review:

1. **Rail active pill** collided its rounded corners with the container edges (the restored 14px radius made it obvious). The nav now insets items with px-2, matching the admin sidebar's contained look; icon centering in the collapsed 56px rail is preserved (8+8+12 = 28px midline).
2. **Mini player bar** started at a stale `md:left-16` offset from the old rail width and read as cut off on the left. It now spans the full viewport width (z-40, above the rail), consistent with the portal player.
3. **Admin traffic AI synopsis** was dead: the route called `claude-sonnet-4-20250514`, which retired 2026-06-15 and returns 404, so the card always showed "Unable to generate synopsis". Swapped to `claude-opus-5`, raised max_tokens for its longer default responses, and the text block is now located by type rather than assuming `content[0]`.

Verified locally: rail + player via dev server screenshots. The synopsis can't run locally (no ANTHROPIC_API_KEY/GA4 creds in dev) - verify in prod with the card's Regenerate button after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)