### PR TITLE
What's New: rail placement + compact stacked pills

### DIFF
--- a/src/components/changelog/ChangelogCategoryBadge.tsx
+++ b/src/components/changelog/ChangelogCategoryBadge.tsx
@@ -17,15 +17,18 @@ const categoryLabels: Record<ChangelogCategory, string> = {
 
 export function ChangelogCategoryBadge({
   category,
+  compact = false,
   className,
 }: {
   category: ChangelogCategory;
+  compact?: boolean;
   className?: string;
 }) {
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide",
+        "inline-flex items-center rounded-full border font-semibold uppercase tracking-wide",
+        compact ? "px-1.5 py-px text-[9px]" : "px-2.5 py-0.5 text-[11px]",
         categoryStyles[category],
         className,
       )}

--- a/src/components/ui/rail.tsx
+++ b/src/components/ui/rail.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { cn } from "@/lib/cn";
 import { Home, Users, DollarSign, LayoutTemplate, BarChart3, Building2 } from "lucide-react";
 import { useFeatureVisible } from "@/hooks/use-feature-visible";
+import { WhatsNewButton } from "@/components/ui/whats-new-button";
 
 const MONEY_QUOTES = [
   "That\u2019s what I want",
@@ -60,6 +61,9 @@ export function Rail() {
       )}
       <NavItem href="/app/analytics" icon={BarChart3} label={t("analytics")} active={isAnalytics} />
       <NavItem href="/app/studio" icon={Building2} label={t("studio")} active={isStudio} />
+      <div className="mt-auto">
+        <WhatsNewButton />
+      </div>
     </nav>
   );
 }

--- a/src/components/ui/top-bar.tsx
+++ b/src/components/ui/top-bar.tsx
@@ -9,7 +9,6 @@ import { cn } from "@/lib/cn";
 import { createSupabaseBrowserClient } from "@/lib/supabaseBrowserClient";
 import { NotificationBell } from "@/components/ui/notification-bell";
 import { Tooltip } from "@/components/ui/tooltip";
-import { WhatsNewButton } from "@/components/ui/whats-new-button";
 
 type Props = {
   userId?: string;
@@ -92,9 +91,6 @@ export function TopBar({ userId, userEmail, displayName, onSearchClick, isAdmin 
           <span className="flex-1 text-left">Search...</span>
           <kbd className="text-2xs font-medium text-muted bg-panel border border-border rounded px-1.5 py-0.5">⌘K</kbd>
         </button>
-
-        {/* Version / What's New */}
-        <WhatsNewButton />
 
         {/* What we're spinning */}
         <Tooltip label="What we're spinning" align="right">

--- a/src/components/ui/whats-new-button.tsx
+++ b/src/components/ui/whats-new-button.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from "react";
 import dynamic from "next/dynamic";
+import { Megaphone } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { Tooltip } from "@/components/ui/tooltip";
 import { displayVersion, useChangelogStatus } from "@/hooks/use-changelog-status";
 
 const WhatsNewDialog = dynamic(
@@ -11,6 +11,11 @@ const WhatsNewDialog = dynamic(
   { ssr: false },
 );
 
+/**
+ * Rail footer item: megaphone icon with an unread dot, version label
+ * revealed alongside it exactly like the NavItem labels (hover-expand
+ * on mid-size screens, permanent from xl up).
+ */
 export function WhatsNewButton() {
   const t = useTranslations("help");
   const { entries, versionTag, hasUnread, markSeen } = useChangelogStatus();
@@ -22,22 +27,25 @@ export function WhatsNewButton() {
 
   return (
     <>
-      <Tooltip label={t("whatsNew")} align="right">
-        <button
-          type="button"
-          onClick={() => {
-            markSeen();
-            setOpen(true);
-          }}
-          aria-label={hasUnread ? t("whatsNewUnreadAria") : t("whatsNewOpenAria")}
-          className="relative h-9 px-2 rounded-lg flex items-center text-muted hover:text-text hover:bg-panel2 transition-colors"
-        >
-          <span className="font-mono text-2xs">{label}</span>
+      <button
+        type="button"
+        onClick={() => {
+          markSeen();
+          setOpen(true);
+        }}
+        aria-label={hasUnread ? t("whatsNewUnreadAria") : t("whatsNewOpenAria")}
+        className="flex items-center gap-3 w-full px-2 h-10 rounded-md text-muted transition-all duration-150 hover:text-text hover:bg-panel2 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-signal-muted"
+      >
+        <span className="relative w-6 h-10 grid place-items-center shrink-0">
+          <Megaphone size={20} strokeWidth={1.5} />
           {hasUnread && (
-            <span aria-hidden className="absolute top-1.5 right-0.5 w-1.5 h-1.5 rounded-full bg-signal" />
+            <span aria-hidden className="absolute top-2 right-0 w-1.5 h-1.5 rounded-full bg-signal" />
           )}
-        </button>
-      </Tooltip>
+        </span>
+        <span className="font-mono text-2xs whitespace-nowrap opacity-0 group-hover/rail:opacity-100 xl:opacity-100 transition-opacity duration-150 delay-75">
+          {label}
+        </span>
+      </button>
       {open && <WhatsNewDialog entries={entries} onClose={() => setOpen(false)} />}
     </>
   );

--- a/src/components/ui/whats-new-dialog.tsx
+++ b/src/components/ui/whats-new-dialog.tsx
@@ -80,16 +80,14 @@ export function WhatsNewDialog({
                     </span>
                     <span className="text-xs text-faint">{formatDate(group.publishedAt)}</span>
                   </div>
-                  <ul className="space-y-3">
+                  <ul className="space-y-4">
                     {group.entries.map((entry) => (
-                      <li key={entry.slug} className="flex items-start gap-2.5">
-                        <ChangelogCategoryBadge category={entry.category} className="mt-0.5 shrink-0" />
-                        <div className="min-w-0">
-                          <p className="text-sm font-medium text-text">{entry.title}</p>
-                          {entry.summary && (
-                            <p className="text-sm text-muted line-clamp-2">{entry.summary}</p>
-                          )}
-                        </div>
+                      <li key={entry.slug}>
+                        <ChangelogCategoryBadge category={entry.category} compact className="mb-1" />
+                        <p className="text-sm font-medium text-text">{entry.title}</p>
+                        {entry.summary && (
+                          <p className="text-sm text-muted line-clamp-2">{entry.summary}</p>
+                        )}
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## What

Follow-ups to #98 from design review:

- The version chip moves from the top bar to the **bottom of the left rail**: megaphone icon with the unread dot, version label revealed on rail hover-expand and permanently from `xl` up (same reveal pattern as the nav item labels).
- Modal entries now stack a **compact category pill above the title**, so titles and summaries are all left-justified. `ChangelogCategoryBadge` gains a `compact` prop (`cn()` is a plain join, so utility overrides via className are unreliable).

## Data (already live, not in this PR)

Admin-section entries were removed from the changelog: 11 entries deleted, 6 rewritten to drop admin mentions. Now 131 entries across 51 versions; latest version is 2026.08.09.

## Testing

- `tsc --noEmit` clean; eslint clean on touched files (the one reported error is the pre-existing `mounted` effect in top-bar.tsx, untouched here).
- Browser-verified via a temporary harness: rail item renders at the bottom with the version label, unread dot on the megaphone, modal opens with stacked compact pills and left-justified text, fresh data shows v2026.08.09 with zero admin entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)