### PR TITLE
Billing audit fixes: renewals, retryable webhook, billing_interval

### DIFF
--- a/scripts/stripe-billing-audit.mjs
+++ b/scripts/stripe-billing-audit.mjs
@@ -1,0 +1,191 @@
+/**
+ * One-off billing audit + repair script (2026-08-17 billing audit).
+ *
+ * Read-only by default. Requires STRIPE_SECRET_KEY in the environment.
+ *
+ *   node --env-file=.env.local scripts/stripe-billing-audit.mjs
+ *
+ * What it does (read-only):
+ *   1. Lists webhook endpoints in the key's mode and flags which events the
+ *      handler depends on but the endpoint does not send. This is the root
+ *      cause of current_period_end never advancing: the handler has branches
+ *      for customer.subscription.updated/.deleted and invoice.paid handling,
+ *      but those event types have never appeared in stripe_processed_events.
+ *   2. Retrieves the known paying subscription and reports livemode, status,
+ *      billing interval, and the true current_period_end. If the key is
+ *      sk_live and the subscription 404s, it is a TEST-mode subscription and
+ *      reported MRR is $0 (audit issue 4b).
+ *   3. Lists expired Checkout Sessions and groups them by mode / metadata /
+ *      whether a payment_intent was ever created (audit issue 3: both
+ *      session-creation call sites are click-driven, so expirations represent
+ *      real users reaching checkout and leaving).
+ *
+ * Flags (each asks nothing and does exactly one write):
+ *   --fix-events   PATCH the webhook endpoint's enabled_events to add the
+ *                  missing event types (additive; nothing is removed).
+ *   --backfill     Write the true current_period_end / billing_interval /
+ *                  status onto the subscriptions row (needs
+ *                  NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY).
+ *                  If the subscription turns out to be test-mode, sets
+ *                  is_test_account = true on the profile instead.
+ */
+import Stripe from "stripe";
+import { createClient } from "@supabase/supabase-js";
+
+const STRIPE_KEY = process.env.STRIPE_SECRET_KEY;
+if (!STRIPE_KEY) {
+  console.error(
+    "STRIPE_SECRET_KEY is not set. Pull it from Vercel (vercel env pull) or export it, then re-run.",
+  );
+  process.exit(1);
+}
+const stripe = new Stripe(STRIPE_KEY);
+const mode = STRIPE_KEY.startsWith("sk_live") ? "live" : "test";
+const FIX_EVENTS = process.argv.includes("--fix-events");
+const BACKFILL = process.argv.includes("--backfill");
+
+// The one paying subscription from the 2026-08-17 audit.
+const KNOWN_SUBSCRIPTION_ID = "sub_1TpyQmKHQrWWYOjJgD5DrtKL";
+
+// Every event.type the webhook handler branches on.
+const REQUIRED_EVENTS = [
+  "checkout.session.completed",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+  "invoice.paid",
+  "invoice.payment_failed",
+  "charge.dispute.created",
+  "charge.refunded",
+  "account.updated",
+];
+
+console.log(`\n=== Stripe key mode: ${mode.toUpperCase()} ===`);
+
+// ── 1. Webhook endpoint event coverage ──────────────────────────────
+const endpoints = await stripe.webhookEndpoints.list({ limit: 10 });
+if (endpoints.data.length === 0) {
+  console.log(`\nNo webhook endpoints exist in ${mode} mode.`);
+}
+for (const ep of endpoints.data) {
+  console.log(`\nEndpoint: ${ep.url}\n  status: ${ep.status}`);
+  const enabled = ep.enabled_events;
+  const sendsAll = enabled.includes("*");
+  const missing = sendsAll
+    ? []
+    : REQUIRED_EVENTS.filter((e) => !enabled.includes(e));
+  console.log(`  enabled_events: ${sendsAll ? "* (all)" : enabled.join(", ")}`);
+  if (missing.length === 0) {
+    console.log("  ✓ all handler-required events are enabled");
+  } else {
+    console.log(`  ✗ MISSING: ${missing.join(", ")}`);
+    if (FIX_EVENTS) {
+      const updated = await stripe.webhookEndpoints.update(ep.id, {
+        enabled_events: [...new Set([...enabled, ...missing])],
+      });
+      console.log(`  → fixed; now sends: ${updated.enabled_events.join(", ")}`);
+    } else {
+      console.log("  → re-run with --fix-events to add them");
+    }
+  }
+}
+
+// ── 2. The known paying subscription ────────────────────────────────
+console.log(`\n=== Subscription ${KNOWN_SUBSCRIPTION_ID} (${mode} mode) ===`);
+let sub = null;
+try {
+  sub = await stripe.subscriptions.retrieve(KNOWN_SUBSCRIPTION_ID, {
+    expand: ["items"],
+  });
+} catch (err) {
+  if (err?.statusCode === 404) {
+    console.log(
+      `Not found in ${mode} mode.` +
+        (mode === "live"
+          ? " ⇒ this is a TEST-mode subscription: reported MRR from it is $0 (issue 4b confirmed)."
+          : " Try again with the live key."),
+    );
+  } else {
+    throw err;
+  }
+}
+if (sub) {
+  const item = sub.items?.data?.[0];
+  const periodEnd = item?.current_period_end
+    ? new Date(item.current_period_end * 1000).toISOString()
+    : null;
+  const interval = item?.price?.recurring?.interval ?? null;
+  console.log(`  livemode: ${sub.livemode}`);
+  console.log(`  status: ${sub.status}  cancel_at_period_end: ${sub.cancel_at_period_end}`);
+  console.log(`  billing interval: ${interval}`);
+  console.log(`  true current_period_end: ${periodEnd}`);
+  if (sub.test_clock) console.log(`  ⚠ attached to test clock: ${sub.test_clock}`);
+
+  if (BACKFILL) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) {
+      console.error("--backfill needs NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY");
+      process.exit(1);
+    }
+    const supabase = createClient(url, key);
+    if (!sub.livemode) {
+      const { data: row } = await supabase
+        .from("subscriptions")
+        .select("user_id")
+        .eq("stripe_subscription_id", KNOWN_SUBSCRIPTION_ID)
+        .maybeSingle();
+      if (row?.user_id) {
+        await supabase
+          .from("profiles")
+          .update({ is_test_account: true })
+          .eq("id", row.user_id);
+        console.log(`  → test-mode sub: set is_test_account=true on profile ${row.user_id}`);
+      }
+    } else {
+      const statusMap = {
+        active: "active", past_due: "past_due", canceled: "canceled",
+        trialing: "trialing", incomplete: "incomplete",
+        incomplete_expired: "canceled", unpaid: "past_due", paused: "canceled",
+      };
+      const { error } = await supabase
+        .from("subscriptions")
+        .update({
+          status: statusMap[sub.status] || "active",
+          current_period_end: periodEnd,
+          billing_interval: interval === "month" || interval === "year" ? interval : null,
+          cancel_at_period_end: sub.cancel_at_period_end,
+        })
+        .eq("stripe_subscription_id", KNOWN_SUBSCRIPTION_ID);
+      console.log(error ? `  → backfill FAILED: ${error.message}` : "  → row backfilled");
+    }
+  }
+}
+
+// ── 3. Expired checkout sessions (issue 3) ──────────────────────────
+console.log(`\n=== Expired Checkout Sessions (${mode} mode, up to 100) ===`);
+const sessions = await stripe.checkout.sessions.list({ status: "expired", limit: 100 });
+const groups = {};
+for (const s of sessions.data) {
+  const kind = s.metadata?.quote_id
+    ? "quote-payment"
+    : s.metadata?.supabase_user_id
+      ? `subscription:${s.metadata?.plan ?? "pro"}`
+      : "untagged";
+  const pi = s.payment_intent ? "reached-payment-intent" : "no-payment-intent";
+  const key = `${s.mode} | ${kind} | ${pi}`;
+  groups[key] = (groups[key] || 0) + 1;
+}
+console.log(`total: ${sessions.data.length}${sessions.has_more ? "+ (has more)" : ""}`);
+for (const [k, n] of Object.entries(groups).sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${String(n).padStart(4)}  ${k}`);
+}
+const oldest = sessions.data.at(-1);
+const newest = sessions.data[0];
+if (newest && oldest) {
+  console.log(
+    `  range: ${new Date(oldest.created * 1000).toISOString().slice(0, 10)} → ${new Date(newest.created * 1000).toISOString().slice(0, 10)}`,
+  );
+}
+console.log(
+  "\nInterpretation: both session-creation call sites are click-only (auth'd upgrade button, quote-portal Pay button), so these are real users reaching checkout and not completing. Quote-payment groups point at the client payment flow; subscription groups at the upgrade flow. no-payment-intent means they left before entering a card.\n",
+);

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -34,6 +34,28 @@ function getPeriodEnd(sub: Stripe.Subscription): string | null {
   return null;
 }
 
+function getBillingInterval(sub: Stripe.Subscription): "month" | "year" | null {
+  const interval = sub.items?.data?.[0]?.price?.recurring?.interval;
+  return interval === "month" || interval === "year" ? interval : null;
+}
+
+/** In Stripe API v2025+, the invoice's subscription moved under parent.subscription_details. */
+function getInvoiceSubscriptionId(invoice: Stripe.Invoice): string | null {
+  const sub = invoice.parent?.subscription_details?.subscription;
+  return typeof sub === "string" ? sub : sub?.id ?? null;
+}
+
+const SUBSCRIPTION_STATUS_MAP: Record<string, string> = {
+  active: "active",
+  past_due: "past_due",
+  canceled: "canceled",
+  trialing: "trialing",
+  incomplete: "incomplete",
+  incomplete_expired: "canceled",
+  unpaid: "past_due",
+  paused: "canceled",
+};
+
 /**
  * POST /api/stripe/webhook
  * Handles Stripe webhook events to sync subscription state.
@@ -238,13 +260,15 @@ export async function POST(req: NextRequest) {
         // session so existing behavior is preserved.
         const checkoutPlan = session.metadata?.plan === "studio" ? "studio" : "pro";
 
-        // Fetch the subscription to get period end
+        // Fetch the subscription to get period end + billing interval
         let periodEnd: string | null = null;
+        let billingInterval: "month" | "year" | null = null;
         if (subscriptionId) {
           const sub = await stripe.subscriptions.retrieve(subscriptionId, {
             expand: ["items"],
           });
           periodEnd = getPeriodEnd(sub);
+          billingInterval = getBillingInterval(sub);
         }
 
         const { error } = await supabase.from("subscriptions").upsert(
@@ -255,6 +279,7 @@ export async function POST(req: NextRequest) {
             plan: checkoutPlan,
             status: "active",
             current_period_end: periodEnd,
+            billing_interval: billingInterval,
             cancel_at_period_end: false,
             granted_by_admin: false,
           },
@@ -263,7 +288,20 @@ export async function POST(req: NextRequest) {
 
         if (error) {
           console.error("[stripe/webhook] upsert failed:", error);
+          // Throw so the outer catch releases the idempotency row and
+          // Stripe retries; returning 200 here would grant nothing and
+          // never try again.
+          throw new Error(`subscription upsert failed: ${error.message}`);
         } else {
+          // Test-mode checkouts (Stripe test clocks, sk_test keys) must
+          // not count as revenue. Flag the profile so admin MRR excludes it.
+          if (!event.livemode) {
+            await supabase
+              .from("profiles")
+              .update({ is_test_account: true })
+              .eq("id", userId);
+            console.log("[stripe/webhook] test-mode checkout: flagged is_test_account for", userId);
+          }
           console.log("[stripe/webhook] subscription activated for user:", userId, checkoutPlan);
           logActivity(userId, "subscription_started", { plan: checkoutPlan });
 
@@ -301,18 +339,7 @@ export async function POST(req: NextRequest) {
           break;
         }
 
-        const statusMap: Record<string, string> = {
-          active: "active",
-          past_due: "past_due",
-          canceled: "canceled",
-          trialing: "trialing",
-          incomplete: "incomplete",
-          incomplete_expired: "canceled",
-          unpaid: "past_due",
-          paused: "canceled",
-        };
-
-        const mappedStatus = statusMap[subscription.status] || "active";
+        const mappedStatus = SUBSCRIPTION_STATUS_MAP[subscription.status] || "active";
         const periodEnd = getPeriodEnd(subscription);
 
         // Resolve the plan from the subscription's current price (robust
@@ -333,12 +360,14 @@ export async function POST(req: NextRequest) {
             status: mappedStatus,
             plan: subscription.status === "canceled" ? "free" : resolvedPlan,
             current_period_end: periodEnd,
+            billing_interval: getBillingInterval(subscription),
             cancel_at_period_end: subscription.cancel_at_period_end,
           })
           .eq("id", existingSub.id);
 
         if (error) {
           console.error("[stripe/webhook] subscription update failed:", error);
+          throw new Error(`subscription update failed: ${error.message}`);
         } else {
           console.log("[stripe/webhook] subscription updated:", customerId, mappedStatus);
           if (existingSub.user_id) {
@@ -397,6 +426,7 @@ export async function POST(req: NextRequest) {
 
         if (error) {
           console.error("[stripe/webhook] subscription delete update failed:", error);
+          throw new Error(`subscription delete update failed: ${error.message}`);
         } else {
           console.log("[stripe/webhook] subscription canceled:", customerId);
           if (existingSub.user_id) {
@@ -437,7 +467,12 @@ export async function POST(req: NextRequest) {
         break;
       }
 
-      case "invoice.payment_succeeded": {
+      case "invoice.paid": {
+        // NOTE: the webhook endpoint delivers `invoice.paid`, not
+        // `invoice.payment_succeeded` — the previous branch listened for
+        // the latter and never fired, which is why renewals never
+        // advanced current_period_end (the row's updated_at sat frozen
+        // at creation while two renewals came and went).
         const invoice = event.data.object as Stripe.Invoice;
         const customerId =
           typeof invoice.customer === "string"
@@ -448,20 +483,50 @@ export async function POST(req: NextRequest) {
 
         const { data: sub } = await supabase
           .from("subscriptions")
-          .select("user_id, granted_by_admin, current_period_end")
+          .select("id, user_id, plan, granted_by_admin, current_period_end")
           .eq("stripe_customer_id", customerId)
           .maybeSingle();
 
         if (!sub?.user_id || sub.granted_by_admin) break;
+
+        // Advance the billing period from the source of truth. The
+        // invoice's own period fields describe the invoice line, not the
+        // subscription, so re-read the subscription itself.
+        let nextPeriodEnd: string | null = sub.current_period_end;
+        const invoiceSubId = getInvoiceSubscriptionId(invoice);
+        if (invoiceSubId) {
+          const stripeSub = await stripe.subscriptions.retrieve(invoiceSubId, {
+            expand: ["items"],
+          });
+          nextPeriodEnd = getPeriodEnd(stripeSub) ?? sub.current_period_end;
+
+          const { error } = await supabase
+            .from("subscriptions")
+            .update({
+              status: SUBSCRIPTION_STATUS_MAP[stripeSub.status] || "active",
+              current_period_end: nextPeriodEnd,
+              billing_interval: getBillingInterval(stripeSub),
+              cancel_at_period_end: stripeSub.cancel_at_period_end,
+            })
+            .eq("id", sub.id);
+
+          if (error) {
+            console.error("[stripe/webhook] invoice.paid period update failed:", error);
+            throw new Error(`invoice.paid period update failed: ${error.message}`);
+          }
+          console.log(
+            "[stripe/webhook] period advanced for", customerId, "->", nextPeriodEnd,
+          );
+        }
 
         // Format amount
         const amount = invoice.amount_paid
           ? `$${(invoice.amount_paid / 100).toFixed(2)}`
           : "$0.00";
 
-        // Format period end
-        const nextBilling = sub.current_period_end
-          ? new Date(sub.current_period_end).toLocaleDateString("en-US", {
+        // Format period end (freshly advanced above, not the stale row)
+        const nextBilling = nextPeriodEnd
+          ? new Date(nextPeriodEnd).toLocaleDateString("en-US", {
               month: "long",
               day: "numeric",
               year: "numeric",
@@ -669,6 +734,14 @@ export async function POST(req: NextRequest) {
     }
   } catch (err) {
     console.error("[stripe/webhook] handler error:", err);
+    // Release the idempotency row so Stripe's retry actually re-runs the
+    // branch. Without this, a failed event is marked processed and the
+    // retry short-circuits at the duplicate check — a transient DB blip
+    // would permanently drop the event.
+    await supabase
+      .from("stripe_processed_events")
+      .delete()
+      .eq("event_id", event.id);
     return NextResponse.json({ error: "Webhook handler failed" }, { status: 500 });
   }
 

--- a/supabase/migrations/088_billing_interval_and_signup_guard.sql
+++ b/supabase/migrations/088_billing_interval_and_signup_guard.sql
@@ -1,0 +1,80 @@
+-- 088: billing interval on subscriptions + idempotent signup trigger
+--
+-- 1. subscriptions.billing_interval: the daily MRR check previously
+--    inferred monthly vs annual from (current_period_end - created_at),
+--    which reads a field the webhook was never advancing. Record the
+--    fact from the Stripe price object instead. Backfill for existing
+--    rows happens via scripts/stripe-billing-audit.mjs (one-off), not here.
+--
+-- 2. handle_new_user(): the profiles insert had no duplicate guard,
+--    unlike the email_preferences insert in the same function. A re-run,
+--    backfill, or manual auth.users insert would raise 23505 and abort
+--    user creation. ON CONFLICT DO NOTHING makes it idempotent.
+
+-- ── 1. billing_interval ─────────────────────────────────────────────
+ALTER TABLE public.subscriptions
+  ADD COLUMN IF NOT EXISTS billing_interval text;
+
+ALTER TABLE public.subscriptions
+  DROP CONSTRAINT IF EXISTS subscriptions_billing_interval_check;
+ALTER TABLE public.subscriptions
+  ADD CONSTRAINT subscriptions_billing_interval_check
+  CHECK (billing_interval IS NULL OR billing_interval IN ('month', 'year'));
+
+-- ── 2. idempotent handle_new_user ───────────────────────────────────
+-- Verbatim copy of 084's function with ON CONFLICT guards added to the
+-- profiles insert (id is the auth user id / PK).
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public'
+AS $function$
+DECLARE
+  v_workspace_id uuid;
+  v_name text;
+BEGIN
+  INSERT INTO public.profiles (id, full_name)
+  VALUES (new.id, coalesce(new.raw_user_meta_data->>'full_name', ''))
+  ON CONFLICT (id) DO NOTHING;
+
+  v_name := coalesce(
+    nullif(trim(new.raw_user_meta_data->>'full_name'), ''),
+    nullif(split_part(coalesce(new.email, ''), '@', 1), ''),
+    'My'
+  ) || '''s Workspace';
+
+  INSERT INTO public.workspaces (owner_user_id, name, plan)
+  VALUES (new.id, v_name, 'free')
+  RETURNING id INTO v_workspace_id;
+
+  INSERT INTO public.workspace_members (workspace_id, user_id, invited_email, role, accepted_at)
+  VALUES (v_workspace_id, new.id, coalesce(new.email, new.id::text), 'owner', now());
+
+  INSERT INTO public.email_preferences (user_id)
+  VALUES (new.id)
+  ON CONFLICT (user_id) DO NOTHING;
+
+  IF new.email IS NOT NULL THEN
+    INSERT INTO public.email_outbox (user_id, to_email, display_name, category)
+    VALUES (
+      new.id,
+      new.email,
+      coalesce(
+        nullif(trim(new.raw_user_meta_data->>'full_name'), ''),
+        split_part(new.email, '@', 1)
+      ),
+      'welcome'
+    );
+  END IF;
+
+  RETURN new;
+END;
+$function$;
+
+-- CREATE OR REPLACE preserves existing ACLs, but per repo convention
+-- (see 065/080) restate the revokes explicitly so the definer fn is
+-- never callable by anon/authenticated regardless of default privileges.
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM public;
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM authenticated;


### PR DESCRIPTION
Works through the 2026-08-17 billing & signup audit. Root causes found and fixed:

## Issue 1 (P0): current_period_end never advanced

Two independent causes, both fixed:

1. **Wrong event name**: the handler's receipt/period branch listened for `invoice.payment_succeeded`, but the endpoint delivers `invoice.paid` (3 delivered lifetime, 0 `payment_succeeded`). The branch was dead code, so renewals never wrote anything. It now handles `invoice.paid`: resolves the subscription id (via `invoice.parent.subscription_details` per the 2025+ Stripe API), re-reads the subscription from Stripe, and writes `status`, `current_period_end`, `billing_interval`, `cancel_at_period_end` before sending the receipt email (which now shows the fresh date instead of the stale row value).
2. **Missing endpoint events**: `customer.subscription.updated`/`.deleted` have never been delivered (0 rows lifetime) even though the handler has full branches for them, so the endpoint's "events to send" list is missing them. That's a Stripe dashboard/API config fix: run `scripts/stripe-billing-audit.mjs --fix-events` (details below).

Also fixed the audit's predicted one-shot event trap: the idempotency row is inserted before processing, so any handler failure marked the event processed and the retry was skipped. The outer catch now deletes the idempotency row before returning 500, and critical subscription writes throw instead of logging, so Stripe redelivery actually re-runs the work.

## Issue 4a: billing_interval

Migration 088 (**already applied to prod**) adds `subscriptions.billing_interval` (`month|year`), written from the Stripe price in every subscription write path. MRR reporting can read a fact instead of inferring from a field Issue 1 proved stale.

## Issue 4b: test-account flag

The webhook now flags `profiles.is_test_account = true` when a subscription checkout arrives with `livemode = false`. Whether the existing "Mix Arch Test Studio" sub is test-mode is decided by the script below.

## Issue 2: duplicate profile — NOT an app bug

Both profile IDs correspond to **distinct `auth.users` rows with different emails** (nathan.pr.souza@ then nate.cccp@, 20s apart). The only profiles insert path in the system is the `handle_new_user` trigger; the person simply signed up twice with two addresses. No orphan row exists — each auth user has exactly one profile. Migration 088 still adds the audit-requested guard (`ON CONFLICT (id) DO NOTHING`) so trigger re-runs/backfills can't abort signup. Recommendation: leave the idle first account alone; it is a real (likely unconfirmed) auth user, not a dangling row.

## Issue 3: expired checkouts — classified as the genuine case

Both `checkout.sessions.create` call sites are strictly click-driven (authed upgrade button in settings/new-release banner; quote-portal Pay buttons). Nothing creates sessions on page load, so the 115 expirations represent real intent abandoned at checkout. Characterizing them (quote vs subscription, reached-payment-intent vs not) needs the Stripe API: the script's read-only default prints the breakdown.

## One-off script (run locally, needs STRIPE_SECRET_KEY)

```
node --env-file=.env.local scripts/stripe-billing-audit.mjs                # read-only report
node --env-file=.env.local scripts/stripe-billing-audit.mjs --fix-events   # add missing endpoint events
node --env-file=.env.local scripts/stripe-billing-audit.mjs --backfill     # fix the stale row / set test flag
```

STRIPE_SECRET_KEY is not in .env.local (Vercel-only) — add it temporarily or export it inline. If the known subscription 404s under the live key, it is test-mode and reported MRR is $0.

## Verification

- `tsc --noEmit` and eslint clean.
- Deploy order is safe: migration 088 is already applied, so the new column exists before this code ships.
- The natural end-to-end test is the imminent renewal (`invoice.upcoming` fired 2026-08-13): after merge + `--fix-events`, watch `current_period_end` advance on its own and `stripe_processed_events` start recording `customer.subscription.*` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)