### PR TITLE
Site Traffic report export with AI summary

### DIFF
--- a/src/app/admin/traffic/page.tsx
+++ b/src/app/admin/traffic/page.tsx
@@ -21,6 +21,7 @@ import {
   LogIn,
   BarChart3,
   MonitorSmartphone,
+  Download,
 } from "lucide-react";
 import type { TrafficData, OverviewMetrics, BreakdownEntry } from "@/lib/openpanel-api";
 import { AISynopsis } from "@/components/admin/traffic/AISynopsis";
@@ -179,6 +180,26 @@ export default function SiteTrafficPage() {
           >
             <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
           </button>
+
+          {/* Export report (Markdown with the AI summary) */}
+          <a
+            href={(() => {
+              const params = new URLSearchParams();
+              if (!rawFrom && !rawTo && rawRange) {
+                params.set("range", rawRange);
+              } else {
+                params.set("from", formatDateISO(periodFrom));
+                params.set("to", formatDateISO(periodTo));
+              }
+              return `/api/admin/analytics/export?${params.toString()}`;
+            })()}
+            download
+            className="p-2 rounded-md border border-border text-muted hover:text-text hover:bg-panel2 transition-colors"
+            aria-label="Export analytics report"
+            title="Export report (includes the AI summary)"
+          >
+            <Download size={14} />
+          </a>
         </div>
       </div>
 

--- a/src/app/api/admin/analytics/export/route.ts
+++ b/src/app/api/admin/analytics/export/route.ts
@@ -1,0 +1,198 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
+import { isAdmin } from "@/lib/admin";
+import { rateLimit, getClientIp } from "@/lib/rate-limit";
+import { getAllGA4TrafficData, type GA4FullPayload } from "@/lib/ga4-api";
+import {
+  getCachedTrafficSynopsis,
+  generateTrafficSynopsis,
+  RANGE_LABELS,
+} from "@/lib/traffic-synopsis";
+
+function mdTable(headers: string[], rows: (string | number)[][]): string {
+  if (rows.length === 0) return "_No data for this period._\n";
+  return [
+    `| ${headers.join(" | ")} |`,
+    `| ${headers.map(() => "---").join(" | ")} |`,
+    ...rows.map((r) => `| ${r.join(" | ")} |`),
+  ].join("\n");
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+function buildReport(
+  data: GA4FullPayload,
+  rangeLabel: string,
+  synopsis: string | null,
+): string {
+  const o = data.overview;
+  const generatedAt = new Date().toISOString().replace("T", " ").slice(0, 16);
+
+  const sections: string[] = [
+    `# Mix Architect: Site Traffic Report`,
+    ``,
+    `**Period:** ${rangeLabel}`,
+    `**Generated:** ${generatedAt} UTC`,
+    ``,
+    `## AI Summary`,
+    ``,
+    synopsis ??
+      `_The AI summary could not be generated for this export. The traffic data below is complete._`,
+    ``,
+    `## Overview`,
+    ``,
+    mdTable(
+      ["Metric", "Value"],
+      [
+        ["Visitors", o.visitors],
+        ["New users", o.new_users ?? 0],
+        ["Returning users", o.returning_users ?? 0],
+        ["Pageviews", o.pageviews],
+        ["Sessions", o.sessions],
+        ["Engagement rate", `${o.engagement_rate ?? 0}%`],
+        ["Bounce rate", `${o.bounce_rate}%`],
+        ["Avg session duration", formatDuration(o.session_duration)],
+        ["Pages per session", o.views_per_session],
+        ["Active right now", o.current_visitors],
+      ],
+    ),
+    ``,
+    `## Channels`,
+    ``,
+    mdTable(
+      ["Channel", "Sessions"],
+      data.channels.map((c) => [c.name, c.count]),
+    ),
+    ``,
+    `## Top Pages`,
+    ``,
+    mdTable(
+      ["Page", "Views"],
+      data.topPages.map((p) => [p.name, p.count]),
+    ),
+    ``,
+    `## Landing Pages`,
+    ``,
+    mdTable(
+      ["Page", "Sessions"],
+      data.landingPages.map((p) => [p.name, p.count]),
+    ),
+    ``,
+    `## Referrers`,
+    ``,
+    mdTable(
+      ["Source", "Sessions"],
+      data.referrers.map((r) => [r.name, r.count]),
+    ),
+    ``,
+    `## Countries`,
+    ``,
+    mdTable(
+      ["Country", "Sessions"],
+      data.countries.map((c) => [c.name, c.count]),
+    ),
+    ``,
+    `## Custom Events`,
+    ``,
+    mdTable(
+      ["Event", "Count"],
+      Object.entries(data.events).map(([name, count]) => [name, count]),
+    ),
+    ``,
+    `## Devices and Browsers`,
+    ``,
+    mdTable(
+      ["Device", "Sessions"],
+      data.devices.map((d) => [d.name, d.count]),
+    ),
+    ``,
+    mdTable(
+      ["Browser", "Sessions"],
+      data.browsers.map((b) => [b.name, b.count]),
+    ),
+    ``,
+  ];
+
+  return sections.join("\n");
+}
+
+/**
+ * GET /api/admin/analytics/export?range=7d
+ * GET /api/admin/analytics/export?from=2026-08-01&to=2026-08-09
+ *
+ * Downloads a Markdown site-traffic report for the requested period,
+ * led by the AI summary (reusing the synopsis cache when warm). If the
+ * summary cannot be generated, the report still exports with a note in
+ * its place - the data tables never depend on the model call.
+ */
+export async function GET(req: NextRequest) {
+  const ip = getClientIp(req);
+  const { success } = rateLimit(`admin-analytics-export:${ip}`, 5, 60_000);
+  if (!success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user || !(await isAdmin(user.id))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const from = req.nextUrl.searchParams.get("from");
+  const to = req.nextUrl.searchParams.get("to");
+  const range = req.nextUrl.searchParams.get("range");
+
+  // Preset range key when given (matches the synopsis cache key); custom
+  // ranges query GA4 by explicit dates and cache under "from_to".
+  const rangeInput = range ?? (from && to ? { start: from, end: to } : "7d");
+  const cacheKey = range ?? (from && to ? `${from}_${to}` : "7d");
+  const rangeLabel = range
+    ? (RANGE_LABELS[range] ?? range)
+    : from && to
+      ? `${from} to ${to}`
+      : RANGE_LABELS["7d"];
+
+  try {
+    const data = await getAllGA4TrafficData(rangeInput);
+
+    let synopsis: string | null = getCachedTrafficSynopsis(cacheKey);
+    if (!synopsis) {
+      try {
+        synopsis = await generateTrafficSynopsis(data, cacheKey);
+      } catch (err) {
+        console.error(
+          "[admin/analytics/export] Synopsis generation failed, exporting without it:",
+          err instanceof Error ? err.message : String(err),
+        );
+        synopsis = null;
+      }
+    }
+
+    const report = buildReport(data, rangeLabel, synopsis);
+    const datePart = new Date().toISOString().slice(0, 10);
+    const namePart = (range ?? (from && to ? `${from}-to-${to}` : "7d"))
+      .replace(/[^a-zA-Z0-9-]/g, "-");
+    const filename = `mix-architect-traffic-${namePart}-${datePart}.md`;
+
+    return new NextResponse(report, {
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (err) {
+    console.error(
+      "[admin/analytics/export] Error:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return NextResponse.json(
+      { error: "Failed to build the analytics report" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/analytics/synopsis/route.ts
+++ b/src/app/api/admin/analytics/synopsis/route.ts
@@ -3,102 +3,17 @@ import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import { isAdmin } from "@/lib/admin";
 import { rateLimit, getClientIp } from "@/lib/rate-limit";
 import { getAllGA4TrafficData } from "@/lib/ga4-api";
-import Anthropic from "@anthropic-ai/sdk";
-
-// ---------------------------------------------------------------------------
-// In-memory cache (1 hour TTL per range)
-// ---------------------------------------------------------------------------
-
-const synopsisCache = new Map<string, { text: string; timestamp: number }>();
-const CACHE_TTL = 60 * 60 * 1000; // 1 hour
-
-const MAX_CACHE_ENTRIES = 20;
-
-function getCachedSynopsis(range: string): string | null {
-  const cached = synopsisCache.get(range);
-  if (cached && Date.now() - cached.timestamp < CACHE_TTL) return cached.text;
-  if (cached) synopsisCache.delete(range); // expired
-  return null;
-}
-
-function setCachedSynopsis(range: string, text: string) {
-  // Evict oldest entries if cache is full
-  if (synopsisCache.size >= MAX_CACHE_ENTRIES) {
-    const oldest = synopsisCache.keys().next().value;
-    if (oldest) synopsisCache.delete(oldest);
-  }
-  synopsisCache.set(range, { text, timestamp: Date.now() });
-}
-
-// ---------------------------------------------------------------------------
-// Prompt builder
-// ---------------------------------------------------------------------------
-
-const RANGE_LABELS: Record<string, string> = {
-  "24h": "the last 24 hours",
-  today: "today",
-  yesterday: "yesterday",
-  "7d": "the last 7 days",
-  "30d": "the last 30 days",
-  "90d": "the last 90 days",
-  "365d": "the last 365 days",
-};
-
-function buildPrompt(data: Awaited<ReturnType<typeof getAllGA4TrafficData>>, range: string): string {
-  const label = RANGE_LABELS[range] ?? `the period ${range}`;
-  const o = data.overview;
-
-  return `You are the analytics assistant for Mix Architect, a SaaS platform for freelance mix/mastering engineers and independent artists. The platform handles release management, audio versioning, client collaboration, and payment tracking.
-
-Analyze the following site traffic data for ${label} and write a concise 3-5 sentence synopsis. Focus on:
-- What stands out (traffic trends, unusual referrers, notable pages)
-- Conversion signals (pricing page visits, signup events, checkout events)
-- Portal traffic as a percentage of total (paths starting with /portal are client delivery portals; this is our viral loop)
-- Anything that might need attention (high bounce rates, drop-offs, zero events where there should be activity)
-
-Be direct, specific with numbers, and actionable. No filler. Write in a natural, conversational tone. Do not use bullet points or headers. Do not start with "Here's" or "Based on". Just give me the analysis as a short paragraph.
-
-DATA:
-- Visitors: ${o.visitors} (New: ${o.new_users ?? 0}, Returning: ${o.returning_users ?? 0})
-- Pageviews: ${o.pageviews}
-- Sessions: ${o.sessions}
-- Engagement Rate: ${o.engagement_rate ?? 0}%
-- Bounce Rate: ${o.bounce_rate}%
-- Avg Session Duration: ${o.session_duration}s
-- Pages per Session: ${o.views_per_session}
-- Real-time Active: ${o.current_visitors}
-
-Channels:
-${data.channels.map((c) => `  ${c.name}: ${c.count} sessions`).join("\n")}
-
-Top Pages:
-${data.topPages.map((p) => `  ${p.name}: ${p.count} views`).join("\n")}
-
-Landing Pages:
-${data.landingPages.map((p) => `  ${p.name}: ${p.count} sessions`).join("\n")}
-
-Referrers:
-${data.referrers.map((r) => `  ${r.name}: ${r.count} sessions`).join("\n")}
-
-Countries:
-${data.countries.map((c) => `  ${c.name}: ${c.count} sessions`).join("\n")}
-
-Custom Events:
-${Object.entries(data.events).map(([name, count]) => `  ${name}: ${count}`).join("\n") || "  (no custom events tracked yet)"}
-
-Browsers: ${data.browsers.map((b) => `${b.name}: ${b.count}`).join(", ")}
-Devices: ${data.devices.map((d) => `${d.name}: ${d.count}`).join(", ")}`;
-}
-
-// ---------------------------------------------------------------------------
-// Route handler
-// ---------------------------------------------------------------------------
+import {
+  getCachedTrafficSynopsis,
+  generateTrafficSynopsis,
+} from "@/lib/traffic-synopsis";
 
 /**
  * GET /api/admin/analytics/synopsis?range=7d[&refresh=true]
  *
  * Generates an AI synopsis of GA4 analytics data using Claude.
- * Cached for 1 hour per range. Pass refresh=true to regenerate.
+ * Cached for 1 hour per range (cache shared with the report export).
+ * Pass refresh=true to regenerate.
  */
 export async function GET(req: NextRequest) {
   const ip = getClientIp(req);
@@ -117,39 +32,16 @@ export async function GET(req: NextRequest) {
   const range = req.nextUrl.searchParams.get("range") ?? "7d";
   const refresh = req.nextUrl.searchParams.get("refresh") === "true";
 
-  // Check cache first
   if (!refresh) {
-    const cached = getCachedSynopsis(range);
+    const cached = getCachedTrafficSynopsis(range);
     if (cached) {
       return NextResponse.json({ synopsis: cached, range, cached: true });
     }
   }
 
   try {
-    const apiKey = process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
-      return NextResponse.json({ error: "Anthropic API key not configured" }, { status: 500 });
-    }
-
-    // Fetch GA4 data
     const data = await getAllGA4TrafficData(range);
-
-    // Generate synopsis with Claude. claude-sonnet-4-20250514 was retired
-    // 2026-06-15 and began returning 404, which is why the synopsis card
-    // showed "Unable to generate synopsis" on every load.
-    const anthropic = new Anthropic({ apiKey });
-    const message = await anthropic.messages.create({
-      model: "claude-opus-5",
-      max_tokens: 1000,
-      messages: [{ role: "user", content: buildPrompt(data, range) }],
-    });
-
-    const textBlock = message.content.find((b) => b.type === "text");
-    const synopsis = textBlock && textBlock.type === "text" ? textBlock.text : "";
-
-    // Cache the result
-    setCachedSynopsis(range, synopsis);
-
+    const synopsis = await generateTrafficSynopsis(data, range);
     return NextResponse.json({ synopsis, range, cached: false });
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/lib/traffic-synopsis.ts
+++ b/src/lib/traffic-synopsis.ts
@@ -1,0 +1,110 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { GA4FullPayload } from "@/lib/ga4-api";
+
+/**
+ * Shared AI traffic-synopsis generation with a 1-hour in-memory cache,
+ * used by both the synopsis endpoint (the Site Traffic card) and the
+ * analytics report export so the two never bill a second generation for
+ * the same range within the cache window.
+ */
+
+const synopsisCache = new Map<string, { text: string; timestamp: number }>();
+const CACHE_TTL = 60 * 60 * 1000; // 1 hour
+const MAX_CACHE_ENTRIES = 20;
+
+export function getCachedTrafficSynopsis(range: string): string | null {
+  const cached = synopsisCache.get(range);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL) return cached.text;
+  if (cached) synopsisCache.delete(range); // expired
+  return null;
+}
+
+function setCachedSynopsis(range: string, text: string) {
+  if (synopsisCache.size >= MAX_CACHE_ENTRIES) {
+    const oldest = synopsisCache.keys().next().value;
+    if (oldest) synopsisCache.delete(oldest);
+  }
+  synopsisCache.set(range, { text, timestamp: Date.now() });
+}
+
+export const RANGE_LABELS: Record<string, string> = {
+  "24h": "the last 24 hours",
+  today: "today",
+  yesterday: "yesterday",
+  "7d": "the last 7 days",
+  "30d": "the last 30 days",
+  "90d": "the last 90 days",
+  "365d": "the last 365 days",
+};
+
+function buildPrompt(data: GA4FullPayload, range: string): string {
+  const label = RANGE_LABELS[range] ?? `the period ${range}`;
+  const o = data.overview;
+
+  return `You are the analytics assistant for Mix Architect, a SaaS platform for freelance mix/mastering engineers and independent artists. The platform handles release management, audio versioning, client collaboration, and payment tracking.
+
+Analyze the following site traffic data for ${label} and write a concise 3-5 sentence synopsis. Focus on:
+- What stands out (traffic trends, unusual referrers, notable pages)
+- Conversion signals (pricing page visits, signup events, checkout events)
+- Portal traffic as a percentage of total (paths starting with /portal are client delivery portals; this is our viral loop)
+- Anything that might need attention (high bounce rates, drop-offs, zero events where there should be activity)
+
+Be direct, specific with numbers, and actionable. No filler. Write in a natural, conversational tone. Do not use bullet points or headers. Do not start with "Here's" or "Based on". Just give me the analysis as a short paragraph.
+
+DATA:
+- Visitors: ${o.visitors} (New: ${o.new_users ?? 0}, Returning: ${o.returning_users ?? 0})
+- Pageviews: ${o.pageviews}
+- Sessions: ${o.sessions}
+- Engagement Rate: ${o.engagement_rate ?? 0}%
+- Bounce Rate: ${o.bounce_rate}%
+- Avg Session Duration: ${o.session_duration}s
+- Pages per Session: ${o.views_per_session}
+- Real-time Active: ${o.current_visitors}
+
+Channels:
+${data.channels.map((c) => `  ${c.name}: ${c.count} sessions`).join("\n")}
+
+Top Pages:
+${data.topPages.map((p) => `  ${p.name}: ${p.count} views`).join("\n")}
+
+Landing Pages:
+${data.landingPages.map((p) => `  ${p.name}: ${p.count} sessions`).join("\n")}
+
+Referrers:
+${data.referrers.map((r) => `  ${r.name}: ${r.count} sessions`).join("\n")}
+
+Countries:
+${data.countries.map((c) => `  ${c.name}: ${c.count} sessions`).join("\n")}
+
+Custom Events:
+${Object.entries(data.events).map(([name, count]) => `  ${name}: ${count}`).join("\n") || "  (no custom events tracked yet)"}
+
+Browsers: ${data.browsers.map((b) => `${b.name}: ${b.count}`).join(", ")}
+Devices: ${data.devices.map((d) => `${d.name}: ${d.count}`).join(", ")}`;
+}
+
+/**
+ * Generate a synopsis for already-fetched traffic data and cache it under
+ * the given range key. Throws when ANTHROPIC_API_KEY is unset or the API
+ * call fails; callers decide whether that is fatal (synopsis card) or
+ * degradable (report export).
+ */
+export async function generateTrafficSynopsis(
+  data: GA4FullPayload,
+  range: string,
+): Promise<string> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("Anthropic API key not configured");
+
+  const anthropic = new Anthropic({ apiKey });
+  const message = await anthropic.messages.create({
+    model: "claude-opus-5",
+    max_tokens: 1000,
+    messages: [{ role: "user", content: buildPrompt(data, range) }],
+  });
+
+  const textBlock = message.content.find((b) => b.type === "text");
+  const synopsis = textBlock && textBlock.type === "text" ? textBlock.text : "";
+  if (synopsis) setCachedSynopsis(range, synopsis);
+  return synopsis;
+}


### PR DESCRIPTION
Adds an **Export report** button (next to Refresh on /admin/traffic) that downloads a Markdown site-traffic report for the currently selected period, led by the AI summary.

## What's in the report
AI Summary, Overview metrics, Channels, Top Pages, Landing Pages, Referrers, Countries, Custom Events, Devices and Browsers - all as Markdown tables, filename like `mix-architect-traffic-7d-2026-08-10.md`.

## Implementation
- New `GET /api/admin/analytics/export` (admin check + rate limit), supporting preset ranges (`?range=7d`) and custom date ranges (`?from=&to=`)
- Synopsis generation + its 1-hour cache extracted to `src/lib/traffic-synopsis.ts`, shared by the synopsis card and the export - a warm card means the export reuses the same summary instead of billing a second generation
- Degrades gracefully: if the summary can't be generated, the report exports anyway with a note in its place

## Verification
- Build + tsc + lint clean; button renders with correct href per range; route verified through auth/rate-limit down to the GA4 call locally (fails there only because Google/Anthropic creds are prod-only)
- **Prod check after merge:** open /admin/traffic and click the download icon - a .md file with the summary and tables should download

🤖 Generated with [Claude Code](https://claude.com/claude-code)