### PR TITLE
Raise Claude review max-turns to 40 (turn-cap false negative on PR #95)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -62,9 +62,10 @@ jobs:
             One summary comment for cross-cutting concerns. Skip nitpicks
             (formatting, debatable style) — focus on what could break in
             production or hurt paying customers.
-          # 15 turns: 10 wasn't enough when a PR touches a long file
-          # (settings/page.tsx is ~1700 lines) — Claude exhausted the
-          # budget reading surrounding context before producing the
-          # summary and returned error_max_turns. Per-PR cost rises
-          # to roughly $0.20–$0.60, still bounded.
-          claude_args: "--max-turns 15 --model claude-sonnet-4-6"
+          # 40 turns: a runaway guard, not a routine budget. At 15 the
+          # action failed the required check on PR #95 even though the
+          # review finished ("successful result after 17 turns") — the
+          # cap must sit well above what a large PR legitimately needs.
+          # Don't "fix" overruns with continue-on-error: that would let
+          # the required check pass when the review genuinely fails.
+          claude_args: "--max-turns 40 --model claude-sonnet-4-6"


### PR DESCRIPTION
## Summary
The Claude Code Review required check failed on PR #95 with **"Claude reported a successful result after 17 turns, exceeding the configured maximum of 15"** — the review completed fine, but the turn cap turned it into a failing required check and blocked the merge.

- Raise `--max-turns` from 15 to 40 so the cap works as a runaway guard instead of a routine budget large PRs can trip over.
- Deliberately **not** adding `continue-on-error`: that would make the required check pass even when the review genuinely fails, defeating branch protection. Keeping the hard-fail with generous headroom preserves the guard while eliminating the false negative.

## Verification
For `pull_request` events the workflow definition comes from the PR's merge commit, so this PR's own Claude Code Review run exercises the new 40-turn cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)