### PR TITLE
What's New modal: show full entry summaries

### DIFF
--- a/src/components/ui/whats-new-dialog.tsx
+++ b/src/components/ui/whats-new-dialog.tsx
@@ -86,7 +86,7 @@ export function WhatsNewDialog({
                         <ChangelogCategoryBadge category={entry.category} compact className="mb-1" />
                         <p className="text-sm font-medium text-text">{entry.title}</p>
                         {entry.summary && (
-                          <p className="text-sm text-muted line-clamp-2">{entry.summary}</p>
+                          <p className="text-sm text-muted">{entry.summary}</p>
                         )}
                       </li>
                     ))}


### PR DESCRIPTION
Summaries in the What's New modal were clamped to two lines and cut off mid-sentence. The modal body already scrolls, so the clamp is removed and summaries wrap in full.

Browser-verified via a temporary harness: the previously truncated entry now shows its complete summary, in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)